### PR TITLE
Re-added Sample to avoid redraw when models are equal, added intial draw case, fixed bug on effect cases not redrawing

### DIFF
--- a/src/Example.hs
+++ b/src/Example.hs
@@ -77,12 +77,6 @@ data Msg
   | ChangeVisibility T.Text
    deriving Show
 
-data DebugVTree
-
-instance ToAction Msg Model DebugVTree where
-  toAction _ action = 
-    print . view . getModelFromEffect . update action 
-
 stepConfig :: Proxy '[ SaveToLocalStorage "todo-mvc", DebugActions ]
 stepConfig = Proxy
 


### PR DESCRIPTION
- Readded `Sample`, this means `datch` won't be called unless model has changed, `(==)` is lazy, so model diffing should short circuit on first difference.
- Added `isInitialDiff`, initial diff always has equal models, `isInitialDiff` forces page draw (to avoid a blank page)
- `ToAction` now called on each step on FRP (RAF), instead on each individual `action` received. So if your app has many events introduced on a specific tick of RAF that cause the model to change, saving to local storage will only be called once for _all_ actions after they have been received, instead of once for each (perf. optimization).
- Fixed bug in `goFold` where the model wasn't being compared to the original, but the previous model. This was introducing cases where diffs wouldn't be detected in the presence of `Effect` on updates.

cc @3noch 
