### PR TITLE
Swap text and element diffing cases

### DIFF
--- a/jsbits/diff.js
+++ b/jsbits/diff.js
@@ -5,11 +5,11 @@ function diff (currentObj, newObj, parent) {
   else if (currentObj && !newObj) parent.removeChild (currentObj.domRef);
   else {
     if (currentObj.type === "vtext") {
-      if (newObj.type === "vnode") replaceElementWithText (currentObj, newObj, parent);
+      if (newObj.type === "vnode") replaceTextWithElement (currentObj, newObj, parent);
       else diffTextNodes (currentObj, newObj);
     } else {
       if (newObj.type === "vnode") diffVNodes (currentObj, newObj, parent);
-      else replaceTextWithElement (currentObj, newObj, parent);
+      else replaceElementWithText (currentObj, newObj, parent);
     }
   }
 }


### PR DESCRIPTION
When diffing between a text node and an element, the correct swapping function should be executed. 

To reproduce the bug:
```haskell
{-# LANGUAGE RecordWildCards #-}
module Main where

import Miso
import Miso.String

type Model = Bool

main :: IO ()
main = startApp App {..}
  where
    model  = False
    update = updateModel
    view   = viewModel
    events = defaultEvents
    subs   = []

updateModel :: Action -> Model -> Effect Model Action
updateModel Action m = noEff ( not m )

data Action = Action
  deriving (Show, Eq)

viewModel :: Bool -> View Action
viewModel x = div_ [] $ button_ [ onClick Action ] [] : handle x
  where
    handle True = [ text $ pack "fooo" ]
    handle False = [
      ul_ [] [
        li_ [] [ text $ pack "hey" ]
      , li_ [] [ text $ pack "there" ]
      ]
      ]
```
This fix diffs text and element nodes properly.