### PR TITLE
Added BoundedChan, simplified Notify, replace SkipChan imp.

### DIFF
--- a/examples/mario/Main.hs
+++ b/examples/mario/Main.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
 {-# LANGUAGE MultiWayIf        #-}
+{-# LANGUAGE BangPatterns      #-}
 module Main where
 
 import           Data.Function
@@ -11,9 +12,9 @@ import           Miso
 import           Miso.String
 
 data Action
-  = GetArrows Arrows
-  | Time Double
-  | WindowCoords (Int,Int)
+  = GetArrows !Arrows
+  | Time !Double
+  | WindowCoords !(Int,Int)
 
 foreign import javascript unsafe "$r = performance.now();"
   now :: IO Double
@@ -32,15 +33,15 @@ main = do
              ]
 
 data Model = Model
-    { x :: Double
-    , y :: Double
-    , vx :: Double
-    , vy :: Double
-    , dir :: Direction
-    , time :: Double
-    , delta :: Double
-    , arrows :: Arrows
-    , window :: (Int,Int)
+    { x :: !Double
+    , y :: !Double
+    , vx :: !Double
+    , vy :: !Double
+    , dir :: !Direction
+    , time :: !Double
+    , delta :: !Double
+    , arrows :: !Arrows
+    , window :: !(Int,Int)
     } deriving (Show, Eq)
 
 data Direction

--- a/ghcjs-src/Miso/Subscription/Keyboard.hs
+++ b/ghcjs-src/Miso/Subscription/Keyboard.hs
@@ -36,8 +36,8 @@ import           Miso.Html.Internal ( Sub )
 --  39 right arrow ( x =  1 )
 --  40 down arrow  ( y = -1 )
 data Arrows = Arrows {
-   arrowX :: Int
- , arrowY :: Int
+   arrowX :: !Int
+ , arrowY :: !Int
  } deriving (Show, Eq)
 
 -- | Helper function to convert keys currently pressed to `Arrow`

--- a/miso-ghc.nix
+++ b/miso-ghc.nix
@@ -1,5 +1,5 @@
 { mkDerivation, aeson, base, bytestring, containers, lucid
-, stdenv, text, vector
+, stdenv, text, vector, BoundedChan
 }:
 mkDerivation {
   pname = "miso";
@@ -8,7 +8,7 @@ mkDerivation {
   isLibrary = true;
   isExecutable = true;
   libraryHaskellDepends = [
-    aeson base bytestring containers lucid text vector
+    aeson base bytestring containers lucid text vector BoundedChan
   ];
   homepage = "http://github.com/dmjio/miso";
   description = "Haskell front-end framework";

--- a/miso-ghcjs.nix
+++ b/miso-ghcjs.nix
@@ -1,7 +1,7 @@
 { mkDerivation, aeson, base, bytestring, containers, ghcjs-base
 , network-uri, scientific, stdenv, text, transformers
 , unordered-containers, vector, hspec, hspec-core, servant
-, http-types, http-api-data
+, http-types, http-api-data, BoundedChan
 }:
 mkDerivation {
   pname = "miso";
@@ -12,7 +12,7 @@ mkDerivation {
   libraryHaskellDepends = [
     aeson base bytestring containers ghcjs-base network-uri scientific
     text transformers unordered-containers vector hspec hspec-core servant
-    http-types http-api-data
+    http-types http-api-data BoundedChan
   ];
   homepage = "http://github.com/dmjio/miso";
   description = "Haskell front-end framework";

--- a/miso.cabal
+++ b/miso.cabal
@@ -128,6 +128,7 @@ library
     aeson,
     base < 5,
     bytestring,
+    BoundedChan,
     containers,
     text
   if impl(ghcjs)


### PR DESCRIPTION
In `Miso.Concurrent`, `EventWriter` uses an unbounded channel to receive events. This causes linear growth of memory under high load. The mario example demonstrates this very well.

<img width="283" alt="screen shot 2017-07-07 at 12 37 22 am" src="https://user-images.githubusercontent.com/875324/27948036-153b3e14-62ad-11e7-85a9-2f40ff736b75.png">

This PR introduces `BoundedChan` to drop unnecessary events and specify an upper bound on the number of messages that can exist in memory at any given time.

<img width="221" alt="screen shot 2017-07-07 at 12 39 50 am" src="https://user-images.githubusercontent.com/875324/27948061-2ec1b516-62ad-11e7-9c8e-209d37a6524b.png">

This PR also adds strictness to the mario model example, and replaces the `SkipChan` implementation from `Control.Concurrent` with a single synchronizing variable.