### PR TITLE
Expose Miso from ghc-src

### DIFF
--- a/ghc-src/Miso.hs
+++ b/ghc-src/Miso.hs
@@ -1,0 +1,21 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE LambdaCase          #-}
+{-# LANGUAGE RecordWildCards     #-}
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE KindSignatures      #-}
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Miso
+-- Copyright   :  (C) 2016-2017 David M. Johnson
+-- License     :  BSD3-style (see the file LICENSE)
+-- Maintainer  :  David M. Johnson <djohnson.m@gmail.com>
+-- Stability   :  experimental
+-- Portability :  non-portable
+----------------------------------------------------------------------------
+module Miso
+  ( module Miso.Event
+  , module Miso.Html
+  ) where
+
+import           Miso.Event
+import           Miso.Html

--- a/miso.cabal
+++ b/miso.cabal
@@ -139,6 +139,7 @@ library
   default-language:
     Haskell2010
   exposed-modules:
+    Miso
     Miso.Html
     Miso.Html.Element
     Miso.Html.Event
@@ -185,7 +186,6 @@ library
       jsbits/isomorphic.js
       jsbits/util.js
     exposed-modules:
-      Miso
       Miso.Effect
       Miso.Effect.Storage
       Miso.Effect.XHR


### PR DESCRIPTION
`Miso` was missing from the export list for `ghc` src