### PR TITLE
Share MkLink across ghc/ghcjs-src

### DIFF
--- a/ghcjs-src/Miso/Html/Internal.hs
+++ b/ghcjs-src/Miso/Html/Internal.hs
@@ -1,19 +1,20 @@
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE CPP                #-}
-{-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE OverloadedStrings          #-}
+{-# LANGUAGE CPP                        #-}
+{-# LANGUAGE TypeFamilies               #-}
+{-# LANGUAGE TypeOperators              #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE DataKinds #-}
-{-# LANGUAGE KindSignatures #-}
-{-# LANGUAGE LambdaCase            #-}
-{-# LANGUAGE ConstraintKinds       #-}
-{-# LANGUAGE FlexibleInstances     #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE ScopedTypeVariables   #-}
-{-# LANGUAGE OverloadedStrings     #-}
-{-# LANGUAGE DeriveGeneric         #-}
-{-# LANGUAGE RecordWildCards       #-}
-{-# OPTIONS_GHC -fno-warn-orphans  #-}
+{-# LANGUAGE DataKinds                  #-}
+{-# LANGUAGE KindSignatures             #-}
+{-# LANGUAGE LambdaCase                 #-}
+{-# LANGUAGE ConstraintKinds            #-}
+{-# LANGUAGE FlexibleInstances          #-}
+{-# LANGUAGE MultiParamTypeClasses      #-}
+{-# LANGUAGE UndecidableInstances       #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
+{-# LANGUAGE OverloadedStrings          #-}
+{-# LANGUAGE DeriveGeneric              #-}
+{-# LANGUAGE RecordWildCards            #-}
+{-# OPTIONS_GHC -fno-warn-orphans       #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Miso.Html.Internal
@@ -51,19 +52,20 @@ module Miso.Html.Internal (
   ) where
 
 import           Control.Monad
--- import           Data.Aeson hiding (Object)
-import           Data.Aeson.Types (parseEither)
-import           Data.Monoid
+import           Data.Aeson.Types           (parseEither)
 import           Data.JSString
 import           Data.JSString.Text
-import qualified Data.Map as M
-import qualified Data.Text as T
+import qualified Data.Map                   as M
+import           Data.Monoid
+import           Data.Proxy
+import qualified Data.Text                  as T
 import           GHCJS.Foreign.Callback
 import           GHCJS.Marshal
 import           GHCJS.Types
-import           JavaScript.Array.Internal (fromList)
+import           JavaScript.Array.Internal  (fromList)
 import           JavaScript.Object
 import           JavaScript.Object.Internal (Object (Object))
+import           Servant.API
 
 import           Miso.Event.Decoder
 import           Miso.Event.Types
@@ -82,6 +84,11 @@ newtype VTree = VTree { getTree :: Object }
 newtype View action = View {
   runView :: (action -> IO ()) -> IO VTree
 }
+
+-- | For constructing type-safe links
+instance HasLink (View a) where
+  type MkLink (View a) = MkLink (Get '[] ())
+  toLink _ = toLink (Proxy :: Proxy (Get '[] ()))
 
 -- | Convenience class for using View
 class ToView v where toView :: v -> View m

--- a/ghcjs-src/Miso/Router.hs
+++ b/ghcjs-src/Miso/Router.hs
@@ -137,11 +137,6 @@ instance HasRouter m (View a) where
   type RouteT m (View a) x = m -> x
   route _ _ a m = RPage (a m)
 
--- | Link
-instance HasLink (View a) where
-  type MkLink (View a) = MkLink (Get '[] ())
-  toLink _ = toLink (Proxy :: Proxy (Get '[] ()))
-
 -- | Use a handler to route a 'Location'.
 -- Normally 'runRoute' should be used instead, unless you want custom
 -- handling of string failing to parse as 'URI'.

--- a/miso-ghc.nix
+++ b/miso-ghc.nix
@@ -1,5 +1,5 @@
 { mkDerivation, aeson, base, bytestring, containers, lucid
-, stdenv, text, vector, BoundedChan
+, stdenv, text, vector, BoundedChan, servant
 }:
 mkDerivation {
   pname = "miso";
@@ -8,7 +8,7 @@ mkDerivation {
   isLibrary = true;
   isExecutable = true;
   libraryHaskellDepends = [
-    aeson base bytestring containers lucid text vector BoundedChan
+    aeson base bytestring containers lucid text vector BoundedChan servant
   ];
   homepage = "http://github.com/dmjio/miso";
   description = "A tasty Haskell front-end framework";

--- a/miso.cabal
+++ b/miso.cabal
@@ -165,6 +165,7 @@ library
     bytestring,
     BoundedChan,
     containers,
+    servant,
     text
   if impl(ghcjs)
     hs-source-dirs:
@@ -177,7 +178,6 @@ library
       containers,
       scientific,
       unordered-containers,
-      servant,
       transformers,
       vector
     js-sources:


### PR DESCRIPTION
To allow type-safe links to be generated on the server, w/o causing orphans