### PR TITLE
Add sse example, fixes #196

### DIFF
--- a/examples/sse/LICENSE
+++ b/examples/sse/LICENSE
@@ -1,0 +1,30 @@
+Copyright (c) 2017, David Johnson
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+
+    * Neither the name of David Johnson nor the names of other
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/examples/sse/client.nix
+++ b/examples/sse/client.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, aeson, base, containers, miso, network-uri, servant
+, stdenv
+}:
+mkDerivation {
+  pname = "sse";
+  version = "0.1.0.0";
+  src = ./.;
+  isLibrary = false;
+  isExecutable = true;
+  executableHaskellDepends = [
+    aeson base containers miso network-uri servant
+  ];
+  homepage = "https://sse.haskell-miso.org";
+  description = "Server sent events example";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/examples/sse/client/Main.hs
+++ b/examples/sse/client/Main.hs
@@ -1,0 +1,40 @@
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE OverloadedStrings #-}
+module Main where
+
+import Common
+import Data.Proxy
+
+import Miso
+
+-- 'runRoute' requires that our model includes the current URI.
+instance HasURI Model where
+  lensURI = makeLens getter setter
+    where
+      getter = modelUri
+      setter = \m u -> m { modelUri = u }
+
+main :: IO ()
+main = do
+  currentURI <- getCurrentURI
+  miso
+    App {initialAction = NoOp, model = Model currentURI "No event received", ..}
+  where
+    update = updateModel
+    view
+      -- If 'runRoute' fails, we fall back to displaying a 404 page.
+     =
+      either (const the404) id . runRoute (Proxy :: Proxy ClientRoutes) handlers
+    events = defaultEvents
+    subs = [sseSub "/sse" handleSseMsg, uriSub HandleURI]
+
+handleSseMsg :: SSE String -> Action
+handleSseMsg (SSEMessage msg) = ServerMsg msg
+handleSseMsg SSEClose = ServerMsg "SSE connection closed"
+handleSseMsg SSEError = ServerMsg "SSE error"
+
+updateModel :: Action -> Model -> Effect Model Action
+updateModel (ServerMsg msg) m = noEff (m {modelMsg = "Event received: " ++ msg})
+updateModel (HandleURI u) m = m {modelUri = u} <# pure NoOp
+updateModel (ChangeURI u) m = m <# (pushURI u >> pure NoOp)
+updateModel NoOp m = noEff m

--- a/examples/sse/default.nix
+++ b/examples/sse/default.nix
@@ -1,0 +1,14 @@
+{ pkgs ? import <nixpkgs> {} }:
+let
+  inherit (pkgs) runCommand closurecompiler;
+  inherit (pkgs.haskell.packages) ghcjs ghc802;
+  miso-ghc = ghc802.callPackage ./../../miso-ghc.nix { };
+  miso-ghcjs = ghcjs.callPackage ./../../miso-ghcjs.nix { };
+  server = ghc802.callPackage ./server.nix { miso = miso-ghc; };
+  client = ghcjs.callPackage ./client.nix { miso = miso-ghcjs; };
+in
+  runCommand "sse.haskell-miso.org" { inherit client server; } ''
+    mkdir -p $out/{bin,static}
+    ${closurecompiler}/bin/closure-compiler ${client}/bin/client.jsexe/all.js > $out/static/all.js
+    cp ${server}/bin/* $out/bin
+  ''

--- a/examples/sse/nix/config.nix
+++ b/examples/sse/nix/config.nix
@@ -1,0 +1,24 @@
+{ pkgs, config, ... }:
+{
+  imports = [ ./module.nix ];
+  nixpkgs.config.packageOverrides = pkgs: {
+    sse-haskell-miso = import ./../default.nix {};
+  };
+  services = {
+    sse-haskell-miso.enable = true;
+    nginx = {
+      enable = true;
+      virtualHosts = {
+        "sse.haskell-miso.org" = {
+           forceSSL = true;
+           enableACME = true;
+           locations = {
+	     "/" = {
+	        proxyPass = "http://localhost:3003";
+            };
+          };
+        };
+      };
+    };
+  };
+}

--- a/examples/sse/nix/module.nix
+++ b/examples/sse/nix/module.nix
@@ -1,0 +1,25 @@
+{ options, lib, config, pkgs, modulesPath }:
+let
+  cfg = config.services.sse-haskell-miso;
+in {
+   options.services.sse-haskell-miso.enable = lib.mkEnableOption "Enable the sse.haskell-miso.org service";
+   config = lib.mkIf cfg.enable {
+     systemd.services.sse-haskell-miso = {
+       path = with pkgs; [ sse-haskell-miso bash ];
+       wantedBy = [ "multi-user.target" ];
+       script = ''
+	 ./bin/server +RTS -N -A4M -RTS
+       '';
+       description = ''
+         https://sse.haskell-miso.org
+       '';
+       serviceConfig = {
+         WorkingDirectory=pkgs.sse-haskell-miso;
+	 KillSignal="INT";
+	 Type = "simple";
+         Restart = "on-abort";
+         RestartSec = "10";
+      };
+    };
+  };
+}

--- a/examples/sse/server.nix
+++ b/examples/sse/server.nix
@@ -1,0 +1,18 @@
+{ mkDerivation, aeson, base, containers, http-types, lucid, miso
+, mtl, network-uri, servant, servant-lucid, servant-server, stdenv
+, wai, wai-extra, warp
+}:
+mkDerivation {
+  pname = "sse";
+  version = "0.1.0.0";
+  src = ./.;
+  isLibrary = false;
+  isExecutable = true;
+  executableHaskellDepends = [
+    aeson base containers http-types lucid miso mtl network-uri servant
+    servant-lucid servant-server wai wai-extra warp
+  ];
+  homepage = "https://sse.haskell-miso.org";
+  description = "Server sent events example";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/examples/sse/server/Main.hs
+++ b/examples/sse/server/Main.hs
@@ -1,0 +1,101 @@
+{-# LANGUAGE OverloadedStrings          #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE PolyKinds                  #-}
+{-# LANGUAGE DataKinds                  #-}
+{-# LANGUAGE TypeOperators              #-}
+{-# LANGUAGE TypeApplications           #-}
+module Main where
+
+import           Common
+import           Control.Concurrent
+import           Control.Monad
+import           Data.Binary.Builder
+import           Data.Monoid ((<>))
+import           Data.Proxy
+import           Data.Time.Clock
+import qualified Lucid as L
+import           Lucid.Base
+import           Network.HTTP.Types
+import           Network.Wai
+import           Network.Wai.EventSource
+import           Network.Wai.Handler.Warp
+import           Network.Wai.Middleware.Gzip
+import           Network.Wai.Middleware.RequestLogger
+import           Servant
+import qualified System.IO as IO
+
+
+import           Miso
+
+port :: Int
+port = 3003
+
+main :: IO ()
+main = do
+  IO.hPutStrLn IO.stderr ("Running on port " <> show port <> "...")
+  chan <- newChan
+  _ <- forkIO (sendEvents chan)
+  run port $ logStdout (compress (app chan))
+    where
+      compress = gzip def { gzipFiles = GzipCompress }
+
+-- Send 1 event/s containing the current server time
+sendEvents :: Chan ServerEvent -> IO ()
+sendEvents chan =
+  forever $ do
+    time <- getCurrentTime
+    writeChan
+      chan
+      (ServerEvent Nothing Nothing [putStringUtf8 (show (show time))])
+    threadDelay (10 ^ (6 :: Int))
+
+-- | Wrapper for setting HTML doctype and header
+newtype Wrapper a = Wrapper a
+  deriving (Show, Eq)
+
+instance L.ToHtml a => L.ToHtml (Wrapper a) where
+  toHtmlRaw = L.toHtml
+  toHtml (Wrapper x) =
+    L.doctypehtml_ $ do
+      L.head_ $ do
+        L.meta_ [L.charset_ "utf-8"]
+        jsRef "static/all.js" -- Include the frontend
+      L.body_ (L.toHtml x)
+    where
+      jsRef href =
+        L.with
+          (L.script_ mempty)
+          [ makeAttribute "src" href
+          , makeAttribute "async" mempty
+          , makeAttribute "defer" mempty
+          ]
+
+type ServerRoutes = ToServerRoutes ClientRoutes Wrapper Action
+
+handle404 :: Application
+handle404 _ respond =
+  respond $
+  responseLBS status404 [("Content-Type", "text/html")] $
+  renderBS $
+  toHtml $
+  Wrapper $ the404
+
+type API = "static" :> Raw :<|> "sse" :> Raw :<|> ServerRoutes :<|> Raw
+
+app :: Chan ServerEvent -> Application
+app chan =
+  serve
+    (Proxy @API)
+    (static :<|> sseApp chan :<|> (serverHandlers :<|> handle404))
+  where
+    static = serveDirectory "static"
+
+sseApp :: Chan ServerEvent -> Application
+sseApp chan = eventSourceAppChan chan
+
+serverHandlers :: Handler (Wrapper (View Action))
+serverHandlers = homeHandler
+  where
+    send f u =
+      pure $ Wrapper $ f Model {modelUri = u, modelMsg = "No event received"}
+    homeHandler = send home goHome

--- a/examples/sse/shared/Common.hs
+++ b/examples/sse/shared/Common.hs
@@ -1,0 +1,39 @@
+module Common where
+
+import Data.Proxy
+import Servant.API
+
+import Miso
+
+data Model = Model { modelUri :: URI,  modelMsg :: String }
+  deriving (Show, Eq)
+
+data Action
+  = ServerMsg String
+  | NoOp
+  | ChangeURI URI
+  | HandleURI URI
+  deriving (Show, Eq)
+
+home :: Model -> View Action
+home (Model _ msg) =
+  div_ [] [div_ [] [h3_ [] [text ("SSE Example" :: String)]], text msg]
+
+-- There is only a single route in this example
+type ClientRoutes = Home
+
+type Home = View Action
+
+handlers :: Model -> View Action
+handlers = home
+
+the404 :: View Action
+the404 =
+  div_
+    []
+    [ text ("404: Page not found")
+    , a_ [onClick $ ChangeURI goHome] [text " - Go Home"]
+    ]
+
+goHome :: URI
+goHome = safeLink (Proxy :: Proxy ClientRoutes) (Proxy :: Proxy Home)

--- a/examples/sse/sse.cabal
+++ b/examples/sse/sse.cabal
@@ -1,0 +1,60 @@
+name:                sse
+version:             0.1.0.0
+synopsis:            Server sent events example
+homepage:            https://sse.haskell-miso.org
+license:             BSD3
+license-file:        LICENSE
+author:              David Johnson
+maintainer:          djohnson.m@gmail.com
+copyright:           David Johnson (c) 2017
+category:            Web
+build-type:          Simple
+cabal-version:       >=1.10
+
+executable server
+  main-is:
+    Main.hs
+  if impl(ghcjs)
+    buildable: False
+  else
+    ghc-options:
+      -O2 -threaded -Wall -rtsopts
+    hs-source-dirs:
+      server, shared
+    build-depends:
+      aeson,
+      base < 5,
+      binary,
+      containers,
+      http-types,
+      lucid,
+      miso,
+      mtl,
+      network-uri,
+      servant,
+      servant-lucid,
+      servant-server,
+      time,
+      wai,
+      wai-extra,
+      warp
+    default-language:
+      Haskell2010
+
+executable client
+  main-is:
+    Main.hs
+  if !impl(ghcjs)
+    buildable: False
+  else
+    hs-source-dirs:
+      client, shared
+    build-depends:
+      aeson,
+      base < 5,
+      containers,
+      network-uri,
+      miso,
+      servant
+    default-language:
+      Haskell2010


### PR DESCRIPTION
I’m opening this not because it’s finished (although it does work) but so that we have something to look at while we flesh out the details.

1. The examples is deliberately simple and dumb. Personally I like that way since it makes it very clear what this example is focusing on but I can try coming up with something a bit more complex if you prefer that.
2. Currently the backend is just a separate application. Should I try to integrate it in the `haskell-miso.org` backend? The URl and the port also need to be updated before this is merged (I just needed something to test it :))