### PR TITLE
List of Objects and Multi-target Decoding

### DIFF
--- a/examples/svg/Main.hs
+++ b/examples/svg/Main.hs
@@ -9,7 +9,10 @@ import qualified Data.Map           as M
 import           Miso
 import           Miso.String        (MisoString, pack, ms)
 import           Miso.Svg           hiding (height_, id_, style_, width_)
+import Control.Arrow
 import Touch
+
+trunc = truncate *** truncate
 
 main :: IO ()
 main = startApp App {..}
@@ -31,7 +34,7 @@ updateModel (HandleTouch (TouchEvent touch)) model =
   model <# do
     putStrLn "Touch did move"
     print touch
-    return $ HandleMouse $ page touch
+    return $ HandleMouse $ trunc . page $ touch
 updateModel (HandleMouse newCoords) model =
   noEff model { mouseCoords = newCoords }
 updateModel Id model = noEff model

--- a/examples/svg/Touch.hs
+++ b/examples/svg/Touch.hs
@@ -30,13 +30,13 @@ data TouchEvent =
 
 instance FromJSON TouchEvent where
   parseJSON obj = do
-    (x:_) <- parseJSON obj
+    ((x:_):_) <- parseJSON obj
     return $ TouchEvent x
 
 touchDecoder :: Decoder TouchEvent
 touchDecoder = Decoder {..}
   where
-    decodeAt = ["changedTouches"]
+    decodeAt = DecodeTargets [["changedTouches"], ["targetTouches"], ["touches"]]
     decoder = parseJSON
 
 onTouchMove :: (TouchEvent -> action) -> Attribute action

--- a/examples/svg/Touch.hs
+++ b/examples/svg/Touch.hs
@@ -1,0 +1,47 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
+
+module Touch where
+
+import Control.Monad
+import Data.Aeson.Types
+import qualified Data.Vector as V
+import Debug.Trace
+import GHCJS.Marshal
+import Miso
+
+data Touch = Touch
+  { identifier :: Int
+  , screen :: (Int, Int)
+  , client :: (Int, Int)
+  , page :: (Int, Int)
+  } deriving (Eq, Show)
+
+instance FromJSON Touch where
+  parseJSON =
+    withObject "touch" $ \o -> do
+      identifier <- o .: "identifier"
+      screen <- (,) <$> o .: "screenX" <*> o .: "screenY"
+      client <- (,) <$> o .: "clientX" <*> o .: "clientY"
+      page <- (,) <$> o .: "pageX" <*> o .: "pageY"
+      return Touch {..}
+
+data TouchEvent =
+  TouchEvent Touch
+  deriving (Eq, Show)
+
+instance FromJSON TouchEvent where
+  parseJSON obj = do
+    (x:_) <- parseJSON obj
+    return $ TouchEvent x
+
+touchDecoder :: Decoder TouchEvent
+touchDecoder = Decoder {..}
+  where
+    decodeAt = ["changedTouches", "0"]
+    decoder = parseJSON
+
+onTouchMove :: (TouchEvent -> action) -> Attribute action
+onTouchMove = on "touchmove" touchDecoder
+
+onTouchStart = on "touchstart" touchDecoder

--- a/examples/svg/Touch.hs
+++ b/examples/svg/Touch.hs
@@ -5,16 +5,14 @@ module Touch where
 
 import Control.Monad
 import Data.Aeson.Types
-import qualified Data.Vector as V
 import Debug.Trace
-import GHCJS.Marshal
 import Miso
 
 data Touch = Touch
   { identifier :: Int
   , screen :: (Int, Int)
-  , client :: (Int, Int)
-  , page :: (Int, Int)
+  , client :: (Double, Double)
+  , page :: (Double, Double)
   } deriving (Eq, Show)
 
 instance FromJSON Touch where
@@ -38,7 +36,7 @@ instance FromJSON TouchEvent where
 touchDecoder :: Decoder TouchEvent
 touchDecoder = Decoder {..}
   where
-    decodeAt = ["changedTouches", "0"]
+    decodeAt = ["changedTouches"]
     decoder = parseJSON
 
 onTouchMove :: (TouchEvent -> action) -> Attribute action

--- a/ghcjs-src/Miso/Html/Internal.hs
+++ b/ghcjs-src/Miso/Html/Internal.hs
@@ -228,6 +228,11 @@ foreign import javascript unsafe "$r = objectToJSON($1,$2);"
     -> JSVal -- ^ object with impure references to the DOM
     -> IO JSVal
 
+foreign import javascript unsafe "$r = objectsToJSON($1,$2);"
+  objectsToJSON
+    :: JSVal -- ^ decodeAt :: [JSString]
+    -> JSVal -- ^ object with impure references to the DOM
+    -> IO JSVal
 -- | @onWithOptions opts eventName decoder toAction@ is an attribute
 -- that will set the event handler of the associated DOM node to a function that
 -- decodes its argument using @decoder@, converts it to an action
@@ -251,7 +256,7 @@ onWithOptions options eventName Decoder{..} toAction =
    jsOptions <- toJSVal options
    decodeAtVal <- toJSVal decodeAt
    cb <- jsval <$> (asyncCallback1 $ \e -> do
-       Just v <- jsvalToValue =<< objectToJSON decodeAtVal e
+       Just v <- fromJSVal =<< objectsToJSON decodeAtVal e
        case parseEither decoder v of
          Left s -> error $ "Parse error on " <> unpack eventName <> ": " <> s
          Right r -> sink (toAction r))

--- a/ghcjs-src/Miso/Html/Internal.hs
+++ b/ghcjs-src/Miso/Html/Internal.hs
@@ -228,11 +228,6 @@ foreign import javascript unsafe "$r = objectToJSON($1,$2);"
     -> JSVal -- ^ object with impure references to the DOM
     -> IO JSVal
 
-foreign import javascript unsafe "$r = objectsToJSON($1,$2);"
-  objectsToJSON
-    :: JSVal -- ^ decodeAt :: [JSString]
-    -> JSVal -- ^ object with impure references to the DOM
-    -> IO JSVal
 -- | @onWithOptions opts eventName decoder toAction@ is an attribute
 -- that will set the event handler of the associated DOM node to a function that
 -- decodes its argument using @decoder@, converts it to an action
@@ -256,7 +251,7 @@ onWithOptions options eventName Decoder{..} toAction =
    jsOptions <- toJSVal options
    decodeAtVal <- toJSVal decodeAt
    cb <- jsval <$> (asyncCallback1 $ \e -> do
-       Just v <- fromJSVal =<< objectsToJSON decodeAtVal e
+       Just v <- jsvalToValue =<< objectToJSON decodeAtVal e
        case parseEither decoder v of
          Left s -> error $ "Parse error on " <> unpack eventName <> ": " <> s
          Right r -> sink (toAction r))

--- a/jsbits/delegate.js
+++ b/jsbits/delegate.js
@@ -72,10 +72,24 @@ function propogateWhileAble (parentStack, event) {
 
 /* Convert event to JSON at a specific location in the DOM tree*/
 function objectToJSON (at, obj) {
+    console.log("at ", at);
+    console.log("obj ", obj);
     for (var i in at) obj = obj[at[i]];
     var newObj = {};
     for (var i in obj)
-	if (typeof obj[i] == "string" || typeof obj[i] == "number" || typeof obj[i] == "boolean")
-	    newObj[i] = obj[i];
+        if (typeof obj[i] == "string" || typeof obj[i] == "number" || typeof obj[i] == "boolean")
+            newObj[i] = obj[i];
     return (newObj);
+}
+
+function objectsToJSON (at, obj) {
+  var at = [at];
+  res = [];
+  console.log("orig at", at);
+  console.log("obj ", obj);
+  for (var i in at) {
+    res.push(objectToJSON(at[i], obj));
+  }
+  console.log("res ", res);
+  return (res);
 }

--- a/jsbits/delegate.js
+++ b/jsbits/delegate.js
@@ -72,10 +72,16 @@ function propogateWhileAble (parentStack, event) {
 
 /* Convert event to JSON at a specific location in the DOM tree*/
 function objectToJSON (at, obj) {
-    for (var i in at) obj = obj[at[i]];
-    var newObj = {};
-    for (var i in obj)
-	if (typeof obj[i] == "string" || typeof obj[i] == "number" || typeof obj[i] == "boolean")
-	    newObj[i] = obj[i];
+  for (var i in at) obj = obj[at[i]];
+  if ("length" in obj) { // If obj is a list-like object
+    var newObj = [];
+    for (var i = 0; i < obj.length; i++)
+      newObj = newObj.concat(objectToJSON([], obj[i]));
     return (newObj);
+  }
+  var newObj = {};
+  for (var i in obj)
+    if (typeof obj[i] == "string" || typeof obj[i] == "number" || typeof obj[i] == "boolean")
+      newObj[i] = obj[i];
+  return (newObj);
 }

--- a/jsbits/delegate.js
+++ b/jsbits/delegate.js
@@ -72,24 +72,10 @@ function propogateWhileAble (parentStack, event) {
 
 /* Convert event to JSON at a specific location in the DOM tree*/
 function objectToJSON (at, obj) {
-    console.log("at ", at);
-    console.log("obj ", obj);
     for (var i in at) obj = obj[at[i]];
     var newObj = {};
     for (var i in obj)
-        if (typeof obj[i] == "string" || typeof obj[i] == "number" || typeof obj[i] == "boolean")
-            newObj[i] = obj[i];
+	if (typeof obj[i] == "string" || typeof obj[i] == "number" || typeof obj[i] == "boolean")
+	    newObj[i] = obj[i];
     return (newObj);
-}
-
-function objectsToJSON (at, obj) {
-  var at = [at];
-  res = [];
-  console.log("orig at", at);
-  console.log("obj ", obj);
-  for (var i in at) {
-    res.push(objectToJSON(at[i], obj));
-  }
-  console.log("res ", res);
-  return (res);
 }

--- a/jsbits/delegate.js
+++ b/jsbits/delegate.js
@@ -71,14 +71,26 @@ function propogateWhileAble (parentStack, event) {
 }
 
 /* Convert event to JSON at a specific location in the DOM tree*/
-function objectToJSON (at, obj) {
+fuction objectToJSON (at, obj) {
+  /* If at is of type [[MisoString]] */
+  if (typeof at[0] == "object") {
+    var ret = [];
+    for (var i = 0; i < at.length; i++)
+      ret.push(objectToJSON(at[i], obj));
+    return (ret);
+  }
+
   for (var i in at) obj = obj[at[i]];
-  if ("length" in obj) { // If obj is a list-like object
+
+  /* If obj is a list-like object */
+  if ("length" in obj) {
     var newObj = [];
     for (var i = 0; i < obj.length; i++)
-      newObj = newObj.concat(objectToJSON([], obj[i]));
+      newObj.push(objectToJSON([], obj[i]));
     return (newObj);
   }
+
+  /* If obj is a non-list-like object */
   var newObj = {};
   for (var i in obj)
     if (typeof obj[i] == "string" || typeof obj[i] == "number" || typeof obj[i] == "boolean")

--- a/miso.cabal
+++ b/miso.cabal
@@ -179,6 +179,7 @@ executable svg
     build-depends:
       base < 5,
       containers,
+      aeson,
       miso
     default-language:
       Haskell2010


### PR DESCRIPTION
As this is a proof of concept, the implementation is quite limited (at the time of initial commit, only the SVG example works, others are most likely broken). As the Haskell code hasn't changed much, parts of the functionality are being simulated by the `objectsToJSON` function.

The general plan is to change the type of `decodeAt` to `[[MisoString]]`. This will allow for the specification of multiple targets from which to retrieve information. This gets passed to `objectsToJSON`, which returns an array of objects in the same order specified within `decodeAt` by making multiple calls to `objectToJSON`.

As a slightly related, can anyone see if they are still getting the error which @FPtje reported in ghcjs/ghcjs-base#88. At the moment, I'm dealing with this using a temporary fix I got from ghcjs/shims#41, deleting the second `h$listProps` function upon every build.

Related: #121 #274 #273 