### PR TITLE
WebSockets: refactor for error handling, no global mutable variables, etc

### DIFF
--- a/examples/websocket/Main.hs
+++ b/examples/websocket/Main.hs
@@ -21,22 +21,22 @@ import           Miso.String  (MisoString)
 import qualified Miso.String  as S
 
 main :: IO ()
-main = startApp App { initialAction = Id, ..}
-  where
+main = do
+  Right socket <- newWebSocket "wss://echo.websocket.org"
+  let
     model = Model mempty mempty
     events = defaultEvents
-    subs = [ websocketSub uri protocols HandleWebSocket ]
-    update = updateModel
+    subs = [ websocketSub socket HandleWebSocket ]
+    update = updateModel socket
     view = appView
-    uri = URL "wss://echo.websocket.org"
-    protocols = Protocols [ ]
+  startApp App { initialAction = Id, ..}
 
-updateModel :: Action -> Model -> Effect Action Model
-updateModel (HandleWebSocket (WebSocketMessage (Message m))) model
-  = noEff model { received = m }
-updateModel (SendMessage msg) model = model <# do send msg >> pure Id
-updateModel (UpdateMessage m) model = noEff model { msg = Message m }
-updateModel _ model = noEff model
+updateModel :: WebSocket -> Action -> Model -> Effect Action Model
+updateModel ws action model = case action of
+  HandleWebSocket (WebSocketMessage (Message m)) -> pure model {received = m}
+  SendMessage msg -> model <# do Id <$ sendJsonToWebSocket ws msg
+  UpdateMessage m -> pure model { msg = Message m }
+  _ -> pure model
 
 instance ToJSON Message
 instance FromJSON Message
@@ -45,7 +45,7 @@ newtype Message = Message MisoString
   deriving (Eq, Show, Generic, Monoid)
 
 data Action
-  = HandleWebSocket (WebSocket Message)
+  = HandleWebSocket (WebSocketEvent Message)
   | SendMessage Message
   | UpdateMessage MisoString
   | Id

--- a/ghcjs-src/Miso/Effect/Storage.hs
+++ b/ghcjs-src/Miso/Effect/Storage.hs
@@ -46,11 +46,9 @@ getStorageCommon f key = do
   result :: Maybe JSVal <- f key
   case result of
     Nothing -> pure $ Left "Not Found"
-    Just v -> do
-      r <- parse v
-      pure $ case fromJSON r of
-        Success x -> Right x
-        Error y -> Left y
+    Just v -> parseJSValAsJson v >>= pure . \case
+      Success x -> Right x
+      Error y -> Left y
 
 -- | Retrieve session storage
 getSessionStorage :: FromJSON model => JSString -> IO (Either String model)

--- a/ghcjs-src/Miso/Effect/XHR.hs
+++ b/ghcjs-src/Miso/Effect/XHR.hs
@@ -203,7 +203,7 @@ instance HasXHR api => HasXHR (BasicAuth realm usr :> api) where
 --   case contents r of
 --     Nothing -> pure r { contents = Just Null }
 --     Just jsstring -> do
---       x <- parse (unsafeCoerce jsstring)
+--       x <- unsafeParseJSValAsJson (unsafeCoerce jsstring)
 --       pure $ r { contents = Just x }
 
 

--- a/ghcjs-src/Miso/Subscription/SSE.hs
+++ b/ghcjs-src/Miso/Subscription/SSE.hs
@@ -30,7 +30,7 @@ sseSub url f _ = \sink -> do
   es <- newEventSource url
   onMessage es =<< do
     asyncCallback1 $ \val -> do
-      getData val >>= parse >>= \x -> do
+      getData val >>= unsafeParseJSValAsJson >>= \x -> do
         sink $ f (SSEMessage x)
   onError es =<< do
     asyncCallback $


### PR DESCRIPTION
This is a refactor of the websockets subscription module.

Changes:

* Remove global mutable variables and unsafePerformIO, which follows best practices and allows for more than one websocket in an app
* Enable error handling, allowing the user to e.g. respond to a situation where the websocket fails to connect, or a message fails to parse
* Allow the reconnection behavior to be configurable by having the user pass in a function which can decide whether to reconnect
* Enable a simple ping behavior which can be useful to prevent the browser from closing an inactive socket
* Prevent invalid behavior such as closing a websocket before it has opened or sending a message to a closed socket, by using MVar. Also there’s no need for a thread to poll whether the socket has closed
* Allow apps to send plain text as well as ToJSON objects

Despite the large list above, the external interface has only changed a bit. As can be seen in the updated websockets example, there are relatively few things that need to be changed in current code. The main change is that the user is responsible for creating the socket object, which must also be used when sending data.