### PR TITLE
Create AppContext type, allow to be initialized separateely

### DIFF
--- a/ghcjs-src/Miso/Subscription.hs
+++ b/ghcjs-src/Miso/Subscription.hs
@@ -14,7 +14,10 @@ module Miso.Subscription
   , module Miso.Subscription.WebSocket
   , module Miso.Subscription.Window
   , module Miso.Subscription.SSE
+  , Sub, addSub
   ) where
+
+import Data.IORef (readIORef)
 
 import Miso.Subscription.Mouse
 import Miso.Subscription.Keyboard
@@ -22,3 +25,10 @@ import Miso.Subscription.History
 import Miso.Subscription.WebSocket
 import Miso.Subscription.Window
 import Miso.Subscription.SSE
+
+import Miso.Html.Internal (Sub)
+import Miso.Types (AppContext(..), writeEvent)
+
+-- | Add a subscription to a running app
+addSub :: AppContext action model -> Sub action model -> IO ()
+addSub ctx sub = sub (readIORef $ modelRef ctx) (writeEvent ctx)


### PR DESCRIPTION
This maintains the existing API; in particular the current `miso` and `startApp` functions maintain the same behavior as they had before, but allows users with particular needs access to a limited portion of the internals of miso operation.

This puts the `writeEvent`, `notify` and `modelRef` objects into an `AppContext` type rather than hiding them in the internals of the `miso` and `startApp` functions. The user can initialize the `AppContext` themselves (with `newAppContext`) and use it to e.g. start or stop subscriptions during an IO action returned in an `Effect`, rather than having a fixed set of subscriptions which are opaque to the user. The ability to do this was essential for an app I'm working on.

In addition to the changes needed to support the above, there is a bit of code rearrangement in the `Miso` module.