### PR TITLE
Do not generate 'xlink:class' attributes for svg elements

### DIFF
--- a/jsbits/diff.js
+++ b/jsbits/diff.js
@@ -76,8 +76,6 @@ function diffProps (cProps, nProps, node, isSvg) {
 	   if (isSvg) {
 	     if (c === "href")
 		node.setAttributeNS("http://www.w3.org/1999/xlink", "href", newProp);
-	     else if (c === "className" || c === "class")
-		node.setAttributeNS("http://www.w3.org/1999/xlink", "class", newProp);
 	     else
 		node.setAttribute(c, newProp);
 	    } else if (c in node && !(c === "list" || c === "form")) {
@@ -95,8 +93,6 @@ function diffProps (cProps, nProps, node, isSvg) {
 	  if (isSvg) {
 	    if (n === "href")
 	       node.setAttributeNS("http://www.w3.org/1999/xlink", "href", newProp);
-	    else if (n === "className" || n === "class")
-	       node.setAttributeNS("http://www.w3.org/1999/xlink", "class", newProp);
 	    else
 	       node.setAttribute(n, newProp);
 	  } else if (n in node && !(n === "list" || n === "form")) {


### PR DESCRIPTION
The xlink:class prevents css styling from working.

```css
/* default.css */
.myClass { stroke: red; }
```

```haskell
-- some code that generates svg elements
line_ [class_' "myClass", x1_ "0", y1_ "0", x2_ "2", y2_ "3"]
```
```html
<!-- html -->
<head>
  <link rel="stylesheet" href="default.css"/>
</head>
<body>
  <script language="javascript" src="js/all.js" defer></script>
</body>
```

Miso will insert the svg element `<line xlink:class="myClass" ...>`. The result is that the styling in `default.css` will not apply to that element. If we use the `class` attribute directly everything works fine.

I see how the xlink stuff could be important in relation with the `href` attribute. But why for `class`?