### PR TITLE
ghcjs801 stack.yaml update

### DIFF
--- a/stack/ghcjs801/stack.yaml
+++ b/stack/ghcjs801/stack.yaml
@@ -1,11 +1,11 @@
 resolver: lts-7.19
 compiler: ghcjs-0.2.1.9007019_ghc-8.0.1
-compiler-check: match-exact
+compiler-check: match-exact # Be sure you also have this line in ~/.stack/config.yaml (match-minor also works for either/both)
 
 packages:
  - '.'
-extra-deps:
- - miso
+extra-deps: 
+ - miso-0.10.0.0
 
 setup-info:
   ghcjs:


### PR DESCRIPTION
Two things:
1. Need a note about `~/.stack/config.yaml` having `match-exact` in place, or it tries to use GHC 8.0.2 libraries and explodes while building GHCJS. That note will hopefully save people lots of time.
2. Need the miso version number, or Stack thinks the dependency is the folder `./miso` instead of the `miso` library.