### PR TITLE
Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -444,7 +444,7 @@ By default `miso` uses a known-to-work, pinned version of [`nixpkgs`](https://gi
 To override this to your system's version of `nixpkgs` write:
 
 ```
-nix-build --arg nixpkgs 'import <nixpkgs> {};'
+nix-build --arg nixpkgs 'import <nixpkgs> {}'
 ```
 
 ## Maintainers


### PR DESCRIPTION
to avoid 
```error: syntax error, unexpected ';', expecting $end, at (string):1:20``` 
while running 
```$ nix-build --arg nixpkgs 'import <nixpkgs> {};``` 
(Note `;` at the end).
