### PR TITLE
Single build of `Mario` example

### DIFF
--- a/README.md
+++ b/README.md
@@ -444,6 +444,8 @@ cd result/examples/todo-mvc.jsexe && python -m SimpleHTTPServer
 Serving HTTP on 0.0.0.0 port 8000 ...
 ```
 
+You can also run [`example of Mario`](https://github.com/dmjio/miso/blob/master/examples/mario/) as a single build as described in its [README](https://github.com/dmjio/miso/blob/master/examples/mario/README.md)
+
 ## Pinning nixpkgs
 
 By default `miso` uses a known-to-work, pinned version of [`nixpkgs`](https://github.com/dmjio/miso/blob/master/default.nix#L1-L6).

--- a/default.nix
+++ b/default.nix
@@ -18,10 +18,7 @@ let
     doCheck = tests && !isDarwin;
     doHaddock = haddock;
     postInstall = ''
-      mkdir -p $out/bin/mario.jsexe/imgs
-      cp -r ${drv.src}/examples/mario/imgs $out/bin/mario.jsexe/
       cp ${drv.src}/examples/todo-mvc/index.html $out/bin/todo-mvc.jsexe/
-      cp ${drv.src}/examples/mario/index.html $out/bin/mario.jsexe/
       cp ${drv.src}/examples/websocket/index.html $out/bin/websocket.jsexe/
       cp ${drv.src}/examples/xhr/index.html $out/bin/xhr.jsexe/
       ${closurecompiler}/bin/closure-compiler $out/bin/todo-mvc.jsexe/all.js > $out/bin/todo-mvc.jsexe/min.js
@@ -33,6 +30,7 @@ let
       phantomjs dist/build/tests/tests.jsexe/all.js
     '';
   });
+  mario = ghcjs.callPackage ./examples/mario/mario.nix { miso = result.miso-ghcjs; };
   flatris = ghcjs.callCabal2nix "hs-flatris" (pkgs.fetchFromGitHub {
     repo = "hs-flatris";
     owner = "ptigwe";
@@ -58,7 +56,7 @@ let
     s3 = pkgs.writeScriptBin "s3.sh" ''
        ${pkgs.s3cmd}/bin/s3cmd sync --recursive ${flatris}/bin/app.jsexe/ s3://aws-website-flatris-b3cr6/
        ${pkgs.s3cmd}/bin/s3cmd sync --recursive ${result.miso-ghcjs}/bin/simple.jsexe/ s3://aws-website-simple-4yic3/
-       ${pkgs.s3cmd}/bin/s3cmd sync --recursive ${result.miso-ghcjs}/bin/mario.jsexe/ s3://aws-website-mario-5u38b/
+       ${ pkgs.s3cmd}/bin/s3cmd sync --recursive ${mario}/bin/mario.jsexe/ s3://aws-website-mario-5u38b/
        ${pkgs.s3cmd}/bin/s3cmd sync --recursive ${result.miso-ghcjs}/bin/todo-mvc.jsexe/ s3://aws-website-todo-mvc-hs61i/
        ${pkgs.s3cmd}/bin/s3cmd sync --recursive ${result.miso-ghcjs}/bin/websocket.jsexe/ s3://aws-website-websocket-0gx34/
        ${pkgs.s3cmd}/bin/s3cmd sync --recursive ${result.miso-ghcjs}/bin/router.jsexe/ s3://aws-website-router-gfy22/
@@ -73,6 +71,8 @@ let
 in pkgs.runCommand "miso" result ''
      mkdir -p $out/{lib,examples}
      cp -r ${result.miso-ghcjs}/bin/* $out/examples
+     mkdir -p $out/examples/mario
+     cp -r ${mario}/bin/* $out/examples/mario
      cp -r ${result.miso-ghcjs}/lib/* $out/lib
      ln -s ${result.miso-ghcjs.doc} $out/ghcjs-doc
      ln -s ${result.miso-ghc.doc} $out/ghc-doc

--- a/examples/mario/Main.hs
+++ b/examples/mario/Main.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
 {-# LANGUAGE MultiWayIf        #-}
-{-# LANGUAGE BangPatterns      #-}
 module Main where
 
 import           Data.Bool
@@ -118,7 +117,7 @@ display :: Model -> View action
 display m@Model{..} = marioImage
   where
     (h,w) = window
-    groundY = 62 - (fromIntegral (fst window) / 2)
+    groundY = 62 - (fromIntegral h / 2)
     marioImage =
       div_ [ height_ $ pack (show h)
            , width_ $ pack (show w)

--- a/examples/mario/README.md
+++ b/examples/mario/README.md
@@ -1,0 +1,17 @@
+# Mario example
+
+## Build
+
+```
+cd examples/mario
+nix-build
+```
+
+
+## Run
+
+```
+cd examples/mario/result/bin/mario.jsexe/
+python -m SimpleHTTPServer
+Serving HTTP on 0.0.0.0 port 8000 ...
+```

--- a/examples/mario/default.nix
+++ b/examples/mario/default.nix
@@ -1,0 +1,12 @@
+{ nixpkgs ? import ((import <nixpkgs> {}).fetchFromGitHub {
+    owner = "NixOS";
+    repo = "nixpkgs";
+    rev = "a0aeb23";
+    sha256 = "04dgg0f2839c1kvlhc45hcksmjzr8a22q1bgfnrx71935ilxl33d";
+  }){}
+}:
+let
+  inherit (nixpkgs.haskell.packages) ghc802 ghcjs;
+  miso = ghcjs.callPackage ./../../miso-ghcjs.nix { };
+in
+  ghcjs.callPackage ./mario.nix { inherit miso; }

--- a/examples/mario/mario.cabal
+++ b/examples/mario/mario.cabal
@@ -1,0 +1,20 @@
+name:                mario
+version:             0.1.0.0
+synopsis:            Mario example
+category:            Web
+build-type:          Simple
+cabal-version:       >=1.10
+
+extra-source-files:
+  index.html
+  imgs/mario.png
+
+executable mario
+  main-is:
+    Main.hs
+  build-depends:
+    base < 5,
+    containers,
+    miso
+  default-language:
+    Haskell2010

--- a/examples/mario/mario.nix
+++ b/examples/mario/mario.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, base, containers, miso, stdenv }:
+mkDerivation {
+  pname = "miso-mario";
+  version = "0.1.0.0";
+  src = ./.;
+  isLibrary = false;
+  isExecutable = true;
+  executableHaskellDepends = [ base containers miso ];
+  description = "Miso's Mario example";
+  license = stdenv.lib.licenses.bsd3;
+  postInstall = ''
+    mkdir -p $out/bin/mario.jsexe/imgs
+    cp -r ./imgs $out/bin/mario.jsexe/
+    cp ./index.html $out/bin/mario.jsexe/
+  '';
+}

--- a/miso.cabal
+++ b/miso.cabal
@@ -18,8 +18,6 @@ extra-source-files:
   README.md
   examples/todo-mvc/index.html
   examples/websocket/index.html
-  examples/mario/index.html
-  examples/mario/imgs/mario.png
 
 flag examples
   default:
@@ -143,21 +141,6 @@ executable websocket
       examples/websocket
     build-depends:
       aeson,
-      base < 5,
-      containers,
-      miso
-    default-language:
-      Haskell2010
-
-executable mario
-  main-is:
-    Main.hs
-  if !impl(ghcjs) || !flag(examples)
-    buildable: False
-  else
-    hs-source-dirs:
-      examples/mario
-    build-depends:
       base < 5,
       containers,
       miso


### PR DESCRIPTION
As discussed in https://haskell-miso.slack.com/archives/C2GPQ2XH7/p1515516892000400 it would be nice to build an example separately and not all at once. 

This PR enables a single build of  `Mario` example w/o the need of building all other examples. It includes a tiny code fix as well - just cosmetic :icecream: .

