### PR TITLE
Fix "disabled" attribute

### DIFF
--- a/ghcjs-src/Miso/Html/Internal.hs
+++ b/ghcjs-src/Miso/Html/Internal.hs
@@ -41,6 +41,7 @@ module Miso.Html.Internal (
   , NS     (..)
   -- * Setting properties on virtual DOM nodes
   , prop
+  , optionalProp
   -- * Setting css
   , style_
   -- * Handling events
@@ -215,6 +216,10 @@ prop k v = Attribute . const $ \n -> do
   val <- toJSVal v
   o <- getProp ("props" :: MisoString) n
   set k val (Object o)
+
+optionalProp :: ToJSVal a => MisoString -> Maybe a -> Attribute action
+optionalProp _ Nothing  = Attribute $ \_ _ -> pure ()
+optionalProp k (Just v) = prop k v
 
 -- | Convenience wrapper for @onWithOptions defaultOptions@.
 --

--- a/src/Miso/Html/Property.hs
+++ b/src/Miso/Html/Property.hs
@@ -176,7 +176,8 @@ autosave_ ::  MisoString -> Attribute action
 autosave_          = textProp "autosave"
 -- | <https://developer.mozilla.org/en-US/docs/Mozilla/Tech/XUL/Attribute/disabled>
 disabled_ ::  Bool -> Attribute action
-disabled_          = boolProp "disabled"
+disabled_ disabled = optionalProp "disabled" $
+                       if disabled then Just True else Nothing
 -- | <https://developer.mozilla.org/en-US/docs/Mozilla/Tech/XUL/Attribute/enctype>
 enctype_ ::  MisoString -> Attribute action
 enctype_           = textProp "enctype"


### PR DESCRIPTION
The "disabled" attribute should not be set to the string "false" when the value is False. Instead we shouldn't set it at all. See:

https://developer.mozilla.org/en-US/docs/Mozilla/Tech/XUL/Attribute/disabled

I'm not sure this is the best fix but I wrote it in a hurry to reach a deadline and it worked correctly.