### PR TITLE
ToMisoString instances for Float, Double and Int

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,12 +412,12 @@ main :: IO ()
 main = startApp App {..}
   where
     initialAction = SayHelloWorld -- initial action to be executed on application load
-    model  = 0                    -- initial model
-    update = updateModel          -- update function
-    view   = viewModel            -- view function
-    events = defaultEvents        -- default delegated events
-    mountPoint = Nothing          -- mount point for miso on DOM, defaults to body
-    subs   = []                   -- empty subscription list
+    model         = 0             -- initial model
+    update        = updateModel   -- update function
+    view          = viewModel     -- view function
+    events        = defaultEvents -- default delegated events
+    subs          = []            -- empty subscription list
+    mountPoint    = Nothing       -- mount point for application (Nothing defaults to 'body')
 
 -- | Updates model, optionally introduces side effects
 updateModel :: Action -> Model -> Effect Action Model
@@ -431,7 +431,7 @@ updateModel SayHelloWorld m = m <# do
 viewModel :: Model -> View Action
 viewModel x = div_ [] [
    button_ [ onClick AddOne ] [ text "+" ]
- , text (ms (show x))
+ , text (ms x)
  , button_ [ onClick SubtractOne ] [ text "-" ]
  ]
 ```

--- a/examples/compose-update/Main.hs
+++ b/examples/compose-update/Main.hs
@@ -103,6 +103,6 @@ viewModel (x, y) =
   div_
     []
     [ button_ [onClick Increment] [text "+"]
-    , text (ms (show x) <> " | " <> ms (show y))
+    , text (ms x <> " | " <> ms y)
     , button_ [onClick Decrement] [text "-"]
     ]

--- a/examples/mario/Main.hs
+++ b/examples/mario/Main.hs
@@ -117,8 +117,8 @@ display m@Model{..} = marioImage
     (h,w) = window
     groundY = 62 - (fromIntegral (fst window) / 2)
     marioImage =
-      div_ [ height_ $ pack (show h)
-           , width_ $ pack (show w)
+      div_ [ height_ $ ms h
+           , width_ $ ms w
            ] [ div_ [ style_ (marioStyle m groundY) ] [] ]
 
 marioStyle :: Model -> Double -> M.Map MisoString MisoString
@@ -142,7 +142,7 @@ matrix dir x y =
   "matrix("
      <> (if dir == L then "-1" else "1")
      <> ",0,0,1,"
-     <> pack (show x)
+     <> ms x
      <> ","
-     <> pack (show y)
+     <> ms y
      <> ")"

--- a/examples/svg/Main.hs
+++ b/examples/svg/Main.hs
@@ -60,15 +60,15 @@ viewModel (Model (x,y)) =
          , onTouchMove HandleTouch
        ] [
      g_ [] [
-     ellipse_ [ cx_ $ pack $ show x
-              , cy_ $ pack $ show y
+     ellipse_ [ cx_ $ ms x
+              , cy_ $ ms y
               , style_ svgStyle
               , rx_ "100"
               , ry_ "100"
               ] [ ]
      ]
-     , text_ [ x_ $ pack $ show x
-             , y_ $ pack $ show y
+     , text_ [ x_ $ ms x
+             , y_ $ ms y
              ] [ text $ ms $ show (x,y) ]
    ]
  ]

--- a/examples/todo-mvc/Main.hs
+++ b/examples/todo-mvc/Main.hs
@@ -220,7 +220,7 @@ viewEntry Entry {..} = liKeyed_ (toKey eid)
         [ class_ "edit"
         , value_ description
         , name_ "title"
-        , id_ $ "todo-" <> S.pack (show eid)
+        , id_ $ "todo-" <> S.ms eid
         , onInput $ UpdateEntry eid
         , onBlur $ EditingEntry eid False
         , onEnter $ EditingEntry eid False
@@ -244,7 +244,7 @@ viewControls model visibility entries =
 viewControlsCount :: Int -> View Msg
 viewControlsCount entriesLeft =
   span_ [ class_ "todo-count" ]
-     [ strong_ [] [ text $ S.pack (show entriesLeft) ]
+     [ strong_ [] [ text $ S.ms entriesLeft ]
      , text (item_ <> " left")
      ]
   where
@@ -277,7 +277,7 @@ viewControlsClear _ entriesCompleted =
     , prop "hidden" (entriesCompleted == 0)
     , onClick DeleteComplete
     ]
-    [ text $ "Clear completed (" <> S.pack (show entriesCompleted) <> ")" ]
+    [ text $ "Clear completed (" <> S.ms entriesCompleted <> ")" ]
 
 viewInput :: Model -> MisoString -> View Msg
 viewInput _ task =

--- a/ghcjs-src/Miso/String.hs
+++ b/ghcjs-src/Miso/String.hs
@@ -25,12 +25,16 @@ import           Data.Aeson
 import qualified Data.ByteString         as B
 import qualified Data.ByteString.Lazy    as BL
 import           Data.JSString
+import           Data.JSString.Int
+import           Data.JSString.RealFloat
 import           Data.JSString.Text
 import           Data.Monoid
 import qualified Data.Text               as T
 import qualified Data.Text.Encoding      as T
 import qualified Data.Text.Lazy          as LT
 import qualified Data.Text.Lazy.Encoding as LT
+import           GHCJS.Marshal.Pure
+import           GHCJS.Types
 
 -- | String type swappable based on compiler
 type MisoString = JSString
@@ -72,3 +76,15 @@ instance ToMisoString B.ByteString where
 instance ToMisoString BL.ByteString where
   toMisoString = toMisoString . LT.decodeUtf8
   fromMisoString = LT.encodeUtf8 . fromMisoString
+instance ToMisoString Float where
+  toMisoString = realFloat
+  fromMisoString = pFromJSVal . toJSNumber
+instance ToMisoString Double where
+  toMisoString = realFloat
+  fromMisoString = pFromJSVal . toJSNumber
+instance ToMisoString Int where
+  toMisoString = decimal
+  fromMisoString = pFromJSVal . toJSNumber
+
+foreign import javascript unsafe "$r = Number($1);"
+  toJSNumber :: JSString -> JSVal

--- a/sample-app/Main.hs
+++ b/sample-app/Main.hs
@@ -44,6 +44,6 @@ updateModel SayHelloWorld m = m <# do
 viewModel :: Model -> View Action
 viewModel x = div_ [] [
    button_ [ onClick AddOne ] [ text "+" ]
- , text (ms (show x))
+ , text (ms x)
  , button_ [ onClick SubtractOne ] [ text "-" ]
  ]


### PR DESCRIPTION
Creates instances of `ToMisoString` for `Float`, `Double` and `Int`.  Also updates the examples to reflect the change.

Some notes:

- `sample-app/default.nix` will need to pin Miso to a commit on or after the one that merges this PR, otherwise it won't compile
- Same for the `README.md` (line 268)
- The `fromMisoString` function assumes the type of the js object and that it can be parsed as a number. It means the function is unsafe. Not *too* bad if the end user knows what they're doing.