### PR TITLE
Fix onInput regression on select elements + onChange

### DIFF
--- a/examples/file-reader/Main.hs
+++ b/examples/file-reader/Main.hs
@@ -65,7 +65,7 @@ viewModel Model {..} = view
         "FileReader API example"
       , input_ [ id_ "fileReader"
              , type_ "file"
-             , onChange ReadFile
+             , onChange (const ReadFile)
              ] []
       , div_ [] [ text info ]
       ]
@@ -90,6 +90,3 @@ foreign import javascript unsafe "$r = $1.result;"
 
 foreign import javascript unsafe "$1.readAsText($2);"
   readText :: JSVal -> JSVal -> IO ()
-
-onChange :: action -> Attribute action
-onChange r = on "change" emptyDecoder (const r)

--- a/jsbits/delegate.js
+++ b/jsbits/delegate.js
@@ -70,7 +70,8 @@ function propogateWhileAble (parentStack, event) {
   }
 }
 
-/* Convert event to JSON at a specific location in the DOM tree*/
+/* Walks down obj following the path described by `at`, then filters primitive
+ values (string, numbers and booleans)*/
 function objectToJSON (at, obj) {
   /* If at is of type [[MisoString]] */
   if (typeof at[0] == "object") {
@@ -83,7 +84,7 @@ function objectToJSON (at, obj) {
   for (var i in at) obj = obj[at[i]];
 
   /* If obj is a list-like object */
-  if ("length" in obj) {
+  if (obj instanceof Array) {
     var newObj = [];
     for (var i = 0; i < obj.length; i++)
       newObj.push(objectToJSON([], obj[i]));

--- a/src/Miso/Html/Event.hs
+++ b/src/Miso/Html/Event.hs
@@ -40,6 +40,7 @@ module Miso.Html.Event
   , onKeyUp
   -- * Form events
   , onInput
+  , onChange
   , onChecked
   , onSubmit
   -- * Focus events
@@ -86,6 +87,10 @@ onDoubleClick action = on "dblclick" emptyDecoder $ \() -> action
 -- | https://developer.mozilla.org/en-US/docs/Web/Events/input
 onInput :: (MisoString -> action) -> Attribute action
 onInput = on "input" valueDecoder
+
+-- | https://developer.mozilla.org/en-US/docs/Web/Events/change
+onChange :: (MisoString -> action) -> Attribute action
+onChange = on "change" valueDecoder
 
 -- | https://developer.mozilla.org/en-US/docs/Web/Events/keydown
 onKeyDown :: (KeyCode -> action) -> Attribute action


### PR DESCRIPTION
## Reproducing
Take the following program:
```haskell
{-# LANGUAGE OverloadedStrings #-}

module Main where

import Miso ( App(..), Transition )
import qualified Miso
import Miso.Html
import qualified Miso.String as Miso

data Model
   = Model
     deriving ( Eq )

data Action
  = ComboBoxEnter !Miso.MisoString
  | NoOp
  deriving (Show, Eq)

main :: IO ()
main =
    Miso.startApp App
      { initialAction = NoOp
      , model         = Model
      , update        = Miso.fromTransition . updateModel
      , view          = viewModel
      , events        = Miso.defaultEvents
      , subs          = []
      , mountPoint    = Nothing
      }

updateModel :: Action -> Transition Action Model ()
updateModel action = case action of
    NoOp -> pure ()
    ComboBoxEnter _str -> pure ()

viewModel :: Model -> View Action
viewModel _m =
    select_ [ onInput ComboBoxEnter ]
    [ option_ [] [ text "foo" ]
    , option_ [] [ text "bar" ]
    ]
```

Run it on a commit right before this PR. Select a value in the `select` box. Observe the following error in console:
```
rts.js:7319 Parse error on input: Error in $: expected target, encountered Array
CallStack (from HasCallStack):
  error, called at ghcjs-src/Miso/Html/Internal.hs:261:20 in miso-0.12.0.0-392GBJa4qbZ1SDKwTbEyhw:Miso.Html.Internal
```

## Cause
See `objectToJSON` in `delegate.js`. That function walks down obj following the path described by `at`, then filters primitive values. On line 87 it checks whether the object, after walking down, contains a field called `length`. The object representing the `<select>` element does indeed have a `length` field, containing the amount of options it has. As such the if-statement's body is run even though it shouldn't be. 

## Solution
Check whether the object is `instanceof Array` instead of checking whether it has a field called `length`. Arrays will pass through the if-statement, select elements will not. 