### PR TITLE
Lifecycle events

### DIFF
--- a/ghc-src/Miso/Html/Internal.hs
+++ b/ghc-src/Miso/Html/Internal.hs
@@ -40,6 +40,9 @@ module Miso.Html.Internal (
   -- * Handling events
   , on
   , onWithOptions
+  -- * Life cycle events
+  , onCreated
+  , onDestroyed
   ) where
 
 import           Data.Aeson (Value(..), ToJSON(..))
@@ -219,6 +222,17 @@ onWithOptions
    -> (r -> action)
    -> Attribute action
 onWithOptions _ _ _ _ = E ()
+
+-- | @onCreated action@ is an event that gets called after the actual DOM
+-- element is created.
+onCreated :: action -> Attribute action
+onCreated _ = E ()
+
+-- | @onDestroyed action@ is an event that gets called after the DOM element
+-- is removed from the DOM. The @action@ is given the DOM element that was
+-- removed from the DOM tree.
+onDestroyed :: action -> Attribute action
+onDestroyed _ = E ()
 
 -- | Constructs CSS for a DOM Element
 --

--- a/jsbits/isomorphic.js
+++ b/jsbits/isomorphic.js
@@ -5,6 +5,10 @@ function copyDOMIntoVTree (vtree) {
 function walk (vtree, node) {
     var i = 0, vdomChild, domChild;
     vtree.domRef = node;
+
+    // Fire onCreated events as though the elements had just been created.
+    callCreated(vtree);
+
     while (i < vtree.children.length) {
       vdomChild = vtree.children[i];
       domChild = node.childNodes[i];


### PR DESCRIPTION
Alright, I'm really enthusiastic about this. This PR enables this example:

https://fptje.github.io/miso-jswidget-example/

(Repository here: https://github.com/FPtje/miso-jswidget-example)

That's a [flatpickr](https://flatpickr.js.org/) widget, acting like it's been written in Miso instead of Javascript. You can click on the dates in the calendar, and the rest of the Miso app will update. You can click the Miso buttons and the widget will update. And there's a `toggle calendar visibility` button to prove that it plays nicely with Miso's diffing algorithm.

This kind of stuff was technically *possible* before, but with this PR, we can be **good** at it. This could be a *huge* selling point! It opens Miso up to a whole world of widgets that have already been made by other people. I'm imagining people making libraries that just bring Javascript widgets into the Miso world. You'd be able to use them without worrying about JS interop.

See #222.

# Current status:
**Don't merge yet!**
- Isomorphism works! (see [here](https://github.com/FPtje/miso-isomorphic-example/tree/test-feat-lifecycles))
- I'd like some feedback on (amongst others) the approach. Is this a good way to implement this feature?
- Before merging I reckon the commits need to be squashed. For now the commits show how this PR progressed over time.
