### PR TITLE
delegate.js speedup effort

### DIFF
--- a/jsbits/delegate.js
+++ b/jsbits/delegate.js
@@ -1,57 +1,77 @@
+"use strict"; // Both performance and bug improvements, OK: https://caniuse.com/#search=strict%20mode
+
+/**
+ * CODE STYLE NOTES
+ * ===============
+ *
+ * const is preferred b/c it's safer, optimizable, widely supported: https://caniuse.com/#search=const
+ * [].forEach/filter/map is OK (it's part of ES5): https://caniuse.com/#search=ECMAScript%205%20Strict%20Mode
+ */
+
+
+
 /* event delegation algorithm */
 function delegate(mountPointElement, events, getVTree) {
-    for (var event in events) {
-	mountPointElement.addEventListener(events[event][0], function(e) {
-            delegateEvent ( e
-                          , getVTree()
-                          , buildTargetToElement(mountPointElement, e.target)
-                          , []
-                          );
-	     }, events[event][1]);
-    }
+  const vtree = getVTree(); // This *is* a constant relative to all the events, correct?
+  events.forEach(function(event) {
+    mountPointElement.addEventListener(events[event][0], function(e) {
+      // NB: Sorely tempted to do a window.setTimeout here as an ad hoc trampoline.
+      // We should check performance of this implementation vs. that one. If the difference is trivial,
+      // it's worth trampolining to clear the stack, let other things run, etc., etc.
+      // If we do this, buildTargetToElement, events[event][0], events[event][1] should all
+      // be called and assigned to const values *before* trampolining.
+      delegateEvent ( e
+                    , vtree
+                    , buildTargetToElement(mountPointElement, e.target)
+                    , []
+                    );
+    }, events[event][1]);
+  });
 }
 
 /* Accumulate parent stack as well for propagation */
 function delegateEvent (event, obj, stack, parentStack) {
+    const stackLength = stack && stack.length;
 
-    /* base case, not found */
-    if (!stack.length) return;
-
-    /* stack not length 1, recurse */
-    else if (stack.length > 1) {
-      if (obj.domRef === stack[0]) parentStack.unshift(obj);
-	for (var o = 0; o < obj.children.length; o++) {
-          if (obj.children[o].type === "vtext") continue;
-          delegateEvent ( event
-                        , obj.children[o]
-                        , stack.slice(1)
-                        , parentStack
-			                  );
-       }
-    }
-
-    /* stack.length == 1 */
-    else {
-	if (obj.domRef === stack[0]) {
-	    var eventObj = obj.events[event.type];
-	    if (eventObj) {
-		var options = eventObj.options;
-		if (options.preventDefault)
-		    event.preventDefault();
-		eventObj.runEvent(event);
-		if (!options.stopPropagation)
-		    propogateWhileAble (parentStack, event);
-	    } else {
-		 /* still propagate to parent handlers even if event not defined */
- 		 propogateWhileAble (parentStack, event);
-	      }
-	}
+    if (!stackLength) { /* subbase case, not found */
+      return;
+    } else if (stackLength > 1) { /* stack not length 1, recurse */
+      if (obj.domRef === stack[0]) parentStack.unshift(obj); // Do we mean for this to change things globally?
+      const stackSlice = stack.slice(1);
+      obj.children.filter(function(child) {
+        return (child.type /= "vtext");
+      }).forEach(function(child) {
+        // We could potentially trampoline here, as well. The other spot is better, and runs less risk of
+        // mucking up expected intuitive execution order.
+        delegateEvent(event, child, stackSlice, parentStack);
+      });
+    } else if(stackLength == 1) { /* stack.length == 1, base case */
+        if (obj.domRef === stack[0]) {
+            const eventObj = obj.events[event.type];
+            if (eventObj) {
+                const options = eventObj.options;
+                if (options.preventDefault) {
+                  event.preventDefault();
+                }
+                eventObj.runEvent(event);
+                if (!options.stopPropagation) {
+                  propogateWhileAble (parentStack, event);
+                }
+            } else {
+               /* still propagate to parent handlers even if event not defined */
+               propogateWhileAble (parentStack, event);
+            }
+        } else {
+          // What does this case mean? Do we really want to silently ignore it?
+        }
+    } else {
+      throw new Error("unexpected stack.length: " + stackLength);
     }
 }
 
 function buildTargetToElement (element, target) {
-    var stack = [];
-    while (element !== target) {
+    const stack = [];
+    while (target && element !== target) {
       stack.unshift (target);
       target = target.parentNode;
     }
@@ -59,13 +79,16 @@ function buildTargetToElement (element, target) {
 }
 
 function propogateWhileAble (parentStack, event) {
-  for (var i = 0; i < parentStack.length; i++) {
-    if (parentStack[i].events[event.type]) {
-      var eventObj = parentStack[i].events[event.type],
-          options = eventObj.options;
-        if (options.preventDefault) event.preventDefault();
-        eventObj.runEvent(event);
-  	if (options.stopPropagation) break;
+  const eventType = event.type;
+  // ES5 doesn't have fold. :(
+  for (var i = 0; i < parentStack.length; i++) { // const is dodgy in this position
+    const parentFrame = parentStack[i];
+    if (parentFrame.events[eventType]) {
+      const eventObj = parentFrame.events[eventType];
+      const options = eventObj.options;
+      if (options.preventDefault) event.preventDefault();
+      eventObj.runEvent(event);
+      if (options.stopPropagation) break; // Have to use a loop b/c of this logic
     }
   }
 }
@@ -75,26 +98,38 @@ function propogateWhileAble (parentStack, event) {
 function objectToJSON (at, obj) {
   /* If at is of type [[MisoString]] */
   if (typeof at[0] == "object") {
-    var ret = [];
-    for (var i = 0; i < at.length; i++)
+    const ret = [];
+    for(var i = 0; i < at.length; i++) {
       ret.push(objectToJSON(at[i], obj));
-    return (ret);
+    }
+    return ret;
   }
 
+  // What is this doing???
   for (var i in at) obj = obj[at[i]];
 
   /* If obj is a list-like object */
-  if (obj instanceof Array) {
-    var newObj = [];
-    for (var i = 0; i < obj.length; i++)
-      newObj.push(objectToJSON([], obj[i]));
+  if (obj.forEach) {
+    const newObj = [];
+    obj.forEach(function(it) {
+      newObj.push(objectToJSON([], it));
+    });
     return (newObj);
   }
 
   /* If obj is a non-list-like object */
-  var newObj = {};
-  for (var i in obj)
-    if (typeof obj[i] == "string" || typeof obj[i] == "number" || typeof obj[i] == "boolean")
-      newObj[i] = obj[i];
+  const newObj = {};
+  for (var i in obj) {
+    const objI = obj[i];
+    switch(typeof objI) {
+      case "string":
+      case "number":
+      case "boolean":
+        newObj[i] = objI;
+        break;
+      default:
+        // Do nothing
+    }
+  }
   return (newObj);
 }

--- a/jsbits/delegate.js
+++ b/jsbits/delegate.js
@@ -13,7 +13,7 @@
 /* event delegation algorithm */
 function delegate(mountPointElement, events, getVTree) {
   const vtree = getVTree(); // This *is* a constant relative to all the events, correct?
-  events.forEach(function(event) {
+  for(var event in events) {
     mountPointElement.addEventListener(events[event][0], function(e) {
       // NB: Sorely tempted to do a window.setTimeout here as an ad hoc trampoline.
       // We should check performance of this implementation vs. that one. If the difference is trivial,
@@ -26,7 +26,7 @@ function delegate(mountPointElement, events, getVTree) {
                     , []
                     );
     }, events[event][1]);
-  });
+  }
 }
 
 /* Accumulate parent stack as well for propagation */

--- a/jsbits/delegate.js
+++ b/jsbits/delegate.js
@@ -109,12 +109,10 @@ function objectToJSON (at, obj) {
   for (var i in at) obj = obj[at[i]];
 
   /* If obj is a list-like object */
-  if (obj.forEach) {
-    const newObj = [];
-    obj.forEach(function(it) {
-      newObj.push(objectToJSON([], it));
+  if (obj instanceof Array) {
+    return obj.map(function(it) {
+      return objectToJSON([], it);
     });
-    return (newObj);
   }
 
   /* If obj is a non-list-like object */


### PR DESCRIPTION
Piggybacking off of https://github.com/dmjio/miso/pull/298 -- took a swing at implementing a more efficient `delegate.js`.

I stayed close to the algorithm currently used by `master`, which seemed mostly reasonable. The specific improvements were around the use of strict mode, `const` vs. `var`, `Array.prototype.forEach` instead of loops, and generally being pretty aggressive about factoring out common variables.

I'm unclear what the testing protocol is to test correctness and performance.