### PR TITLE
Moved withFoldable and conditionalViews

### DIFF
--- a/ghc-src/Miso.hs
+++ b/ghc-src/Miso.hs
@@ -17,9 +17,11 @@ module Miso
   , module Miso.Html
   , module Miso.Router
   , module Miso.TypeLevel
+  , module Miso.Util
   ) where
 
 import           Miso.Event
 import           Miso.Html
 import           Miso.Router
 import           Miso.TypeLevel
+import           Miso.Util

--- a/ghcjs-src/Miso.hs
+++ b/ghcjs-src/Miso.hs
@@ -23,6 +23,7 @@ module Miso
   , module Miso.Types
   , module Miso.Router
   , module Miso.Util
+  , module Miso.FFI
   ) where
 
 import           Control.Concurrent
@@ -31,6 +32,7 @@ import           Data.IORef
 import           Data.List
 import           Data.Sequence                 ((|>))
 import qualified Data.Sequence                 as S
+import           GHCJS.Types (JSVal)
 import qualified JavaScript.Object.Internal    as OI
 import           JavaScript.Web.AnimationFrame
 
@@ -131,3 +133,8 @@ foldEffects sink update = \(Acc model as) action ->
             void $ forkIO (eff sink)
 
 data Acc model = Acc !model !(IO ())
+
+-- | Copies DOM pointers into virtual dom
+-- entry point into isomorphic javascript
+foreign import javascript unsafe "copyDOMIntoVTree($1);"
+  copyDOMIntoVTree :: JSVal -> IO ()

--- a/ghcjs-src/Miso/Delegate.hs
+++ b/ghcjs-src/Miso/Delegate.hs
@@ -13,7 +13,6 @@ import           Data.IORef
 import qualified Data.Map                 as M
 import           Miso.Html.Internal
 import           Miso.String
-import           Miso.FFI
 import qualified JavaScript.Object.Internal as OI
 import           GHCJS.Foreign.Callback
 import           GHCJS.Marshal
@@ -32,3 +31,11 @@ delegator mountPointElement vtreeRef es = do
     pure val
   delegateEvent mountPointElement evts getVTreeFromRef
 
+-- | Event delegation FFI, routes events received on body through the virtual dom
+-- Invokes event handler when found
+foreign import javascript unsafe "delegate($1, $2, $3);"
+  delegateEvent
+     :: JSVal               -- ^ mountPoint element
+     -> JSVal               -- ^ Events
+     -> Callback (IO JSVal) -- ^ Virtual DOM callback
+     -> IO ()

--- a/ghcjs-src/Miso/FFI.hs
+++ b/ghcjs-src/Miso/FFI.hs
@@ -20,10 +20,8 @@ module Miso.FFI
    , consoleLog
    , stringify
    , parse
-   , copyDOMIntoVTree
    , item
    , jsvalToValue
-   , delegateEvent
    , clearBody
    ) where
 
@@ -122,20 +120,6 @@ parse jval = do
 -- | Indexing into a JS object
 foreign import javascript unsafe "$r = $1[$2];"
   item :: JSVal -> JSString -> IO JSVal
-
--- | Copies DOM pointers into virtual dom
--- entry point into isomorphic javascript
-foreign import javascript unsafe "copyDOMIntoVTree($1);"
-  copyDOMIntoVTree :: JSVal -> IO ()
-
--- | Event delegation FFI, routes events received on body through the virtual dom
--- Invokes event handler when found
-foreign import javascript unsafe "delegate($1, $2, $3);"
-  delegateEvent
-     :: JSVal               -- ^ mountPoint element
-     -> JSVal               -- ^ Events
-     -> Callback (IO JSVal) -- ^ Virtual DOM callback
-     -> IO ()
 
 -- | Clear the document body. This is particularly useful to avoid
 -- creating multiple copies of your app when running in GHCJSi.

--- a/miso.cabal
+++ b/miso.cabal
@@ -250,6 +250,7 @@ library
     Haskell2010
   exposed-modules:
     Miso
+    Miso.Util
     Miso.Html
     Miso.Html.Element
     Miso.Html.Event
@@ -311,7 +312,6 @@ library
       Miso.Subscription.Window
       Miso.Subscription.SSE
       Miso.Types
-      Miso.Util
     other-modules:
       Miso.Diff
       Miso.FFI

--- a/src/Miso/Util.hs
+++ b/src/Miso/Util.hs
@@ -8,20 +8,12 @@
 -- Portability :  non-portable
 ----------------------------------------------------------------------------
 module Miso.Util
-  ( now
-  , consoleLog
-  , jsvalToValue
-  , windowAddEventListener
-  , stringify
-  , parse
-
-  , withFoldable
+  ( withFoldable
   , conditionalViews
   ) where
 
-import Miso.FFI
-import Miso.Html.Internal
 import Data.Foldable
+import Miso.Html (View)
 
 -- | Generic @map@ function, useful for creating @View@s from the elements of
 -- some @Foldable@. Particularly handy for @Maybe@, as shown in the example


### PR DESCRIPTION
I made the mistake in #355 to leave out the ghc side of Miso in the helper functions. I've moved them over to a new module `Miso.Helpers`, which is shared by both `ghc` and `ghcjs`. 

Since `Miso.Util` still exports the functions, it's backwards compatible.

Tests: I compiled and ran my isomorphic example, with one of the helpers shoehorned in somewhere to make sure that it works on both ghc and ghcjs.