### PR TITLE
Allow scheduled IO computations access to a sink

### DIFF
--- a/ghcjs-src/Miso.hs
+++ b/ghcjs-src/Miso.hs
@@ -51,7 +51,7 @@ common
   :: Eq model
   => App model action
   -> model
-  -> ((action -> IO ()) -> IO (IORef VTree))
+  -> (Sink action -> IO (IORef VTree))
   -> IO b
 common App {..} m getView = do
   -- init Notifier
@@ -123,7 +123,7 @@ startApp app@App {..} =
 
 -- | Helper
 foldEffects
-  :: (action -> IO ())
+  :: Sink action
   -> (action -> model -> Effect action model)
   -> (model, IO ()) -> action -> (model, IO ())
 foldEffects sink update = \(!model, !as) action ->
@@ -132,4 +132,4 @@ foldEffects sink update = \(!model, !as) action ->
       where
         newAs = as >> do
           forM_ effs $ \eff ->
-            void $ forkIO (sink =<< eff)
+            void $ forkIO (eff sink)

--- a/ghcjs-src/Miso/Html/Internal.hs
+++ b/ghcjs-src/Miso/Html/Internal.hs
@@ -71,15 +71,16 @@ import           Servant.API
 import           Miso.Event.Decoder
 import           Miso.Event.Types
 import           Miso.String
+import           Miso.Effect (Sink)
 import           Miso.FFI
 
 -- | Type synonym for constructing event subscriptions.
 --
 -- The first argument passed to a subscription provides a way to
--- access the current value of the model (without blocking). The
+-- access the current value of the model (without blocking). The 'Sink'
 -- callback is used to dispatch actions which are then fed back to the
 -- @update@ function.
-type Sub action model = IO model -> (action -> IO ()) -> IO ()
+type Sub action model = IO model -> Sink action -> IO ()
 
 -- | Virtual DOM implemented as a JavaScript `Object`.
 --   Used for diffing, patching and event delegation.
@@ -88,7 +89,7 @@ newtype VTree = VTree { getTree :: Object }
 
 -- | Core type for constructing a `VTree`, use this instead of `VTree` directly.
 newtype View action = View {
-  runView :: (action -> IO ()) -> IO VTree
+  runView :: Sink action -> IO VTree
 } deriving Functor
 
 -- | For constructing type-safe links
@@ -201,11 +202,11 @@ instance ToKey Word where toKey = Key . toMisoString
 
 -- | Attribute of a vnode in a `View`.
 --
--- The callback can be used to dispatch actions which are fed back to
+-- The 'Sink' callback can be used to dispatch actions which are fed back to
 -- the @update@ function. This is especially useful for event handlers
 -- like the @onclick@ attribute. The second argument represents the
 -- vnode the attribute is attached to.
-newtype Attribute action = Attribute ((action -> IO ()) -> Object -> IO ())
+newtype Attribute action = Attribute (Sink action -> Object -> IO ())
 
 -- | @prop k v@ is an attribute that will set the attribute @k@ of the DOM node associated with the vnode
 -- to @v@.


### PR DESCRIPTION
As mentioned in https://github.com/dmjio/miso/pull/362#issuecomment-369561451 this slight generalization of `Effect` gives users the power to dispatch actions to the `update` function at their own discretion.

The most pressing use-case is scheduling an IO computation which creates a 3rd-party JS widget which has an associated callback. The callback can then call the sink to turn events into actions. To do this
without accessing a sink requires going via a subscription which introduces a leaky-abstraction. [Here's an example](https://github.com/basvandijk/miso-jswidget-example/commit/421b63f12fd9c14e5fc0ed588b265e4b08ae9b79).

Speaking of subscriptions, this generalization of `Effect` can actually supersede subscriptions. For example we can replace:

```haskell
mouseSub :: ((Int,Int) -> action) -> Sub action model
mouseSub f _ = \sink -> do
  windowAddEventListener "mousemove" =<< do
    asyncCallback1 $ \mouseEvent -> do
      Just x <- fromJSVal =<< getProp "clientX" (Object mouseEvent)
      Just y <- fromJSVal =<< getProp "clientY" (Object mouseEvent)
      sink $ f (x,y)
```

with:

```haskell
mouseSub :: ((Int,Int) -> action) -> Transition action model ()
mouseSub f = scheduleIOWithSink $ \sink -> do
  windowAddEventListener "mousemove" =<< do
    asyncCallback1 $ \mouseEvent -> do
      Just x <- fromJSVal =<< getProp "clientX" (Object mouseEvent)
      Just y <- fromJSVal =<< getProp "clientY" (Object mouseEvent)
      sink $ f (x,y)
```

But lets leave deprecating subscriptions for another day...

Credit to @FPtje for coming up with this generalization.