### PR TITLE
 Remove the 'IO model' argument of Sub 

### DIFF
--- a/ghcjs-src/Miso/Html/Internal.hs
+++ b/ghcjs-src/Miso/Html/Internal.hs
@@ -69,22 +69,14 @@ import           GHCJS.Types
 import           JavaScript.Object
 import           JavaScript.Object.Internal (Object (Object))
 import qualified JavaScript.Array as JSArray
-import           JavaScript.Array.Internal (SomeJSArray(..))
 import           Servant.API
 
+import           Miso.Effect (Sub)
 import           Miso.Event.Decoder
 import           Miso.Event.Types
 import           Miso.String
 import           Miso.Effect (Sink)
 import           Miso.FFI
-
--- | Type synonym for constructing event subscriptions.
---
--- The first argument passed to a subscription provides a way to
--- access the current value of the model (without blocking). The 'Sink'
--- callback is used to dispatch actions which are then fed back to the
--- @update@ function.
-type Sub action model = IO model -> Sink action -> IO ()
 
 -- | Virtual DOM implemented as a JavaScript `Object`.
 --   Used for diffing, patching and event delegation.

--- a/ghcjs-src/Miso/Subscription/History.hs
+++ b/ghcjs-src/Miso/Subscription/History.hs
@@ -83,8 +83,8 @@ chan :: Notify
 chan = unsafePerformIO newNotify
 
 -- | Subscription for `popState` events, from the History API
-uriSub :: (URI -> action) -> Sub action model
-uriSub = \f _ sink -> do
+uriSub :: (URI -> action) -> Sub action
+uriSub = \f sink -> do
   void.forkIO.forever $ do
     wait chan >> do
       sink =<< f <$> getURI

--- a/ghcjs-src/Miso/Subscription/Keyboard.hs
+++ b/ghcjs-src/Miso/Subscription/Keyboard.hs
@@ -62,22 +62,22 @@ toArrows (up, down, left, right) set =
     check = any (`S.member` set)
 
 -- | Maps `Arrows` onto a Keyboard subscription
-arrowsSub :: (Arrows -> action) -> Sub action model
+arrowsSub :: (Arrows -> action) -> Sub action
 arrowsSub = directionSub ([38], [40], [37], [39])
 
 -- | Maps `WASD` onto a Keyboard subscription for directions
-wasdSub :: (Arrows -> action) -> Sub action model
+wasdSub :: (Arrows -> action) -> Sub action
 wasdSub = directionSub ([87], [83], [65], [68])
 
 -- | Maps a specified list of keys to directions (up, down, left, right)
 directionSub :: ([Int], [Int], [Int], [Int])
              -> (Arrows -> action)
-             -> Sub action model
+             -> Sub action
 directionSub dirs = keyboardSub . (. toArrows dirs)
 
 -- | Returns subscription for Keyboard
-keyboardSub :: (Set Int -> action) -> Sub action model
-keyboardSub f _ sink = do
+keyboardSub :: (Set Int -> action) -> Sub action
+keyboardSub f sink = do
   keySetRef <- newIORef mempty
   windowAddEventListener "keyup" =<< keyUpCallback keySetRef
   windowAddEventListener "keydown" =<< keyDownCallback keySetRef
@@ -97,4 +97,3 @@ keyboardSub f _ sink = do
              let !new = S.delete key keys
              in (new, new)
           sink (f newKeys)
-

--- a/ghcjs-src/Miso/Subscription/Mouse.hs
+++ b/ghcjs-src/Miso/Subscription/Mouse.hs
@@ -21,11 +21,10 @@ import Miso.Html.Internal ( Sub )
 
 -- | Captures mouse coordinates as they occur and writes them to
 -- an event sink
-mouseSub :: ((Int,Int) -> action) -> Sub action model
-mouseSub f _ = \sink -> do
+mouseSub :: ((Int,Int) -> action) -> Sub action
+mouseSub f = \sink -> do
   windowAddEventListener "mousemove" =<< do
     asyncCallback1 $ \mouseEvent -> do
       Just x <- fromJSVal =<< getProp "clientX" (Object mouseEvent)
       Just y <- fromJSVal =<< getProp "clientY" (Object mouseEvent)
       sink $ f (x,y)
-

--- a/ghcjs-src/Miso/Subscription/SSE.hs
+++ b/ghcjs-src/Miso/Subscription/SSE.hs
@@ -25,8 +25,8 @@ import Miso.Html.Internal     ( Sub )
 import Miso.String
 
 -- | Server-sent events Subscription
-sseSub :: FromJSON msg => MisoString -> (SSE msg -> action) -> Sub action model
-sseSub url f _ = \sink -> do
+sseSub :: FromJSON msg => MisoString -> (SSE msg -> action) -> Sub action
+sseSub url f = \sink -> do
   es <- newEventSource url
   onMessage es =<< do
     asyncCallback1 $ \val -> do
@@ -66,4 +66,3 @@ foreign import javascript unsafe "$1.onclose = $2;"
 -- | Test URL
 -- http://sapid.sourceforge.net/ssetest/webkit.events.php
 -- var source = new EventSource("demo_sse.php");
-

--- a/ghcjs-src/Miso/Subscription/WebSocket.hs
+++ b/ghcjs-src/Miso/Subscription/WebSocket.hs
@@ -70,8 +70,8 @@ websocketSub
   => URL
   -> Protocols
   -> (WebSocket m -> action)
-  -> Sub action model
-websocketSub (URL u) (Protocols ps) f getModel sink = do
+  -> Sub action
+websocketSub (URL u) (Protocols ps) f sink = do
   socket <- createWebSocket u ps
   writeIORef websocket (Just socket)
   void . forkIO $ handleReconnect
@@ -103,7 +103,7 @@ websocketSub (URL u) (Protocols ps) f getModel sink = do
       if status == 3
         then do
           unless (code == Just CLOSE_NORMAL) $
-            websocketSub (URL u) (Protocols ps) f getModel sink
+            websocketSub (URL u) (Protocols ps) f sink
         else handleReconnect
 
 -- | Sends message to a websocket server

--- a/ghcjs-src/Miso/Subscription/Window.hs
+++ b/ghcjs-src/Miso/Subscription/Window.hs
@@ -21,8 +21,8 @@ import Miso.Html.Internal ( Sub )
 
 -- | Captures window coordinates changes as they occur and writes them to
 -- an event sink
-windowSub :: ((Int, Int) -> action) -> Sub action model
-windowSub f _ = \sink -> do
+windowSub :: ((Int, Int) -> action) -> Sub action
+windowSub f = \sink -> do
   sink . f =<< (,) <$> windowInnerHeight <*> windowInnerWidth
   windowAddEventListener "resize" =<< do
     asyncCallback1 $ \windowEvent -> do
@@ -30,4 +30,3 @@ windowSub f _ = \sink -> do
       Just w <- fromJSVal =<< getProp "innerWidth" (Object target)
       Just h <- fromJSVal =<< getProp "innerHeight" (Object target)
       sink $ f (h, w)
-


### PR DESCRIPTION
Here's a more radical idea: let's get rid of the `getModel :: IO model` action from `Sub`.

We don't have any subscriptions nor examples which use the `getModel` action so I think it's better to remove it until we have a clear use-case.

This simplification allows `Subs` to be scheduled from the `update` function using `scheduleSub` or `effectSub`.