### PR TITLE
Register event related callbacks and clear them right before diffing

### DIFF
--- a/ghcjs-src/Miso.hs
+++ b/ghcjs-src/Miso.hs
@@ -91,6 +91,7 @@ common App {..} m getView = do
           oldVTree <- readIORef viewRef
           void $ waitForAnimationFrame
           (diff mountPoint) (Just oldVTree) (Just newVTree)
+          clearCallbacks
           atomicWriteIORef viewRef newVTree
         loop newModel
   loop m
@@ -137,3 +138,7 @@ data Acc model = Acc !model !(IO ())
 -- entry point into isomorphic javascript
 foreign import javascript unsafe "copyDOMIntoVTree($1);"
   copyDOMIntoVTree :: JSVal -> IO ()
+
+-- | Clears callbacks registered by the virtual DOM.
+foreign import javascript unsafe "clearCallbacks();"
+  clearCallbacks :: IO ()

--- a/jsbits/delegate.js
+++ b/jsbits/delegate.js
@@ -1,3 +1,20 @@
+var registeredCallbacks = [];
+
+/* Callbacks in ghcjs need to be released. With this function one can register
+   callbacks that should be released right before diffing.
+*/
+function registerCallback(cb) {
+    registeredCallbacks.push(cb);
+}
+
+/* This clears the callbacks. */
+function clearCallbacks() {
+    for (var i in registeredCallbacks)
+      h$release(registeredCallbacks[i]);
+
+    registeredCallbacks = [];
+}
+
 /* event delegation algorithm */
 function delegate(mountPointElement, events, getVTree) {
     for (var event in events) {


### PR DESCRIPTION
Fixes #363 

This is a really simple solution. When you create an event related callback, put it in the list. Right before diffing everything in the list is released. They're safe to release, since the view function recreates them.

Tested with my components example and the jswidgets example.