### PR TITLE
Upgrade Miso to make the example compilable

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ compiler-check: match-exact
 packages:
  - '.'
 extra-deps:
- - miso-0.12.0.0
+ - miso-0.18.0.0
 
 setup-info:
   ghcjs:


### PR DESCRIPTION
In `miso-0.12.0.0`, `Int` is not an instance of `ToMisoString`, thus the example app is not compilable as:

```
    No instance for (ToMisoString Model) arising from a use of ‘ms’
    In the first argument of ‘text’, namely ‘(ms x)’
    In the expression: text (ms x)     
    In the second argument of ‘div_’, namely
      ‘[button_ [onClick AddOne] [text "+"], text (ms x),
        button_ [onClick SubtractOne] [text "-"]]’
```