### PR TITLE
Add note to copy Sample Application to Nix section of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,8 @@ in pkgs.haskell.packages.ghcjs.callPackage ./app.nix {
 }
 ```
 
+Add the source from [Sample Application](#sample-application) to `app/Main.hs`
+
 Build the project
 ```
 nix-build


### PR DESCRIPTION
I ran across a build error when trying the Nix instructions because my Main.hs was empty. Adding a reminder for new users to copy the Sample Application.