### PR TITLE
Add CPP for new MkLink

### DIFF
--- a/ghc-src/Miso/Html/Internal.hs
+++ b/ghc-src/Miso/Html/Internal.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP                  #-}
 {-# LANGUAGE DeriveFunctor        #-}
 {-# LANGUAGE KindSignatures       #-}
 {-# LANGUAGE DataKinds            #-}
@@ -123,8 +124,14 @@ newtype View action = View { runView :: VTree action }
 
 -- | For constructing type-safe links
 instance HasLink (View a) where
+#if MIN_VERSION_servant(0,14,0)
+  type MkLink (View a) b = MkLink (Get '[] ()) b
+  toLink Proxy toA = toLink toA (Proxy :: Proxy (Get '[] ()))
+#else
   type MkLink (View a) = MkLink (Get '[] ())
-  toLink _ = toLink (Proxy :: Proxy (Get '[] ()))
+  toLink Proxy = toLink (Proxy :: Proxy (Get '[] ()))
+#endif
+
 
 -- | Convenience class for using View
 class ToView v where toView :: v -> View action

--- a/ghcjs-src/Miso/Html/Internal.hs
+++ b/ghcjs-src/Miso/Html/Internal.hs
@@ -90,8 +90,13 @@ newtype View action = View {
 
 -- | For constructing type-safe links
 instance HasLink (View a) where
+#if MIN_VERSION_servant(0,14,0)
+  type MkLink (View a) b = MkLink (Get '[] ()) b
+  toLink toA Proxy = toLink toA (Proxy :: Proxy (Get '[] ()))
+#else
   type MkLink (View a) = MkLink (Get '[] ())
   toLink _ = toLink (Proxy :: Proxy (Get '[] ()))
+#endif
 
 -- | Convenience class for using View
 class ToView v where toView :: v -> View m


### PR DESCRIPTION
cc @cocreature @danburton

Appears the latest `servant` introduced a breaking change on the `HasLink` typeclass definition. Per @DanBurton's issue #426, adding an additional type variable, and parameter to `toLink`, appears to have fixed the issue. This patch should fix the stack build in https://github.com/commercialhaskell/stackage/issues/3750 as well.