### PR TITLE
Safari checkbox selection bug fix

### DIFF
--- a/jsbits/delegate.js
+++ b/jsbits/delegate.js
@@ -121,8 +121,14 @@ window.objectToJSON = function objectToJSON (at, obj) {
 
   /* If obj is a non-list-like object */
   var newObj = {};
-  for (var i in obj)
+    for (var i in obj){
+    /* bug in safari, throws TypeError if the following fields are referenced on a checkbox */
+    /* https://stackoverflow.com/a/25569117/453261 */
+    /* https://html.spec.whatwg.org/multipage/input.html#do-not-apply */
+    if (obj['type'] == "checkbox" && (i === "selectionDirection" || i === "selectionStart" || i === "selectionEnd"))
+      continue;
     if (typeof obj[i] == "string" || typeof obj[i] == "number" || typeof obj[i] == "boolean")
       newObj[i] = obj[i];
-  return (newObj);
+    }
+    return newObj;
 };


### PR DESCRIPTION
For inputs of type checkbox, selections do not apply and should return
null. Safari throws a type error. This code checks for that condition
to ensure an error is not thrown. cc @tysonzero 