### PR TITLE
Isomorphism: Fix consecutive text nodes causing an error

### DIFF
--- a/jsbits/isomorphic.js
+++ b/jsbits/isomorphic.js
@@ -1,9 +1,9 @@
-function MisoException(message) {
+window.MisoException = function MisoException(message) {
   this.message = message;
   this.name = 'MisoException';
 }
 
-function copyDOMIntoVTree(vtree) {
+window.copyDOMIntoVTree = function copyDOMIntoVTree(vtree, document = document) {
   walk(vtree, document.body.firstChild);
 }
 

--- a/jsbits/isomorphic.js
+++ b/jsbits/isomorphic.js
@@ -3,54 +3,56 @@ window.MisoException = function MisoException(message) {
   this.name = 'MisoException';
 }
 
-window.copyDOMIntoVTree = function copyDOMIntoVTree(vtree, document = document) {
-  walk(vtree, document.body.firstChild);
+window.copyDOMIntoVTree = function copyDOMIntoVTree(vtree, document = window.document) {
+  walk(vtree, document.body.firstChild, document);
 }
 
-function walk(vtree, node) {
+window.walk = function walk(vtree, node, document) {
   // This is slightly more complicated than one might expect since
   // browsers will collapse consecutive text nodes into a single text node.
   // There can thus be fewer DOM nodes than VDOM nodes.
-  var i = 0,
-    j = 0,
-    // This indicates if we are in a block of consecutive text nodes.
-    inTextBlock = false,
-    vdomChild,
-    domChild;
+  var vdomChild,
+      domChild;
+
   vtree.domRef = node;
 
   // Fire onCreated events as though the elements had just been created.
   callCreated(vtree);
 
-  for (i = 0; i < vtree.children.length; i++) {
+  for (var i = 0; i < vtree.children.length; i++) {
     vdomChild = vtree.children[i];
-    domChild = node.childNodes[j];
+    domChild = node.childNodes[i];
     if (vdomChild.type === "vtext") {
-      if (!inTextBlock) {
-        // This is the first text node in a block of consecutive text nodes.
-        inTextBlock = true;
         if (domChild.nodeType !== Node.TEXT_NODE) {
           throw new MisoException("Expected text node but found got element");
         }
-        // Since the text nodes are collapsed on the DOM side, the text
-        // contents can be different here. To make sure the VDOM and
-        // the DOM agree we copy the text contents from the DOM to the VDOM.
-        vdomChild.text = domChild.textContent;
-        vdomChild.domRef = domChild;
-        j++;
-      } else {
-        // In this case there have been other text nodes directly before this node.
-        // There is thus no corresponding DOM node and we need to create a new node.
-        vdomChild.domRef = document.createTextNode("");
-        vdomChild.text = "";
-      }
+
+        if (vdomChild.text === domChild.textContent) {
+          vdomChild.domRef = domChild;
+        } else {
+          var len = vdomChild.text.length,
+              domNodeText = domChild.textContent.substring(0, len);
+          if (domNodeText !== vdomChild.text) {
+            throw new MisoException("Text in DOM does not match text in virtual DOM");
+          }
+          // There are more VDOM nodes than DOM nodes
+          // Create new DOM node to ensure synchrony between VDom and DOM
+          var partialTxt = document.createTextNode(domNodeText);
+          node.insertBefore(partialTxt, domChild);
+          vdomChild.domRef = partialTxt;
+          domChild.textContent = domChild.textContent.substring(len);
+        }
     } else {
-      inTextBlock = false;
       if (domChild.nodeType !== Node.ELEMENT_NODE) {
         throw new MisoException("Expected element but got text node");
       }
-      walk(vdomChild, domChild);
-      j++;
+      walk(vdomChild, domChild, document);
     }
+
+  }
+  // After walking the sizes of VDom and DOM should be equal
+  // Otherwise there are DOM nodes unaccounted for
+  if (vtree.children.length !== node.childNodes.length) {
+    throw new MisoException("Non-matching DOM an VDOM");
   }
 }

--- a/jsbits/isomorphic.js
+++ b/jsbits/isomorphic.js
@@ -1,13 +1,17 @@
-window.MisoException = function MisoException(message) {
-  this.message = message;
-  this.name = 'MisoException';
+window.copyDOMIntoVTree = function copyDOMIntoVTree(vtree, doc = window.document) {
+  var node = doc.body.firstChild;
+  if (!walk(vtree, node, doc)) {
+    console.warn('Could not copy DOM into virtual DOM, falling back to diff');
+    // Remove all children before rebuilding DOM
+    while (node.firstChild)
+      node.removeChild(node.lastChild);
+    window.diff(null, vtree, doc.body.firstChild, doc);
+    return false;
+  }
+  return true;
 }
 
-window.copyDOMIntoVTree = function copyDOMIntoVTree(vtree, document = window.document) {
-  walk(vtree, document.body.firstChild, document);
-}
-
-window.walk = function walk(vtree, node, document) {
+window.walk = function walk(vtree, node, doc) {
   // This is slightly more complicated than one might expect since
   // browsers will collapse consecutive text nodes into a single text node.
   // There can thus be fewer DOM nodes than VDOM nodes.
@@ -23,36 +27,31 @@ window.walk = function walk(vtree, node, document) {
     vdomChild = vtree.children[i];
     domChild = node.childNodes[i];
     if (vdomChild.type === "vtext") {
-        if (domChild.nodeType !== Node.TEXT_NODE) {
-          throw new MisoException("Expected text node but found got element");
-        }
+        if (domChild.nodeType !== Node.TEXT_NODE) return false;
 
         if (vdomChild.text === domChild.textContent) {
           vdomChild.domRef = domChild;
         } else {
           var len = vdomChild.text.length,
               domNodeText = domChild.textContent.substring(0, len);
-          if (domNodeText !== vdomChild.text) {
-            throw new MisoException("Text in DOM does not match text in virtual DOM");
-          }
+          if (domNodeText !== vdomChild.text) return false;
+
           // There are more VDOM nodes than DOM nodes
           // Create new DOM node to ensure synchrony between VDom and DOM
-          var partialTxt = document.createTextNode(domNodeText);
+          var partialTxt = doc.createTextNode(domNodeText);
           node.insertBefore(partialTxt, domChild);
           vdomChild.domRef = partialTxt;
           domChild.textContent = domChild.textContent.substring(len);
         }
     } else {
-      if (domChild.nodeType !== Node.ELEMENT_NODE) {
-        throw new MisoException("Expected element but got text node");
-      }
-      walk(vdomChild, domChild, document);
+      if (domChild.nodeType !== Node.ELEMENT_NODE) return false;
+      walk(vdomChild, domChild, doc);
     }
 
   }
   // After walking the sizes of VDom and DOM should be equal
   // Otherwise there are DOM nodes unaccounted for
-  if (vtree.children.length !== node.childNodes.length) {
-    throw new MisoException("Non-matching DOM an VDOM");
-  }
+  if (vtree.children.length !== node.childNodes.length) return false;
+
+  return true;
 }

--- a/jsbits/isomorphic.js
+++ b/jsbits/isomorphic.js
@@ -1,23 +1,56 @@
-window.copyDOMIntoVTree = function copyDOMIntoVTree (vtree) {
-  walk (vtree, document.body.firstChild);
-};
+function MisoException(message) {
+  this.message = message;
+  this.name = 'MisoException';
+}
 
-window.walk = function walk (vtree, node) {
-  var i = 0, vdomChild, domChild;
+function copyDOMIntoVTree(vtree) {
+  walk(vtree, document.body.firstChild);
+}
+
+function walk(vtree, node) {
+  // This is slightly more complicated than one might expect since
+  // browsers will collapse consecutive text nodes into a single text node.
+  // There can thus be fewer DOM nodes than VDOM nodes.
+  var i = 0,
+    j = 0,
+    // This indicates if we are in a block of consecutive text nodes.
+    inTextBlock = false,
+    vdomChild,
+    domChild;
   vtree.domRef = node;
 
   // Fire onCreated events as though the elements had just been created.
   callCreated(vtree);
 
-  while (i < vtree.children.length) {
+  for (i = 0; i < vtree.children.length; i++) {
     vdomChild = vtree.children[i];
-    domChild = node.childNodes[i];
+    domChild = node.childNodes[j];
     if (vdomChild.type === "vtext") {
-      vdomChild.domRef = domChild;
-      i++;
-      continue;
+      if (!inTextBlock) {
+        // This is the first text node in a block of consecutive text nodes.
+        inTextBlock = true;
+        if (domChild.nodeType !== Node.TEXT_NODE) {
+          throw new MisoException("Expected text node but found got element");
+        }
+        // Since the text nodes are collapsed on the DOM side, the text
+        // contents can be different here. To make sure the VDOM and
+        // the DOM agree we copy the text contents from the DOM to the VDOM.
+        vdomChild.text = domChild.textContent;
+        vdomChild.domRef = domChild;
+        j++;
+      } else {
+        // In this case there have been other text nodes directly before this node.
+        // There is thus no corresponding DOM node and we need to create a new node.
+        vdomChild.domRef = document.createTextNode("");
+        vdomChild.text = "";
+      }
+    } else {
+      inTextBlock = false;
+      if (domChild.nodeType !== Node.ELEMENT_NODE) {
+        throw new MisoException("Expected element but got text node");
+      }
+      walk(vdomChild, domChild);
+      j++;
     }
-    walk(vdomChild, domChild);
-    i++;
   }
-};
+}

--- a/tests/diff.test.js
+++ b/tests/diff.test.js
@@ -759,7 +759,7 @@ test('Should copy simple nested DOM into VTree', () => {
     expect(currentNode.children[0].children[0].text).toEqual('foo');
 });
 
-test('Should throw exception about expecting text node', () => {
+test('Should fail because of expecting text node', () => {
     var document = new jsdom.JSDOM().window.document;
     var body = document.body;
     var div = document.createElement("div");
@@ -767,13 +767,11 @@ test('Should throw exception about expecting text node', () => {
     var nestedDiv = document.createElement("div");
     div.appendChild(nestedDiv);
     var currentNode = vnodeKids('div', [ vtext("foo") ]);
-    const f = () => {
-        copyDOMIntoVTree(currentNode, document);
-    };
-    expect(f).toThrow(MisoException);
+    var res = copyDOMIntoVTree(currentNode, document);
+    expect(res).toEqual(false);
 });
 
-test('Should throw exception about expecting element', () => {
+test('Should fail because of expecting element', () => {
     var document = new jsdom.JSDOM().window.document;
     var body = document.body;
     var div = document.createElement("div");
@@ -781,13 +779,11 @@ test('Should throw exception about expecting element', () => {
     var txt = document.createTextNode("foo");
     div.appendChild(txt);
     var currentNode = vnodeKids('div', [ vnode('div', []) ]);
-    const f = () => {
-        copyDOMIntoVTree(currentNode, document);
-    };
-    expect(f).toThrow(MisoException);
+    var res = copyDOMIntoVTree(currentNode, document);
+    expect(res).toEqual(false);
 });
 
-test('Should throw exception about non-matching text', () => {
+test('Should fail because of non-matching text', () => {
     var document = new jsdom.JSDOM().window.document;
     var body = document.body;
     var div = document.createElement("div");
@@ -795,13 +791,11 @@ test('Should throw exception about non-matching text', () => {
     var txt = document.createTextNode("foo");
     div.appendChild(txt);
     var currentNode = vnodeKids('div', [ vtext("bar") ]);
-    const f = () => {
-        copyDOMIntoVTree(currentNode, document);
-    };
-    expect(f).toThrow(MisoException);
+    var res = copyDOMIntoVTree(currentNode, document);
+    expect(res).toEqual(false);
 });
 
-test('Should throw exception about non-matching DOM and VDOM', () => {
+test('Should fail because of non-matching DOM and VDOM', () => {
     var document = new jsdom.JSDOM().window.document;
     var body = document.body;
     var div = document.createElement("div");
@@ -809,10 +803,8 @@ test('Should throw exception about non-matching DOM and VDOM', () => {
     var txt = document.createTextNode("foobar");
     div.appendChild(txt);
     var currentNode = vnodeKids('div', [ vtext("foo") ]);
-    const f = () => {
-        copyDOMIntoVTree(currentNode, document);
-    };
-    expect(f).toThrow(MisoException);
+    var res = copyDOMIntoVTree(currentNode, document);
+    expect(res).toEqual(false);
 });
 
 test('Should copy DOM into VTree with multiple consecutive text nodes', () => {

--- a/tests/diff.test.js
+++ b/tests/diff.test.js
@@ -1,4 +1,5 @@
 const diff = require('./diff');
+const isomorphic = require('./isomorphic.js');
 const jsdom = require('jsdom');
 
 function vnode(tag, children, props, css, ns, ref, oc, od, key) {
@@ -742,4 +743,60 @@ test('Should diff keyed text nodes', () => {
     diff(currentNode, newNode, body, document);
     expect(newNode.children.length).toBe(currentNode.children.length);
     expect(newNode.children).toEqual(currentNode.children);
+});
+
+test('Should copy simple nested DOM into VTree', () => {
+    var document = new jsdom.JSDOM().window.document;
+    var body = document.body;
+    var div = document.createElement("div");
+    body.appendChild(div);
+    var nestedDiv = document.createElement("div");
+    div.appendChild(nestedDiv);
+    var txt = document.createTextNode("foo");
+    nestedDiv.appendChild(txt);
+    var currentNode = vnodeKids('div', [ vnodeKids('div', [ vtext("foo") ]) ]);
+    copyDOMIntoVTree(currentNode, document);
+    expect(currentNode.children[0].children[0].text).toEqual('foo');
+});
+
+test('Should throw exception about expecting text node', () => {
+    var document = new jsdom.JSDOM().window.document;
+    var body = document.body;
+    var div = document.createElement("div");
+    body.appendChild(div);
+    var nestedDiv = document.createElement("div");
+    div.appendChild(nestedDiv);
+    var currentNode = vnodeKids('div', [ vtext("foo") ]);
+    const f = () => {
+        copyDOMIntoVTree(currentNode, document);
+    };
+    expect(f).toThrow(MisoException);
+});
+
+test('Should throw exception about expecting element', () => {
+    var document = new jsdom.JSDOM().window.document;
+    var body = document.body;
+    var div = document.createElement("div");
+    body.appendChild(div);
+    var txt = document.createTextNode("foo");
+    div.appendChild(txt);
+    var currentNode = vnodeKids('div', [ vnode('div', []) ]);
+    const f = () => {
+        copyDOMIntoVTree(currentNode, document);
+    };
+    expect(f).toThrow(MisoException);
+});
+
+test('Should copy DOM into VTree with multiple consecutive text nodes', () => {
+    var document = new jsdom.JSDOM().window.document;
+    var body = document.body;
+    var div = document.createElement("div");
+    body.appendChild(div);
+    var txt = document.createTextNode("foobarbaz");
+    div.appendChild(txt);
+    var currentNode = vnodeKids('div', [ vtext("foo"), vtext("bar"), vtext("baz") ]);
+    copyDOMIntoVTree(currentNode, document);
+    expect(currentNode.children[0].text).toEqual('foobarbaz');
+    expect(currentNode.children[1].text).toEqual('');
+    expect(currentNode.children[2].text).toEqual('');
 });

--- a/tests/diff.test.js
+++ b/tests/diff.test.js
@@ -787,6 +787,34 @@ test('Should throw exception about expecting element', () => {
     expect(f).toThrow(MisoException);
 });
 
+test('Should throw exception about non-matching text', () => {
+    var document = new jsdom.JSDOM().window.document;
+    var body = document.body;
+    var div = document.createElement("div");
+    body.appendChild(div);
+    var txt = document.createTextNode("foo");
+    div.appendChild(txt);
+    var currentNode = vnodeKids('div', [ vtext("bar") ]);
+    const f = () => {
+        copyDOMIntoVTree(currentNode, document);
+    };
+    expect(f).toThrow(MisoException);
+});
+
+test('Should throw exception about non-matching DOM and VDOM', () => {
+    var document = new jsdom.JSDOM().window.document;
+    var body = document.body;
+    var div = document.createElement("div");
+    body.appendChild(div);
+    var txt = document.createTextNode("foobar");
+    div.appendChild(txt);
+    var currentNode = vnodeKids('div', [ vtext("foo") ]);
+    const f = () => {
+        copyDOMIntoVTree(currentNode, document);
+    };
+    expect(f).toThrow(MisoException);
+});
+
 test('Should copy DOM into VTree with multiple consecutive text nodes', () => {
     var document = new jsdom.JSDOM().window.document;
     var body = document.body;
@@ -796,7 +824,8 @@ test('Should copy DOM into VTree with multiple consecutive text nodes', () => {
     div.appendChild(txt);
     var currentNode = vnodeKids('div', [ vtext("foo"), vtext("bar"), vtext("baz") ]);
     copyDOMIntoVTree(currentNode, document);
-    expect(currentNode.children[0].text).toEqual('foobarbaz');
-    expect(currentNode.children[1].text).toEqual('');
-    expect(currentNode.children[2].text).toEqual('');
+    // Expect "foobarbaz" to be split up into three nodes in the DOM
+    expect(div.childNodes[0].textContent).toEqual('foo');
+    expect(div.childNodes[1].textContent).toEqual('bar');
+    expect(div.childNodes[2].textContent).toEqual('baz');
 });

--- a/tests/package.json
+++ b/tests/package.json
@@ -4,7 +4,7 @@
   "description": "miso tests",
   "main": "diff.test.js",
   "scripts": {
-    "test": "cp ../jsbits/diff.js ./ && echo 'module.exports = diff;' >> diff.js &&./node_modules/.bin/jest --coverage && rm ./diff.js"
+    "test": "cp ../jsbits/diff.js ./ && cp ../jsbits/isomorphic.js ./ && echo 'module.exports = diff;' >> diff.js &&./node_modules/.bin/jest --coverage && rm ./diff.js && rm ./isomorphic.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
- Based on https://github.com/dmjio/miso/pull/309 (CC @cocreature)
- Rebased on latest (and greatest) master
- Created tests for isomorphism (within diff.test.js, can change if desired)

Test report:
![2019-04-17-231143_3142x1966_scrot](https://user-images.githubusercontent.com/1202014/56321227-59a42980-6166-11e9-878c-c3055c207b95.png)

Note: When running `npm test` I got the following error:
```
SecurityError: localStorage is not available for opaque origins
```

After some Googling I found you need to set `"testURL": "http://localhost/"` in a jest config file, which is then passed to the `./node_modules/.bin/jest --config jestconfig.json` command. This change is not included in this PR as it might be caused by the version of jest I'm running.