### PR TITLE
Add Float, Double, Int and Word instances to backend ToMisoString

### DIFF
--- a/frontend-src/Miso/String.hs
+++ b/frontend-src/Miso/String.hs
@@ -84,7 +84,7 @@ instance ToMisoString Float where
   fromMisoString = realToFrac . jsStringToDouble
 instance ToMisoString Double where
   toMisoString = realFloatToJSString
-  fromMisoString =  jsStringToDouble
+  fromMisoString = jsStringToDouble
 instance ToMisoString Int where
   toMisoString = integralToJSString
   fromMisoString = round . jsStringToDouble

--- a/ghc-src/Miso/String.hs
+++ b/ghc-src/Miso/String.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE TypeSynonymInstances #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeApplications #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Miso.String
@@ -54,3 +55,17 @@ instance ToMisoString B.ByteString where
 instance ToMisoString BL.ByteString where
   toMisoString = toMisoString . LT.decodeUtf8
   fromMisoString = LT.encodeUtf8 . fromMisoString
+instance ToMisoString Float where
+  toMisoString = T.pack . show
+  fromMisoString = read . T.unpack
+instance ToMisoString Double where
+  toMisoString = T.pack . show
+  fromMisoString = read . T.unpack
+instance ToMisoString Int where
+  toMisoString = T.pack . show
+  -- Replicate frontend behavior
+  fromMisoString = round . read @Double . T.unpack
+instance ToMisoString Word where
+  toMisoString = T.pack . show
+  -- Replicate frontend behavior
+  fromMisoString = round . read @Double . T.unpack


### PR DESCRIPTION
This is a bit of a discussion starter. When working on the isomorphic consecutive text thing I noticed my view code still had `show` in it. In the frontend we've added `ToMisoString` instances to `Float`, `Double`, `Int` and `Word`. I couldn't change the code to use `toMisoString` directly though, as the server would fail on missing instances.

This implementation should pretty much give the same behavior as the frontend.