### PR TITLE
copyDOMIntoVTree: take mountpoint into account

### DIFF
--- a/frontend-src/Miso.hs
+++ b/frontend-src/Miso.hs
@@ -125,8 +125,9 @@ miso f = do
   common app model $ \writeEvent -> do
     let initialView = view model
     VTree (OI.Object iv) <- flip runView writeEvent initialView
+    mountEl <- mountElement mountPoint
     -- Initial diff can be bypassed, just copy DOM into VTree
-    copyDOMIntoVTree iv
+    copyDOMIntoVTree mountEl iv
     let initialVTree = VTree (OI.Object iv)
     -- Create virtual dom, perform initial diff
     liftIO (newIORef initialVTree)

--- a/ghcjs-ffi/Miso/FFI.hs
+++ b/ghcjs-ffi/Miso/FFI.hs
@@ -213,8 +213,11 @@ foreign import javascript unsafe "$1($2);"
 
 -- | Copies DOM pointers into virtual dom
 -- entry point into isomorphic javascript
-foreign import javascript unsafe "copyDOMIntoVTree($1);"
-  copyDOMIntoVTree :: JSVal -> IO ()
+foreign import javascript unsafe "copyDOMIntoVTree($1, $2);"
+  copyDOMIntoVTree
+    :: JSVal -- ^ mountPoint element of the isomorphic app
+    -> JSVal -- ^ VDom object
+    -> IO ()
 
 -- | Pins down the current callbacks for clearing later
 foreign import javascript unsafe "swapCallbacks();"

--- a/jsaddle-ffi/Miso/FFI.hs
+++ b/jsaddle-ffi/Miso/FFI.hs
@@ -199,8 +199,8 @@ delegateEvent' mountPoint events cb = () <$ jsg3 "delegate" mountPoint events cb
 
 -- | Copies DOM pointers into virtual dom
 -- entry point into isomorphic javascript
-copyDOMIntoVTree :: JSVal -> JSM ()
-copyDOMIntoVTree a = () <$ jsg1 "copyDOMIntoVTree" a
+copyDOMIntoVTree :: JSVal -> JSVal -> JSM ()
+copyDOMIntoVTree mountPoint a = () <$ jsg1 "copyDOMIntoVTree" mountPoint a
 
 -- TODO For now, we do not free callbacks when compiling with JSaddle
 

--- a/jsbits/isomorphic.js
+++ b/jsbits/isomorphic.js
@@ -1,11 +1,11 @@
-window.copyDOMIntoVTree = function copyDOMIntoVTree(vtree, doc = window.document) {
-  var node = doc.body.firstChild;
+window.copyDOMIntoVTree = function copyDOMIntoVTree(mountPoint, vtree, doc = window.document) {
+  var node = mountPoint ? mountPoint.firstChild : doc.body.firstChild;
   if (!walk(vtree, node, doc)) {
     console.warn('Could not copy DOM into virtual DOM, falling back to diff');
     // Remove all children before rebuilding DOM
     while (node.firstChild)
       node.removeChild(node.lastChild);
-    window.diff(null, vtree, doc.body.firstChild, doc);
+    window.diff(null, vtree, node, doc);
     return false;
   }
   return true;

--- a/tests/diff.test.js
+++ b/tests/diff.test.js
@@ -755,7 +755,7 @@ test('Should copy simple nested DOM into VTree', () => {
     var txt = document.createTextNode("foo");
     nestedDiv.appendChild(txt);
     var currentNode = vnodeKids('div', [ vnodeKids('div', [ vtext("foo") ]) ]);
-    copyDOMIntoVTree(currentNode, document);
+    copyDOMIntoVTree(body, currentNode, document);
     expect(currentNode.children[0].children[0].text).toEqual('foo');
 });
 
@@ -767,7 +767,7 @@ test('Should fail because of expecting text node', () => {
     var nestedDiv = document.createElement("div");
     div.appendChild(nestedDiv);
     var currentNode = vnodeKids('div', [ vtext("foo") ]);
-    var res = copyDOMIntoVTree(currentNode, document);
+    var res = copyDOMIntoVTree(body, currentNode, document);
     expect(res).toEqual(false);
 });
 
@@ -779,7 +779,7 @@ test('Should fail because of expecting element', () => {
     var txt = document.createTextNode("foo");
     div.appendChild(txt);
     var currentNode = vnodeKids('div', [ vnode('div', []) ]);
-    var res = copyDOMIntoVTree(currentNode, document);
+    var res = copyDOMIntoVTree(body, currentNode, document);
     expect(res).toEqual(false);
 });
 
@@ -791,7 +791,7 @@ test('Should fail because of non-matching text', () => {
     var txt = document.createTextNode("foo");
     div.appendChild(txt);
     var currentNode = vnodeKids('div', [ vtext("bar") ]);
-    var res = copyDOMIntoVTree(currentNode, document);
+    var res = copyDOMIntoVTree(body, currentNode, document);
     expect(res).toEqual(false);
 });
 
@@ -803,7 +803,7 @@ test('Should fail because of non-matching DOM and VDOM', () => {
     var txt = document.createTextNode("foobar");
     div.appendChild(txt);
     var currentNode = vnodeKids('div', [ vtext("foo") ]);
-    var res = copyDOMIntoVTree(currentNode, document);
+    var res = copyDOMIntoVTree(body, currentNode, document);
     expect(res).toEqual(false);
 });
 
@@ -815,9 +815,30 @@ test('Should copy DOM into VTree with multiple consecutive text nodes', () => {
     var txt = document.createTextNode("foobarbaz");
     div.appendChild(txt);
     var currentNode = vnodeKids('div', [ vtext("foo"), vtext("bar"), vtext("baz") ]);
-    copyDOMIntoVTree(currentNode, document);
+    copyDOMIntoVTree(body, currentNode, document);
     // Expect "foobarbaz" to be split up into three nodes in the DOM
     expect(div.childNodes[0].textContent).toEqual('foo');
     expect(div.childNodes[1].textContent).toEqual('bar');
     expect(div.childNodes[2].textContent).toEqual('baz');
+});
+
+test('Should copy DOM into VTree at mountPoint', () => {
+    var document = new jsdom.JSDOM().window.document;
+    var body = document.body;
+    var unrelatedDiv = document.createElement("div");
+    body.appendChild(unrelatedDiv);
+    var unrelatedTxt = document.createTextNode("Not part of Miso app");
+    unrelatedDiv.appendChild(unrelatedTxt);
+    var misoDiv = document.createElement("div");
+    body.appendChild(misoDiv);
+    var nestedDiv1 = document.createElement("div");
+    misoDiv.appendChild(nestedDiv1);
+    var nestedDiv2 = document.createElement("div");
+    nestedDiv1.appendChild(nestedDiv2);
+    var txt = document.createTextNode("foo");
+    nestedDiv2.appendChild(txt);
+    var currentNode = vnodeKids('div', [ vnodeKids('div', [ vtext("foo") ]) ]);
+    var succeeded = copyDOMIntoVTree(misoDiv, currentNode, document);
+    expect(currentNode.children[0].children[0].domRef).toEqual(txt);
+    expect(succeeded).toEqual(true);
 });


### PR DESCRIPTION
Fixes mountpoint throwing an error when working with the `miso` function

Fixes #455

Also created a test to prevent future breaking


I actually just found out that there was already an implementation mentioned in the issue. This PR is somewhat more up to date and defines a test case. 