### PR TITLE
fix missing import

### DIFF
--- a/src/Miso/Html/Property.hs
+++ b/src/Miso/Html/Property.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE CPP #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Miso.Html.Property
@@ -120,7 +121,10 @@ module Miso.Html.Property
 
 import           Miso.Html.Internal
 import           Miso.String (MisoString, intercalate)
+
+#if __GLASGOW_HASKELL__ < 841
 import           Data.Monoid ((<>))
+#endif
 
 -- | Set field to `Bool` value
 boolProp :: MisoString -> Bool -> Attribute action

--- a/src/Miso/Html/Property.hs
+++ b/src/Miso/Html/Property.hs
@@ -120,6 +120,7 @@ module Miso.Html.Property
 
 import           Miso.Html.Internal
 import           Miso.String (MisoString, intercalate)
+import           Data.Monoid ((<>))
 
 -- | Set field to `Bool` value
 boolProp :: MisoString -> Bool -> Attribute action


### PR DESCRIPTION
Fix the following error when compiling miso:
```
$ nix-build
...
Building source dist for miso-0.21.2.0...
Preprocessing library miso-0.21.2.0...
Source tarball created: dist/miso-0.21.2.0.tar.gz
running tests
haddockPhase
installing
post-installation fixup
[ 8 of 21] Compiling Miso.Html.Event  ( src/Miso/Html/Event.hs, dist/build/Miso/Html/Event.o )
[ 9 of 21] Compiling Miso.Html.Property ( src/Miso/Html/Property.hs, dist/build/Miso/Html/Property.o )

src/Miso/Html/Property.hs:391:31: error:
    • Variable not in scope: (<>) :: [Char] -> MisoString -> MisoString
    • Perhaps you meant one of these:
        ‘<$’ (imported from Prelude), ‘<$>’ (imported from Prelude),
        ‘*>’ (imported from Prelude)
      Perhaps you want to add ‘<>’ to the import list in the import of
      ‘Miso.String’ (src/Miso/Html/Property.hs:122:1-54).
```