### PR TITLE
Live reload command fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ nix-shell -A env --run 'cabal configure --ghcjs && cabal build`
 
 For incremental development inside of the `nix-shell` we recommend using a tool like [`entr`](http://eradman.com/entrproject/) to automatically rebuild on file changes, or roll your own solution with `inotify`.
 ```
-ag -l | entr 'cabal build'
+ag -l | entr cabal build
 ```
 
 ### Architecture

--- a/sample-app/Main.hs
+++ b/sample-app/Main.hs
@@ -8,6 +8,8 @@ module Main where
 -- | Miso framework import
 import Miso
 import Miso.String
+import Language.Javascript.JSaddle.Warp as JSaddle
+import Control.Monad.IO.Class (liftIO)
 
 -- | Type synonym for an application model
 type Model = Int
@@ -22,7 +24,7 @@ data Action
 
 -- | Entry point for a miso application
 main :: IO ()
-main = startApp App {..}
+main = JSaddle.run 8080 $ startApp App {..}
   where
     initialAction = SayHelloWorld -- initial action to be executed on application load
     model  = 0                    -- initial model
@@ -38,7 +40,7 @@ updateModel AddOne m = noEff (m + 1)
 updateModel SubtractOne m = noEff (m - 1)
 updateModel NoOp m = noEff m
 updateModel SayHelloWorld m = m <# do
-  putStrLn "Hello World" >> pure NoOp
+  liftIO (putStrLn "Hello World") >> pure NoOp
 
 -- | Constructs a virtual DOM from a model
 viewModel :: Model -> View Action

--- a/sample-app/app.cabal
+++ b/sample-app/app.cabal
@@ -1,13 +1,16 @@
+cabal-version:       2.4
 name:                app
 version:             0.1.0.0
 synopsis:            First miso app
 category:            Web
 build-type:          Simple
-cabal-version:       >=1.10
 
 executable app
   main-is:             Main.hs
   ghcjs-options:
     -dedupe
-  build-depends:       base, miso
+  build-depends:
+        base   ^>= 4.12.0.0,
+        miso,
+        jsaddle-warp
   default-language:    Haskell2010

--- a/sample-app/cabal.config
+++ b/sample-app/cabal.config
@@ -1,1 +1,0 @@
-compiler: ghcjs

--- a/sample-app/default.nix
+++ b/sample-app/default.nix
@@ -3,4 +3,4 @@ with (import (builtins.fetchTarball {
   sha256 = "0kg9lg18qdsnb6gw3jmnl49widzf5cy151bls7k09d5dxlm0myd8";
 }) {});
 with pkgs.haskell.packages;
-ghcjs.callCabal2nix "app" ./. {}
+ghc865.callCabal2nix "app" ./. { miso = ghc865.miso-jsaddle; }

--- a/sample-app/shell.nix
+++ b/sample-app/shell.nix
@@ -1,0 +1,1 @@
+(import ./default.nix).env


### PR DESCRIPTION
The command for live reload example is wrong:

    ag -l | entr 'cabal build'

In above command it thinks that `cabal build` is an executable so it fails with error:

    entr: exec cabal build: No such file or directory