### PR TITLE
Fix live reload entr command example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ nix-shell -A env --run 'cabal configure --ghcjs && cabal build`
 
 For incremental development inside of the `nix-shell` we recommend using a tool like [`entr`](http://eradman.com/entrproject/) to automatically rebuild on file changes, or roll your own solution with `inotify`.
 ```
-ag -l | entr 'cabal build'
+ag -l | entr cabal build
 ```
 
 ### Architecture


### PR DESCRIPTION
The command for live reload example is wrong:

    ag -l | entr 'cabal build'

In above command it thinks that `cabal build` is an executable so it fails with error:

    entr: exec cabal build: No such file or directory