### PR TITLE
Remove default parameter values.

### DIFF
--- a/jsbits/isomorphic.js
+++ b/jsbits/isomorphic.js
@@ -1,5 +1,6 @@
 window = typeof window === 'undefined' ? {} : window;
-window['copyDOMIntoVTree'] = function copyDOMIntoVTree(mountPoint, vtree, doc = window.document) {
+window['copyDOMIntoVTree'] = function copyDOMIntoVTree(mountPoint, vtree, doc) {
+  if (!doc) { doc = window.document; }
   var node = mountPoint ? mountPoint.firstChild : doc.body.firstChild;
   if (!window['walk'](vtree, node, doc)) {
     console.warn('Could not copy DOM into virtual DOM, falling back to diff');


### PR DESCRIPTION
This syntax breaks hjsmin, which is needed for minification before cross-compilation.