### PR TITLE
Improve haddock coverage of things exported from Miso module

### DIFF
--- a/frontend-src/Miso.hs
+++ b/frontend-src/Miso.hs
@@ -129,7 +129,7 @@ common App {..} m getView = do
         loop newModel
   loop m
 
--- | Runs an isomorphic miso application
+-- | Runs an isomorphic miso application.
 -- Assumes the pre-rendered DOM is already present
 miso :: Eq model => (URI -> App model action) -> JSM ()
 miso f = do

--- a/frontend-src/Miso/Effect.hs
+++ b/frontend-src/Miso/Effect.hs
@@ -6,6 +6,9 @@
 -- Maintainer  :  David M. Johnson <djohnson.m@gmail.com>
 -- Stability   :  experimental
 -- Portability :  non-portable
+--
+-- This module defines `Effect` and `Sub` types, which are used to define
+-- `Miso.Types.update` function and `Miso.Types.subs` field of the `Miso.Types.App`.
 ----------------------------------------------------------------------------
 module Miso.Effect (
   module Miso.Effect.Storage
@@ -37,10 +40,10 @@ data Effect action model = Effect model [Sub action]
 -- | Type synonym for constructing event subscriptions.
 --
 -- The 'Sink' callback is used to dispatch actions which are then fed
--- back to the 'update' function.
+-- back to the 'Miso.Types.update' function.
 type Sub action = Sink action -> JSM ()
 
--- | Function to asynchronously dispatch actions to the 'update' function.
+-- | Function to asynchronously dispatch actions to the 'Miso.Types.update' function.
 type Sink action = action -> IO ()
 
 -- | Turn a subscription that consumes actions of type @a@ into a subscription

--- a/frontend-src/Miso/Types.hs
+++ b/frontend-src/Miso/Types.hs
@@ -52,7 +52,7 @@ data App model action = App
   , initialAction :: action
   -- ^ Initial action that is run after the application has loaded
   , mountPoint :: Maybe MisoString
-  -- ^ Id of the root element for DOM diff. If 'Nothing' is provided, the entire document body is used.
+  -- ^ Id of the root element for DOM diff. If 'Nothing' is provided, the entire document body is used as a mount point.
   }
 
 -- | A monad for succinctly expressing model transitions in the 'update' function.


### PR DESCRIPTION
@dmjio is this the kind of docs you're looking for? Maybe this kind of trivial docs are not really useful for people forged by the fire of web platform, but for someone like me (relatively inexperienced in web development) it would be useful :)

Also there are bunch of functions exported from Miso module, about which I have no idea as to their purpose, like callbackToJSVal, objectToJSVal, ghcjsPure, swapCallbacks, releaseCallbacks, registerCallback. I'll dive into the source code and hopefully understand their usefulness. I'd like to add some short code examples to illustrate the usage of some non-obvious functions.