### PR TITLE
Remove redundant equality check

### DIFF
--- a/jsbits/delegate.js
+++ b/jsbits/delegate.js
@@ -55,21 +55,19 @@ window['delegateEvent'] = function delegateEvent (event, obj, stack, parentStack
 
   /* stack.length == 1 */
   else {
-    if (obj['domRef'] === stack[0]) {
       var eventObj = obj['events'][event.type];
       if (eventObj) {
 	var options = eventObj.options;
-      if (options['preventDefault'])
-	event.preventDefault();
-      eventObj['runEvent'](event);
-      if (!options['stopPropagation'])
-	window['propogateWhileAble'] (parentStack, event);
+        if (options['preventDefault'])
+  	  event.preventDefault();
+        eventObj['runEvent'](event);
+        if (!options['stopPropagation'])
+ 	  window['propogateWhileAble'] (parentStack, event);
       } else {
 	/* still propagate to parent handlers even if event not defined */
 	window['propogateWhileAble'] (parentStack, event);
       }
-    }
-  }
+   }
 };
 
 window['buildTargetToElement'] = function buildTargetToElement (element, target) {


### PR DESCRIPTION
`domRef` equality check is redundant, and can be removed.