### PR TITLE
jsaddle example: better reload script

### DIFF
--- a/sample-app-jsaddle/shell.nix
+++ b/sample-app-jsaddle/shell.nix
@@ -1,9 +1,10 @@
 with (import ./default.nix);
-dev.env.overrideAttrs (old: {
-  shellHook = ''
-    function reload () {
-      ${pkgs.haskell.packages.ghc865.ghcid}/bin/ghcid -c '${pkgs.haskell.packages.ghc865.cabal-install}/bin/cabal new-repl' -T ':main'
-    }
-  '';
+let
+  reload-script = pkgs.writeScriptBin "reload" ''
+      ${pkgs.haskell.packages.ghc865.ghcid}/bin/ghcid -c \
+        '${pkgs.haskell.packages.ghc865.cabal-install}/bin/cabal new-repl' \
+        -T ':main'
+'';
+in dev.env.overrideAttrs (old: {
+  buildInputs = old.buildInputs ++ [reload-script];
 })
-


### PR DESCRIPTION
I think this is a better way to provide `reload` script in nix-shell environment. Even though technically speaking I see nothing bad about the old way I think this one is more idiomatic nix way of accomplishing it. Advantage is that with this change the script is created (and cached) in nix store though for something as simple as this it doesn't matter that much.