### PR TITLE
split off a FromMisoString class from the ToMisoString class ( adresses #492)

### DIFF
--- a/frontend-src/Miso/String.hs
+++ b/frontend-src/Miso/String.hs
@@ -116,5 +116,6 @@ instance FromMisoString Word where
   fromMisoStringEither = fmap round . jsStringToDoubleEither
 
 jsStringToDoubleEither :: JSString -> Either String Double
-jsStringToDoubleEither = Right . jsStringToDouble
--- TODO
+jsStringToDoubleEither s = let d = jsStringToDouble s
+                           in if isNaN d then Left "jsStringToDoubleEither: parse failed"
+                                         else Right d

--- a/frontend-src/Miso/String.hs
+++ b/frontend-src/Miso/String.hs
@@ -126,13 +126,14 @@ jsStringToDoubleEither s = let d = jsStringToDouble s
                                          else Right d
 
 
-parseWord :: MisoString -> Either String Word
-parseWord = fmap snd . foldr k (Right (1,0))
+parseWord   :: MisoString -> Either String Word
+parseWord s = case uncons s of
+                Nothing     -> Left "parseWord: parse error"
+                Just (c,s') -> foldl' k (pDigit c) s'
   where
-    k c acc = do (l,x) <- acc
-                 y     <- if isDigit c then Right (fromIntegral $ digitToInt c)
-                                       else Left "parseWord: parse error"
-                 pure $ (l*10,l*y + x)
+    pDigit c | isDigit c = Right . fromIntegral . digitToInt $ c
+             | otherwise = Left "parseWord: parse error"
+    k ea c = (\a x -> 10*a + x) <$> ea <*> pDigit c
 
 parseInt   :: MisoString -> Either String Int
 parseInt s = case uncons s of

--- a/frontend-src/Miso/String.hs
+++ b/frontend-src/Miso/String.hs
@@ -31,6 +31,7 @@ import           Data.Char
 #endif
 import qualified Data.ByteString as B
 import qualified Data.ByteString.Lazy as BL
+import           Data.Char
 import           Data.JSString
 import           Data.JSString.Text
 import           Data.Monoid

--- a/ghc-src/Miso/String.hs
+++ b/ghc-src/Miso/String.hs
@@ -87,7 +87,6 @@ instance FromMisoString Float where
 instance FromMisoString Double where
   fromMisoStringEither = readEither . T.unpack
 instance FromMisoString Int where
-  fromMisoStringEither = fmap round . (readEither :: String -> Either String Int) . T.unpack
+  fromMisoStringEither = readEither . T.unpack
 instance FromMisoString Word where
-  -- Replicate frontend behavior
-  fromMisoStringEither = fmap round . (readEither :: String -> Either String Word) . T.unpack
+  fromMisoStringEither = readEither . T.unpack

--- a/ghc-src/Miso/String.hs
+++ b/ghc-src/Miso/String.hs
@@ -87,8 +87,7 @@ instance FromMisoString Float where
 instance FromMisoString Double where
   fromMisoStringEither = readEither . T.unpack
 instance FromMisoString Int where
-  -- Replicate frontend behavior
-  fromMisoStringEither = fmap round . (readEither :: String -> Either String Double) . T.unpack
+  fromMisoStringEither = fmap round . (readEither :: String -> Either String Int) . T.unpack
 instance FromMisoString Word where
   -- Replicate frontend behavior
-  fromMisoStringEither = fmap round . (readEither :: String -> Either String Double) . T.unpack
+  fromMisoStringEither = fmap round . (readEither :: String -> Either String Word) . T.unpack


### PR DESCRIPTION
WIP: don't merge yet

This partly addresses #492. Essentially, I created a new 'FromMisoString' class that has a 'fromMisoStringEither' function that tries to read a MisoString into an Either String a. Still todo: 

1. for ghcjs I added a 'jsStringToDoubleEither' function whose function it is to try to parse double. The current implementation is kind of silly, as it just directly uses 'jsStringToDoubleEither' and wraps it in a 'Right'. Clearly, that is not yet the right thing to do. (But I will have to figure out how to do the right thing there). 

2. Trying to parse a, say Int, from a nonsensical string the error returned in the Left is now simply "Prelude.read: no parse". Maybe we want a better (= more specific) message there.

3. Update docs where necessary.

Before going through those steps (in particular 1 will require some figuring out for me), let me ask: Do you think this is a reasonable solution? 
