### PR TITLE
Fix error in code in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ nix-shell -A env --run 'ghcjs-pkg list'
 
 To build the project with `cabal` after entering the `nix-shell`
 ```
-nix-shell -A env --run 'cabal configure --ghcjs && cabal build`
+nix-shell -A env --run 'cabal configure --ghcjs && cabal build'
 ```
 
 For incremental development inside of the `nix-shell` we recommend using a tool like [`entr`](http://eradman.com/entrproject/) to automatically rebuild on file changes, or roll your own solution with `inotify`.


### PR DESCRIPTION
Command as written in README causes erroneous behavior:
```
[nix-shell:~/]$ nix-shell -A env --run 'cabal configure --ghcjs && cabal build`
>
```

After edit to command, desired behavior occurs:
```
[nix-shell:~/]$ nix-shell -A env --run 'cabal configure --ghcjs && cabal build'
'cabal.project.local' file already exists. Now overwriting it.
Build profile: -w ghcjs-8.6.0.1 -O1
In order, the following would be built (use -v for more details):
 ...
```
