### PR TITLE
Always update checked and value when diffing props.

### DIFF
--- a/jsbits/diff.js
+++ b/jsbits/diff.js
@@ -101,7 +101,7 @@ window['diffProps'] = function diffProps(cProps, nProps, node, isSvg) {
         node[c] = '';
     } else {
       /* Already on DOM from previous diff, continue */
-      if (newProp === cProps[c]) continue;
+      if (newProp === cProps[c] && c !== 'checked' && c !== 'value') continue;
       if (isSvg) {
         if (c === 'href')
           node.setAttributeNS('http://www.w3.org/1999/xlink', 'href', newProp);


### PR DESCRIPTION
In the case where the old and new vdom have the same value, don't assume the UI control state has the same value. Only relevant for `checked` and `value` (potentially others).