### PR TITLE
Check for input type before event accumulation.

### DIFF
--- a/examples/miso-examples.cabal
+++ b/examples/miso-examples.cabal
@@ -1,5 +1,5 @@
 name:                miso-examples
-version:             1.5.1.0
+version:             1.5.2.0
 category:            Web, Miso, Data Structures
 author:              David M. Johnson <djohnson.m@gmail.com>
 maintainer:          David M. Johnson <djohnson.m@gmail.com>

--- a/jsbits/delegate.js
+++ b/jsbits/delegate.js
@@ -115,11 +115,12 @@ window['objectToJSON'] = function objectToJSON (at, obj) {
 
   /* If obj is a non-list-like object */
   newObj = {};
+  var isInput = obj['localName'] === 'input';
   for (var i in obj){
     /* bug in safari, throws TypeError if the following fields are referenced on a checkbox */
     /* https://stackoverflow.com/a/25569117/453261 */
     /* https://html.spec.whatwg.org/multipage/input.html#do-not-apply */
-    if (obj['type'] == 'checkbox' && (i === 'selectionDirection' || i === 'selectionStart' || i === 'selectionEnd'))
+    if (isInput && (i === 'selectionDirection' || i === 'selectionStart' || i === 'selectionEnd'))
       continue;
     if (typeof obj[i] == 'string' || typeof obj[i] == 'number' || typeof obj[i] == 'boolean')
       newObj[i] = obj[i];

--- a/miso.cabal
+++ b/miso.cabal
@@ -1,5 +1,5 @@
 name:                miso
-version:             1.5.1.0
+version:             1.5.2.0
 category:            Web, Miso, Data Structures
 license:             BSD3
 license-file:        LICENSE


### PR DESCRIPTION
Safari throws a TypeError when selection* is indexed on a DOM node. This PR checks for that case and ignores it.