### PR TITLE
Support some pass-through nixpkgs arguments.

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -3,6 +3,10 @@
 , examples ? false
 , ios ? false
 , overlays ? []
+, nixpkgsConfig ? {}
+, system ? builtins.currentSystem
+, crossSystem ? null
+, crossOverlays ? []
 }:
 with (builtins.fromJSON (builtins.readFile ./nixpkgs.json));
 let
@@ -195,7 +199,13 @@ let
   pkgs = import (builtins.fetchTarball {
     url = "https://github.com/NixOS/nixpkgs/archive/${rev}.tar.gz";
     inherit sha256;
-  }) { config.packageOverrides = overrides; config.allowUnfree = true; inherit overlays; };
+  }) {
+    config = {
+      packageOverrides = overrides;
+      allowUnfree = true;
+    } // nixpkgsConfig;
+    inherit system crossSystem overlays crossOverlays;
+  };
   more-examples = import ./nix/examples.nix pkgs;
   uploadCoverage = pkgs.writeScriptBin "upload-coverage.sh" ''
     #!/usr/bin/env bash


### PR DESCRIPTION
Among other things, this makes it possible to build Miso for multiple
platforms with Hydra.