### PR TITLE
Collapse sibling text nodes.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ matrix:
 before_install:
  - nix-channel --list
  - nix-channel --update
+ - echo "trusted-users = root travis" | sudo tee -a /etc/nix/nix.conf && sudo pkill nix-daemon
  - nix-env -iA cachix -f https://cachix.org/api/v1/install
  - cachix use miso-haskell
  - nix-build -A pkgs.yarn default.nix && nix-env -i ./result

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ matrix:
 before_install:
  - nix-channel --list
  - nix-channel --update
- - nix upgrade-nix
  - nix-env -iA cachix -f https://cachix.org/api/v1/install
  - cachix use miso-haskell
  - nix-build -A pkgs.yarn default.nix && nix-env -i ./result

--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ main = startApp App {..}
     events = defaultEvents        -- default delegated events
     subs   = []                   -- empty subscription list
     mountPoint = Nothing          -- mount point for application (Nothing defaults to 'body')
-    debug = False                 -- used during prerendering to see if the VDOM and DOM are in sync (only applies to `miso` function)
+    logLevel = Off                -- used during prerendering to see if the VDOM and DOM are in sync (only applies to `miso` function)
 
 -- | Updates model, optionally introduces side effects
 updateModel :: Action -> Model -> Effect Action Model
@@ -343,7 +343,7 @@ main = startApp App {..}
     events = defaultEvents        -- default delegated events
     subs   = []                   -- empty subscription list
     mountPoint = Nothing          -- mount point for application (Nothing defaults to 'body')
-    debug = False                 -- used during prerendering to see if the VDOM and DOM are in sync (only applies to `miso` function)
+    logLevel = Off                -- used during prerendering to see if the VDOM and DOM are in sync (only applies to `miso` function)
 
 -- | Updates model, optionally introduces side effects
 updateModel :: Action -> Transition Action Model ()

--- a/README.md
+++ b/README.md
@@ -269,6 +269,7 @@ main = startApp App {..}
     events = defaultEvents        -- default delegated events
     subs   = []                   -- empty subscription list
     mountPoint = Nothing          -- mount point for application (Nothing defaults to 'body')
+    debug = False                 -- used during prerendering to see if the VDOM and DOM are in sync (only applies to `miso` function)
 
 -- | Updates model, optionally introduces side effects
 updateModel :: Action -> Model -> Effect Action Model
@@ -342,6 +343,7 @@ main = startApp App {..}
     events = defaultEvents        -- default delegated events
     subs   = []                   -- empty subscription list
     mountPoint = Nothing          -- mount point for application (Nothing defaults to 'body')
+    debug = False                 -- used during prerendering to see if the VDOM and DOM are in sync (only applies to `miso` function)
 
 -- | Updates model, optionally introduces side effects
 updateModel :: Action -> Transition Action Model ()

--- a/examples/canvas2d/Main.hs
+++ b/examples/canvas2d/Main.hs
@@ -35,7 +35,7 @@ main = do
     subs   = []
     events = defaultEvents
     mountPoint = Nothing -- default to body
-    debug = False
+    logLevel = Off
 
 updateModel
   :: (Image,Image,Image)

--- a/examples/canvas2d/Main.hs
+++ b/examples/canvas2d/Main.hs
@@ -35,6 +35,7 @@ main = do
     subs   = []
     events = defaultEvents
     mountPoint = Nothing -- default to body
+    debug = False
 
 updateModel
   :: (Image,Image,Image)

--- a/examples/compose-update/Main.hs
+++ b/examples/compose-update/Main.hs
@@ -97,6 +97,7 @@ main = startApp App { initialAction = NoOp, ..}
     events = defaultEvents
     subs   = []
     mountPoint = Nothing
+    debug = True
 
 viewModel :: Model -> View Action
 viewModel (x, y) =

--- a/examples/compose-update/Main.hs
+++ b/examples/compose-update/Main.hs
@@ -97,7 +97,7 @@ main = startApp App { initialAction = NoOp, ..}
     events = defaultEvents
     subs   = []
     mountPoint = Nothing
-    debug = True
+    logLevel = Off
 
 viewModel :: Model -> View Action
 viewModel (x, y) =

--- a/examples/file-reader/Main.hs
+++ b/examples/file-reader/Main.hs
@@ -40,6 +40,7 @@ main = do
       events = defaultEvents
       subs   = []
       view   = viewModel
+      debug  = False
 
 -- | Update your model
 updateModel :: Action -> Model -> Effect Action Model

--- a/examples/file-reader/Main.hs
+++ b/examples/file-reader/Main.hs
@@ -40,7 +40,7 @@ main = do
       events = defaultEvents
       subs   = []
       view   = viewModel
-      debug  = False
+      logLevel = Off
 
 -- | Update your model
 updateModel :: Action -> Model -> Effect Action Model

--- a/examples/haskell-miso.org/client/Main.hs
+++ b/examples/haskell-miso.org/client/Main.hs
@@ -19,6 +19,7 @@ main = miso $ \currentURI -> App
       update = updateModel
       events = defaultEvents
       subs = [ uriSub HandleURI ]
+      debug = True
       viewModel m =
         case runRoute (Proxy :: Proxy ClientRoutes) handlers uri m of
           Left _ -> the404 m

--- a/examples/haskell-miso.org/client/Main.hs
+++ b/examples/haskell-miso.org/client/Main.hs
@@ -19,7 +19,7 @@ main = miso $ \currentURI -> App
       update = updateModel
       events = defaultEvents
       subs = [ uriSub HandleURI ]
-      debug = True
+      logLevel = DebugPrerender
       viewModel m =
         case runRoute (Proxy :: Proxy ClientRoutes) handlers uri m of
           Left _ -> the404 m

--- a/examples/mario/Main.hs
+++ b/examples/mario/Main.hs
@@ -66,7 +66,7 @@ main = runApp $ do
              , windowCoordsSub WindowCoords
              ]
     mountPoint = Nothing
-    debug = True
+    logLevel = Off
 
 data Model = Model
     { x :: !Double

--- a/examples/mario/Main.hs
+++ b/examples/mario/Main.hs
@@ -66,6 +66,7 @@ main = runApp $ do
              , windowCoordsSub WindowCoords
              ]
     mountPoint = Nothing
+    debug = True
 
 data Model = Model
     { x :: !Double

--- a/examples/mathml/Main.hs
+++ b/examples/mathml/Main.hs
@@ -28,6 +28,7 @@ main = startApp App {..}
     events = defaultEvents        -- default delegated events
     subs   = []                   -- empty subscription list
     mountPoint = Nothing          -- mount point for application (Nothing defaults to 'body')
+    debug = False
 
 -- | Updates model, optionally introduces side effects
 updateModel :: Action -> Model -> Effect Action Model

--- a/examples/mathml/Main.hs
+++ b/examples/mathml/Main.hs
@@ -28,7 +28,7 @@ main = startApp App {..}
     events = defaultEvents        -- default delegated events
     subs   = []                   -- empty subscription list
     mountPoint = Nothing          -- mount point for application (Nothing defaults to 'body')
-    debug = False
+    logLevel = Off
 
 -- | Updates model, optionally introduces side effects
 updateModel :: Action -> Model -> Effect Action Model

--- a/examples/router/Main.hs
+++ b/examples/router/Main.hs
@@ -55,6 +55,7 @@ main =
     subs   = [ uriSub HandleURI ]
     view   = viewModel
     mountPoint = Nothing
+    debug = True
 
 -- | Update your model
 updateModel :: Action -> Model -> Effect Action Model

--- a/examples/router/Main.hs
+++ b/examples/router/Main.hs
@@ -55,7 +55,7 @@ main =
     subs   = [ uriSub HandleURI ]
     view   = viewModel
     mountPoint = Nothing
-    debug = True
+    logLevel = Off
 
 -- | Update your model
 updateModel :: Action -> Model -> Effect Action Model

--- a/examples/sse/client/Main.hs
+++ b/examples/sse/client/Main.hs
@@ -24,6 +24,7 @@ main = do
              , uriSub HandleURI
              ]
     mountPoint = Nothing
+    debug = False
 
 handleSseMsg :: SSE String -> Action
 handleSseMsg (SSEMessage msg) = ServerMsg msg

--- a/examples/sse/client/Main.hs
+++ b/examples/sse/client/Main.hs
@@ -24,7 +24,7 @@ main = do
              , uriSub HandleURI
              ]
     mountPoint = Nothing
-    debug = False
+    logLevel = Off
 
 handleSseMsg :: SSE String -> Action
 handleSseMsg (SSEMessage msg) = ServerMsg msg

--- a/examples/svg/Main.hs
+++ b/examples/svg/Main.hs
@@ -25,7 +25,7 @@ main = startApp App {..}
                     M.insert (pack "touchstart") False $
                     M.insert (pack "touchmove") False defaultEvents
     subs          = [ mouseSub HandleMouse ]
-    debug         = False
+    logLevel      = Off
     mountPoint    = Nothing
 
 emptyModel :: Model

--- a/examples/svg/Main.hs
+++ b/examples/svg/Main.hs
@@ -25,6 +25,7 @@ main = startApp App {..}
                     M.insert (pack "touchstart") False $
                     M.insert (pack "touchmove") False defaultEvents
     subs          = [ mouseSub HandleMouse ]
+    debug         = False
     mountPoint    = Nothing
 
 emptyModel :: Model

--- a/examples/three/Main.hs
+++ b/examples/three/Main.hs
@@ -59,6 +59,7 @@ main = do
                , initialAction = Init
                , update = updateModel ref
                , mountPoint = Nothing
+               , debug = False
                , ..
                }
     where

--- a/examples/three/Main.hs
+++ b/examples/three/Main.hs
@@ -59,7 +59,7 @@ main = do
                , initialAction = Init
                , update = updateModel ref
                , mountPoint = Nothing
-               , debug = False
+               , logLevel = Off
                , ..
                }
     where

--- a/examples/todo-mvc/Main.hs
+++ b/examples/todo-mvc/Main.hs
@@ -101,6 +101,7 @@ main = runApp $ startApp App { initialAction = NoOp, ..}
     events     = defaultEvents
     mountPoint = Nothing
     subs       = []
+    debug      = False
 
 updateModel :: Msg -> Model -> Effect Msg Model
 updateModel NoOp m = noEff m

--- a/examples/todo-mvc/Main.hs
+++ b/examples/todo-mvc/Main.hs
@@ -101,7 +101,7 @@ main = runApp $ startApp App { initialAction = NoOp, ..}
     events     = defaultEvents
     mountPoint = Nothing
     subs       = []
-    debug      = False
+    logLevel   = Off
 
 updateModel :: Msg -> Model -> Effect Msg Model
 updateModel NoOp m = noEff m

--- a/examples/websocket/Main.hs
+++ b/examples/websocket/Main.hs
@@ -44,6 +44,7 @@ main = runApp $ startApp App { initialAction = Id, ..}
     uri = URL "wss://echo.websocket.org"
     protocols = Protocols [ ]
     mountPoint = Nothing
+    debug = False
 
 updateModel :: Action -> Model -> Effect Action Model
 updateModel (HandleWebSocket (WebSocketMessage (Message m))) model

--- a/examples/websocket/Main.hs
+++ b/examples/websocket/Main.hs
@@ -44,7 +44,7 @@ main = runApp $ startApp App { initialAction = Id, ..}
     uri = URL "wss://echo.websocket.org"
     protocols = Protocols [ ]
     mountPoint = Nothing
-    debug = False
+    logLevel = Off
 
 updateModel :: Action -> Model -> Effect Action Model
 updateModel (HandleWebSocket (WebSocketMessage (Message m))) model

--- a/examples/xhr/Main.hs
+++ b/examples/xhr/Main.hs
@@ -42,6 +42,7 @@ main = do
       events = defaultEvents
       subs   = []
       view   = viewModel
+      debug  = False
 
 -- | Update your model
 updateModel :: Action -> Model -> Effect Action Model

--- a/examples/xhr/Main.hs
+++ b/examples/xhr/Main.hs
@@ -42,7 +42,7 @@ main = do
       events = defaultEvents
       subs   = []
       view   = viewModel
-      debug  = False
+      logLevel = Off
 
 -- | Update your model
 updateModel :: Action -> Model -> Effect Action Model

--- a/exe/Main.hs
+++ b/exe/Main.hs
@@ -46,7 +46,7 @@ main = runApp $ miso $ \_ -> App {..}
     events = defaultEvents        -- default delegated events
     subs   = []                   -- empty subscription list
     mountPoint = Nothing          -- mount point for application (Nothing defaults to 'body')
-    debug = True                  -- Used to copy DOM into VDOM, applies only to `miso` function
+    debug = False                 -- Used to copy DOM into VDOM, applies only to `miso` function
 
 -- | Updates model, optionally introduces side effects
 updateModel :: Action -> Model -> Effect Action Model

--- a/exe/Main.hs
+++ b/exe/Main.hs
@@ -46,7 +46,7 @@ main = runApp $ miso $ \_ -> App {..}
     events = defaultEvents        -- default delegated events
     subs   = []                   -- empty subscription list
     mountPoint = Nothing          -- mount point for application (Nothing defaults to 'body')
-    debug = False                 -- Used to copy DOM into VDOM, applies only to `miso` function
+    logLevel = Off                -- Used to copy DOM into VDOM, applies only to `miso` function
 
 -- | Updates model, optionally introduces side effects
 updateModel :: Action -> Model -> Effect Action Model

--- a/exe/Main.hs
+++ b/exe/Main.hs
@@ -37,7 +37,7 @@ data Action
 
 -- | Entry point for a miso application
 main :: IO ()
-main = runApp $ startApp App {..}
+main = runApp $ miso $ \_ -> App {..}
   where
     initialAction = SayHelloWorld -- initial action to be executed on application load
     model  = 0                    -- initial model
@@ -46,6 +46,7 @@ main = runApp $ startApp App {..}
     events = defaultEvents        -- default delegated events
     subs   = []                   -- empty subscription list
     mountPoint = Nothing          -- mount point for application (Nothing defaults to 'body')
+    debug = True                  -- Used to copy DOM into VDOM, applies only to `miso` function
 
 -- | Updates model, optionally introduces side effects
 updateModel :: Action -> Model -> Effect Action Model

--- a/frontend-src/Miso.hs
+++ b/frontend-src/Miso.hs
@@ -139,7 +139,7 @@ miso f = do
     VTree (OI.Object iv) <- flip runView writeEvent initialView
     mountEl <- mountElement mountPoint
     -- Initial diff can be bypassed, just copy DOM into VTree
-    copyDOMIntoVTree debug mountEl iv
+    copyDOMIntoVTree (logLevel == DebugPrerender) mountEl iv
     let initialVTree = VTree (OI.Object iv)
     -- Create virtual dom, perform initial diff
     liftIO (newIORef initialVTree)

--- a/frontend-src/Miso.hs
+++ b/frontend-src/Miso.hs
@@ -139,7 +139,7 @@ miso f = do
     VTree (OI.Object iv) <- flip runView writeEvent initialView
     mountEl <- mountElement mountPoint
     -- Initial diff can be bypassed, just copy DOM into VTree
-    copyDOMIntoVTree mountEl iv
+    copyDOMIntoVTree debug mountEl iv
     let initialVTree = VTree (OI.Object iv)
     -- Create virtual dom, perform initial diff
     liftIO (newIORef initialVTree)

--- a/frontend-src/Miso/Html/Internal.hs
+++ b/frontend-src/Miso/Html/Internal.hs
@@ -131,7 +131,6 @@ node ns tag key attrs kids = View $ \sink -> do
   set "key" key vnode
   setAttrs vnode sink
   flip (set "children") vnode
-    =<< collapseSiblingTextNodes
     =<< ghcjsPure . jsval
     =<< setKids sink
   pure $ VTree vnode

--- a/frontend-src/Miso/Html/Internal.hs
+++ b/frontend-src/Miso/Html/Internal.hs
@@ -130,7 +130,10 @@ node ns tag key attrs kids = View $ \sink -> do
   set "tag" tag vnode
   set "key" key vnode
   setAttrs vnode sink
-  flip (set "children") vnode =<< ghcjsPure . jsval =<< setKids sink
+  flip (set "children") vnode
+    =<< collapseSiblingTextNodes
+    =<< ghcjsPure . jsval
+    =<< setKids sink
   pure $ VTree vnode
     where
       setAttrs vnode sink =

--- a/frontend-src/Miso/Types.hs
+++ b/frontend-src/Miso/Types.hs
@@ -9,6 +9,7 @@
 ----------------------------------------------------------------------------
 module Miso.Types
   ( App (..)
+  , LogLevel (..)
   , Effect
   , Sub
 
@@ -53,9 +54,15 @@ data App model action = App
   -- ^ Initial action that is run after the application has loaded
   , mountPoint :: Maybe MisoString
   -- ^ Id of the root element for DOM diff. If 'Nothing' is provided, the entire document body is used as a mount point.
-  , debug :: Bool
+  , logLevel :: LogLevel
   -- ^ Display warning messages when prerendering if the DOM and VDOM are not in sync.
   }
+
+-- | Optional Logging for debugging miso internals (useful to see if prerendering is successful)
+data LogLevel
+  = Off
+  | DebugPrerender
+  deriving (Show, Eq)
 
 -- | A monad for succinctly expressing model transitions in the 'update' function.
 --

--- a/frontend-src/Miso/Types.hs
+++ b/frontend-src/Miso/Types.hs
@@ -53,6 +53,8 @@ data App model action = App
   -- ^ Initial action that is run after the application has loaded
   , mountPoint :: Maybe MisoString
   -- ^ Id of the root element for DOM diff. If 'Nothing' is provided, the entire document body is used as a mount point.
+  , debug :: Bool
+  -- ^ Display warning messages when prerendering if the DOM and VDOM are not in sync.
   }
 
 -- | A monad for succinctly expressing model transitions in the 'update' function.

--- a/ghc-src/Miso/Html/Internal.hs
+++ b/ghc-src/Miso/Html/Internal.hs
@@ -124,7 +124,7 @@ instance L.ToHtml (VTree action) where
 collapseSiblingTextNodes :: [VTree a] -> [VTree a]
 collapseSiblingTextNodes [] = []
 collapseSiblingTextNodes (VText x : VText y : xs) =
-  collapseSiblingTextNodes (VText (x <> " " <> y) : xs)
+  collapseSiblingTextNodes (VText (x <> y) : xs)
 collapseSiblingTextNodes (x:xs) =
   x : collapseSiblingTextNodes xs
 

--- a/ghc-src/Miso/Html/Internal.hs
+++ b/ghc-src/Miso/Html/Internal.hs
@@ -114,7 +114,19 @@ instance L.ToHtml (VTree action) where
                      , "autocomplete"
                      ]
         toTag = T.toLower
-        kids = foldMap L.toHtml vChildren
+        kids
+          = foldMap L.toHtml
+          . V.fromList
+          . collapseSiblingTextNodes
+          . V.toList
+          $ vChildren
+
+collapseSiblingTextNodes :: [VTree a] -> [VTree a]
+collapseSiblingTextNodes [] = []
+collapseSiblingTextNodes (VText x : VText y : xs) =
+  collapseSiblingTextNodes (VText (x <> " " <> y) : xs)
+collapseSiblingTextNodes (x:xs) =
+  x : collapseSiblingTextNodes xs
 
 -- | Helper for turning JSON into Text
 -- Object, Array and Null are kind of non-sensical here

--- a/ghcjs-ffi/Miso/FFI.hs
+++ b/ghcjs-ffi/Miso/FFI.hs
@@ -50,7 +50,6 @@ module Miso.FFI
    , delegateEvent
 
    , copyDOMIntoVTree
-   , collapseSiblingTextNodes
 
    , swapCallbacks
    , releaseCallbacks
@@ -121,10 +120,6 @@ foreign import javascript unsafe "$1.stopPropagation();"
 
 foreign import javascript unsafe "$1.preventDefault();"
     eventPreventDefault :: JSVal -> IO ()
-
--- | Collapse sibling text nodes into a single text node.
-foreign import javascript unsafe "$r = window['collapseSiblingTextNodes']($1);"
-    collapseSiblingTextNodes :: JSVal -> IO JSVal
 
 -- | Window object
 foreign import javascript unsafe "$r = window;"

--- a/ghcjs-ffi/Miso/FFI.hs
+++ b/ghcjs-ffi/Miso/FFI.hs
@@ -50,6 +50,7 @@ module Miso.FFI
    , delegateEvent
 
    , copyDOMIntoVTree
+   , collapseSiblingTextNodes
 
    , swapCallbacks
    , releaseCallbacks
@@ -121,6 +122,9 @@ foreign import javascript unsafe "$1.stopPropagation();"
 foreign import javascript unsafe "$1.preventDefault();"
     eventPreventDefault :: JSVal -> IO ()
 
+-- | Collapse sibling text nodes into a single text node.
+foreign import javascript unsafe "$r = window['collapseSiblingTextNodes']($1);"
+    collapseSiblingTextNodes :: JSVal -> IO JSVal
 
 -- | Window object
 foreign import javascript unsafe "$r = window;"

--- a/ghcjs-ffi/Miso/FFI.hs
+++ b/ghcjs-ffi/Miso/FFI.hs
@@ -241,9 +241,10 @@ foreign import javascript unsafe "$1($2);"
 
 -- | Copies DOM pointers into virtual dom
 -- entry point into isomorphic javascript
-foreign import javascript unsafe "window['copyDOMIntoVTree']($1, $2);"
+foreign import javascript unsafe "window['copyDOMIntoVTree']($1, $2, $3);"
   copyDOMIntoVTree
-    :: JSVal -- ^ mountPoint element of the isomorphic app
+    :: Bool  -- ^ Display debugging information when pre-rendering
+    -> JSVal -- ^ mountPoint element of the isomorphic app
     -> JSVal -- ^ VDom object
     -> IO ()
 

--- a/jsaddle-ffi/Miso/FFI.hs
+++ b/jsaddle-ffi/Miso/FFI.hs
@@ -41,7 +41,6 @@ module Miso.FFI
    , jsStringToDouble
    , delegateEvent
    , copyDOMIntoVTree
-   , collapseSiblingTextNodes
    , swapCallbacks
    , releaseCallbacks
    , registerCallback
@@ -225,10 +224,6 @@ delegateEvent' mountPoint events cb = () <$ jsg3 "delegate" mountPoint events cb
 -- entry point into isomorphic javascript
 copyDOMIntoVTree :: JSVal -> JSVal -> JSM ()
 copyDOMIntoVTree mountPoint a = () <$ jsg2 "copyDOMIntoVTree" mountPoint a
-
--- | Collapses sibling text nodes
-collapseSiblingTextNodes :: JSVal -> JSM JSVal
-collapseSiblingTextNodes = jsg1 "collapseSiblingTextNodes"
 
 -- TODO For now, we do not free callbacks when compiling with JSaddle
 

--- a/jsaddle-ffi/Miso/FFI.hs
+++ b/jsaddle-ffi/Miso/FFI.hs
@@ -222,8 +222,8 @@ delegateEvent' mountPoint events cb = () <$ jsg3 "delegate" mountPoint events cb
 
 -- | Copies DOM pointers into virtual dom
 -- entry point into isomorphic javascript
-copyDOMIntoVTree :: JSVal -> JSVal -> JSM ()
-copyDOMIntoVTree mountPoint a = () <$ jsg2 "copyDOMIntoVTree" mountPoint a
+copyDOMIntoVTree :: Bool -> JSVal -> JSVal -> JSM ()
+copyDOMIntoVTree debug mountPoint a = () <$ jsg3 "copyDOMIntoVTree" debug mountPoint a
 
 -- TODO For now, we do not free callbacks when compiling with JSaddle
 

--- a/jsaddle-ffi/Miso/FFI.hs
+++ b/jsaddle-ffi/Miso/FFI.hs
@@ -223,7 +223,7 @@ delegateEvent' mountPoint events cb = () <$ jsg3 "delegate" mountPoint events cb
 -- | Copies DOM pointers into virtual dom
 -- entry point into isomorphic javascript
 copyDOMIntoVTree :: Bool -> JSVal -> JSVal -> JSM ()
-copyDOMIntoVTree debug mountPoint a = () <$ jsg3 "copyDOMIntoVTree" debug mountPoint a
+copyDOMIntoVTree logLevel mountPoint a = () <$ jsg3 "copyDOMIntoVTree" logLevel mountPoint a
 
 -- TODO For now, we do not free callbacks when compiling with JSaddle
 

--- a/jsaddle-ffi/Miso/FFI.hs
+++ b/jsaddle-ffi/Miso/FFI.hs
@@ -18,16 +18,12 @@ module Miso.FFI
    , objectToJSVal
    , ghcjsPure
    , syncPoint
-
    , addEventListener
    , windowAddEventListener
-
    , windowInnerHeight
    , windowInnerWidth
-
    , eventPreventDefault
    , eventStopPropagation
-
    , now
    , consoleLog
    , consoleLogJSVal
@@ -40,19 +36,15 @@ module Miso.FFI
    , getDoc
    , getElementById
    , diff'
-
    , integralToJSString
    , realFloatToJSString
    , jsStringToDouble
-
    , delegateEvent
-
    , copyDOMIntoVTree
-
+   , collapseSiblingTextNodes
    , swapCallbacks
    , releaseCallbacks
    , registerCallback
-
    , focus
    , blur
    , scrollIntoView
@@ -233,6 +225,10 @@ delegateEvent' mountPoint events cb = () <$ jsg3 "delegate" mountPoint events cb
 -- entry point into isomorphic javascript
 copyDOMIntoVTree :: JSVal -> JSVal -> JSM ()
 copyDOMIntoVTree mountPoint a = () <$ jsg2 "copyDOMIntoVTree" mountPoint a
+
+-- | Collapses sibling text nodes
+collapseSiblingTextNodes :: JSVal -> JSM JSVal
+collapseSiblingTextNodes = jsg1 "collapseSiblingTextNodes"
 
 -- TODO For now, we do not free callbacks when compiling with JSaddle
 

--- a/jsbits/isomorphic.js
+++ b/jsbits/isomorphic.js
@@ -1,4 +1,17 @@
 window = typeof window === 'undefined' ? {} : window;
+window['collapseSiblingTextNodes'] = function collapseSiblingTextNodes(vs) {
+  if (!vs) { return []; }
+  var ax = 0, adjusted = vs.length > 0 ? [vs[0]] : [];
+  for (var ix = 1; ix < vs.length; ix++) {
+    if (adjusted[ax]['type'] === 'vtext' && vs[ix]['type'] === 'vtext') {
+	adjusted[ax]['text'] += vs[ix]['text'];
+	continue;
+    }
+    adjusted[++ax] = vs[ix];
+  }
+  return adjusted;
+}
+
 window['copyDOMIntoVTree'] = function copyDOMIntoVTree(mountPoint, vtree, doc) {
   if (!doc) { doc = window.document; }
   var node = mountPoint ? mountPoint.firstChild : doc.body.firstChild;

--- a/jsbits/isomorphic.js
+++ b/jsbits/isomorphic.js
@@ -24,7 +24,9 @@ window['copyDOMIntoVTree'] = function copyDOMIntoVTree(debug,mountPoint, vtree, 
     window['diff'](null, vtree, node.parentNode, doc);
     return false;
   }
-  console.info ('Successfully prendered page');
+  if (debug) {
+    console.info ('Successfully prendered page');
+  }
   return true;
 }
 

--- a/jsbits/isomorphic.js
+++ b/jsbits/isomorphic.js
@@ -14,7 +14,12 @@ window['collapseSiblingTextNodes'] = function collapseSiblingTextNodes(vs) {
 
 window['copyDOMIntoVTree'] = function copyDOMIntoVTree(debug,mountPoint, vtree, doc) {
   if (!doc) { doc = window.document; }
-  var node = mountPoint ? mountPoint.firstChild : doc.body.firstChild;
+  var mountChildIdx = 0;
+  // If script tags are rendered first in body, skip them.
+  while (mountPoint && mountPoint.childNodes && mountPoint.childNodes[mountChildIdx].localName === 'script'){
+    mountChildIdx++;
+  }
+  var node = mountPoint && mountPoint.childNodes ? mountPoint.childNodes [mountChildIdx] : doc.body.firstChild;
     if (!window['walk'](debug,vtree, node, doc)) {
     if (debug) {
       console.warn('Could not copy DOM into virtual DOM, falling back to diff');

--- a/jsbits/isomorphic.js
+++ b/jsbits/isomorphic.js
@@ -47,19 +47,19 @@ window['walk'] = function walk(vtree, node, doc) {
     vdomChild = vtree['children'][i];
     domChild = node.childNodes[i];
       if (!domChild) {
-	  window['diagnoseError'](vdomchild, domChild);
+	  window['diagnoseError'](vdomChild, domChild);
 	  return false;
       }
     if (vdomChild.type === 'vtext') {
         if (domChild.nodeType !== Node.TEXT_NODE) {
-  	    window['diagnoseError'](vdomchild, domChild);
+  	    window['diagnoseError'](vdomChild, domChild);
 	    return false;
 	}
 
         if (vdomChild['text'] === domChild.textContent) {
           vdomChild['domRef'] = domChild;
         } else {
-	  window['diagnoseError'](vdomchild, domChild);
+	  window['diagnoseError'](vdomChild, domChild);
           return false;
 	}
     } else {
@@ -72,7 +72,7 @@ window['walk'] = function walk(vtree, node, doc) {
   // After walking the sizes of VDom and DOM should be equal
   // Otherwise there are DOM nodes unaccounted for
   if (vtree.children.length !== node.childNodes.length) {
-     window['diagnoseError'](vdomchild, domChild);
+     window['diagnoseError'](vdomChild, domChild);
      return false;
   }
   return true;

--- a/jsbits/isomorphic.js
+++ b/jsbits/isomorphic.js
@@ -12,7 +12,7 @@ window['collapseSiblingTextNodes'] = function collapseSiblingTextNodes(vs) {
   return adjusted;
 }
 
-window['copyDOMIntoVTree'] = function copyDOMIntoVTree(debug,mountPoint, vtree, doc) {
+window['copyDOMIntoVTree'] = function copyDOMIntoVTree(logLevel,mountPoint, vtree, doc) {
   if (!doc) { doc = window.document; }
     var mountChildIdx = 0, node;
     // If script tags are rendered first in body, skip them.
@@ -31,8 +31,8 @@ window['copyDOMIntoVTree'] = function copyDOMIntoVTree(debug,mountPoint, vtree, 
 	node = mountPoint.childNodes[mountChildIdx];
     }
 
-    if (!window['walk'](debug,vtree, node, doc)) {
-    if (debug) {
+    if (!window['walk'](logLevel,vtree, node, doc)) {
+    if (logLevel) {
       console.warn('Could not copy DOM into virtual DOM, falling back to diff');
     }
     // Remove all children before rebuilding DOM
@@ -41,17 +41,17 @@ window['copyDOMIntoVTree'] = function copyDOMIntoVTree(debug,mountPoint, vtree, 
     window['populate'](null, vtree, doc);
     return false;
   }
-  if (debug) {
+  if (logLevel) {
     console.info ('Successfully prendered page');
   }
   return true;
 }
 
-window['diagnoseError'] = function diagnoseError(debug, vtree, node) {
-    if (debug) console.warn('VTree differed from node', vtree, node);
+window['diagnoseError'] = function diagnoseError(logLevel, vtree, node) {
+    if (logLevel) console.warn('VTree differed from node', vtree, node);
 }
 
-window['walk'] = function walk(debug, vtree, node, doc) {
+window['walk'] = function walk(logLevel, vtree, node, doc) {
   // This is slightly more complicated than one might expect since
   // browsers will collapse consecutive text nodes into a single text node.
   // There can thus be fewer DOM nodes than VDOM nodes.
@@ -68,32 +68,32 @@ window['walk'] = function walk(debug, vtree, node, doc) {
     vdomChild = vtree['children'][i];
     domChild = node.childNodes[i];
       if (!domChild) {
-	  window['diagnoseError'](debug,vdomChild, domChild);
+	  window['diagnoseError'](logLevel,vdomChild, domChild);
 	  return false;
       }
     if (vdomChild.type === 'vtext') {
         if (domChild.nodeType !== Node.TEXT_NODE) {
-  	    window['diagnoseError'](debug, vdomChild, domChild);
+  	    window['diagnoseError'](logLevel, vdomChild, domChild);
 	    return false;
 	}
 
         if (vdomChild['text'] === domChild.textContent) {
           vdomChild['domRef'] = domChild;
         } else {
-          window['diagnoseError'](debug, vdomChild, domChild);
+          window['diagnoseError'](logLevel, vdomChild, domChild);
           return false;
 	}
     } else {
       if (domChild.nodeType !== Node.ELEMENT_NODE) return false;
       vdomChild['domRef'] = domChild;
-      if(!window['walk'](debug, vdomChild, domChild, doc)) return false;
+      if(!window['walk'](logLevel, vdomChild, domChild, doc)) return false;
     }
 
   }
   // After walking the sizes of VDom and DOM should be equal
   // Otherwise there are DOM nodes unaccounted for
   if (vtree.children.length !== node.childNodes.length) {
-     window['diagnoseError'](debug, vdomChild, domChild);
+     window['diagnoseError'](logLevel, vdomChild, domChild);
      return false;
   }
   return true;

--- a/jsbits/isomorphic.js
+++ b/jsbits/isomorphic.js
@@ -51,6 +51,7 @@ window['walk'] = function walk(vtree, node, doc) {
 	}
     } else {
       if (domChild.nodeType !== Node.ELEMENT_NODE) return false;
+      vdomChild['domRef'] = domChild;
       window['walk'](vdomChild, domChild, doc);
     }
 

--- a/jsbits/isomorphic.js
+++ b/jsbits/isomorphic.js
@@ -48,7 +48,9 @@ window['walk'] = function walk(vtree, node, doc) {
 
         if (vdomChild['text'] === domChild.textContent) {
           vdomChild['domRef'] = domChild;
-        }
+        } else {
+          return false;
+	}
     } else {
       if (domChild.nodeType !== Node.ELEMENT_NODE) return false;
       window['walk'](vdomChild, domChild, doc);

--- a/jsbits/isomorphic.js
+++ b/jsbits/isomorphic.js
@@ -18,9 +18,7 @@ window['copyDOMIntoVTree'] = function copyDOMIntoVTree(mountPoint, vtree, doc) {
   if (!window['walk'](vtree, node, doc)) {
     console.warn('Could not copy DOM into virtual DOM, falling back to diff');
     // Remove all children before rebuilding DOM
-    while (node.firstChild)
-      node.removeChild(node.lastChild);
-    window['diff'](null, vtree, node, doc);
+    window['diff'](null, vtree, node.parentNode, doc);
     return false;
   }
   return true;

--- a/jsbits/isomorphic.js
+++ b/jsbits/isomorphic.js
@@ -25,6 +25,7 @@ window['walk'] = function walk(vtree, node, doc) {
   // Fire onCreated events as though the elements had just been created.
   window['callCreated'](vtree);
 
+  vtree.children = window['collapseSiblingTextNodes'](vtree.children);
   for (var i = 0; i < vtree.children.length; i++) {
     vdomChild = vtree['children'][i];
     domChild = node.childNodes[i];

--- a/jsbits/isomorphic.js
+++ b/jsbits/isomorphic.js
@@ -21,6 +21,9 @@ window['copyDOMIntoVTree'] = function copyDOMIntoVTree(debug,mountPoint, vtree, 
     }
     // Remove all children before rebuilding DOM
     while (node.firstChild) node.removeChild(node.lastChild);
+    // Move node to end since diffing begins at last node of mount point.
+    // No-op if no other nodes are children of body.
+    node.parentNode.appendChild (node);
     window['diff'](null, vtree, node.parentNode, doc);
     return false;
   }

--- a/jsbits/isomorphic.js
+++ b/jsbits/isomorphic.js
@@ -42,22 +42,12 @@ window['walk'] = function walk(vtree, node, doc) {
   for (var i = 0; i < vtree.children.length; i++) {
     vdomChild = vtree['children'][i];
     domChild = node.childNodes[i];
+    if (!domChild) return false;
     if (vdomChild.type === 'vtext') {
         if (domChild.nodeType !== Node.TEXT_NODE) return false;
 
         if (vdomChild['text'] === domChild.textContent) {
           vdomChild['domRef'] = domChild;
-        } else {
-          var len = vdomChild.text.length,
-              domNodeText = domChild.textContent.substring(0, len);
-          if (domNodeText !== vdomChild.text) return false;
-
-          // There are more VDOM nodes than DOM nodes
-          // Create new DOM node to ensure synchrony between VDom and DOM
-          var partialTxt = doc.createTextNode(domNodeText);
-          node.insertBefore(partialTxt, domChild);
-          vdomChild['domRef'] = partialTxt;
-          domChild.textContent = domChild.textContent.substring(len);
         }
     } else {
       if (domChild.nodeType !== Node.ELEMENT_NODE) return false;

--- a/jsbits/isomorphic.js
+++ b/jsbits/isomorphic.js
@@ -29,7 +29,8 @@ window['copyDOMIntoVTree'] = function copyDOMIntoVTree(debug,mountPoint, vtree, 
     // Move node to end since diffing begins at last node of mount point.
     // No-op if no other nodes are children of body.
     node.parentNode.appendChild (node);
-    window['diff'](null, vtree, node.parentNode, doc);
+    vtree['domRef'] = node;
+    window['diffVNodes'](null, vtree['children'], node, doc);
     return false;
   }
   if (debug) {

--- a/jsbits/isomorphic.js
+++ b/jsbits/isomorphic.js
@@ -88,13 +88,6 @@ window['walk'] = function walk(logLevel, vtree, node, doc) {
       vdomChild['domRef'] = domChild;
       if(!window['walk'](logLevel, vdomChild, domChild, doc)) return false;
     }
-
-  }
-  // After walking the sizes of VDom and DOM should be equal
-  // Otherwise there are DOM nodes unaccounted for
-  if (vtree.children.length !== node.childNodes.length) {
-     window['diagnoseError'](logLevel, vdomChild, domChild);
-     return false;
   }
   return true;
 }

--- a/jsbits/isomorphic.js
+++ b/jsbits/isomorphic.js
@@ -25,7 +25,7 @@ window['copyDOMIntoVTree'] = function copyDOMIntoVTree(logLevel,mountPoint, vtre
     } else if (mountPoint.childNodes.length === 0) {
 	node = mountPoint.appendChild (doc.createElement('div'));
     } else {
-	while (mountPoint.childNodes[mountChildIdx].localName === 'script' && mountPoint.childNodes[mountChildIdx].nodeType !== Node.TEXT_NODE){
+	while (mountPoint.childNodes[mountChildIdx].localName === 'script' || mountPoint.childNodes[mountChildIdx].nodeType === Node.TEXT_NODE){
 	  mountChildIdx++;
 	}
 	node = mountPoint.childNodes[mountChildIdx];

--- a/jsbits/util.js
+++ b/jsbits/util.js
@@ -12,3 +12,16 @@ window['callBlur'] = function callBlur(id) {
     if (ele && ele.blur) ele.blur()
   }, 50);
 }
+
+window['collapseSiblingTextNodes'] = function collapseSiblingTextNodes(vs) {
+  if (!vs) { return []; }
+  var ax = 0, adjusted = vs.length > 0 ? [vs[0]] : [];
+  for (var ix = 1; ix < vs.length; ix++) {
+    if (adjusted[ax]['type'] === 'vtext' && vs[ix]['type'] === 'vtext') {
+	adjusted[ax]['text'] += ' ' + vs[ix]['text'];
+	continue;
+    }
+    adjusted[++ax] = vs[ix];
+  }
+  return adjusted;
+}

--- a/jsbits/util.js
+++ b/jsbits/util.js
@@ -12,16 +12,3 @@ window['callBlur'] = function callBlur(id) {
     if (ele && ele.blur) ele.blur()
   }, 50);
 }
-
-window['collapseSiblingTextNodes'] = function collapseSiblingTextNodes(vs) {
-  if (!vs) { return []; }
-  var ax = 0, adjusted = vs.length > 0 ? [vs[0]] : [];
-  for (var ix = 1; ix < vs.length; ix++) {
-    if (adjusted[ax]['type'] === 'vtext' && vs[ix]['type'] === 'vtext') {
-	adjusted[ax]['text'] += vs[ix]['text'];
-	continue;
-    }
-    adjusted[++ax] = vs[ix];
-  }
-  return adjusted;
-}

--- a/jsbits/util.js
+++ b/jsbits/util.js
@@ -18,7 +18,7 @@ window['collapseSiblingTextNodes'] = function collapseSiblingTextNodes(vs) {
   var ax = 0, adjusted = vs.length > 0 ? [vs[0]] : [];
   for (var ix = 1; ix < vs.length; ix++) {
     if (adjusted[ax]['type'] === 'vtext' && vs[ix]['type'] === 'vtext') {
-	adjusted[ax]['text'] += ' ' + vs[ix]['text'];
+	adjusted[ax]['text'] += vs[ix]['text'];
 	continue;
     }
     adjusted[++ax] = vs[ix];

--- a/sample-app-jsaddle/Main.hs
+++ b/sample-app-jsaddle/Main.hs
@@ -50,7 +50,7 @@ main = runApp $ startApp App {..}
     events = defaultEvents        -- default delegated events
     subs   = []                   -- empty subscription list
     mountPoint = Nothing          -- mount point for application (Nothing defaults to 'body')
-    debug = False                 -- used during prerendering to see if the VDOM and DOM are in synch (only used with `miso` function)
+    logLevel = Off                -- used during prerendering to see if the VDOM and DOM are in synch (only used with `miso` function)
 
 -- | Updates model, optionally introduces side effects
 updateModel :: Action -> Model -> Effect Action Model

--- a/sample-app-jsaddle/Main.hs
+++ b/sample-app-jsaddle/Main.hs
@@ -50,6 +50,7 @@ main = runApp $ startApp App {..}
     events = defaultEvents        -- default delegated events
     subs   = []                   -- empty subscription list
     mountPoint = Nothing          -- mount point for application (Nothing defaults to 'body')
+    debug = False                 -- used during prerendering to see if the VDOM and DOM are in synch (only used with `miso` function)
 
 -- | Updates model, optionally introduces side effects
 updateModel :: Action -> Model -> Effect Action Model

--- a/sample-app/Main.hs
+++ b/sample-app/Main.hs
@@ -31,6 +31,7 @@ main = startApp App {..}
     events = defaultEvents        -- default delegated events
     subs   = []                   -- empty subscription list
     mountPoint = Nothing          -- mount point for application (Nothing defaults to 'body')
+    debug = False                 -- used during prerendering to see if the VDOM and DOM are in synch (only used with `miso` function)
 
 -- | Updates model, optionally introduces side effects
 updateModel :: Action -> Model -> Effect Action Model

--- a/sample-app/Main.hs
+++ b/sample-app/Main.hs
@@ -31,7 +31,7 @@ main = startApp App {..}
     events = defaultEvents        -- default delegated events
     subs   = []                   -- empty subscription list
     mountPoint = Nothing          -- mount point for application (Nothing defaults to 'body')
-    debug = False                 -- used during prerendering to see if the VDOM and DOM are in synch (only used with `miso` function)
+    logLevel = Off                -- used during prerendering to see if the VDOM and DOM are in synch (only used with `miso` function)
 
 -- | Updates model, optionally introduces side effects
 updateModel :: Action -> Model -> Effect Action Model

--- a/tests/diff.test.js
+++ b/tests/diff.test.js
@@ -906,6 +906,8 @@ test('Should copy DOM into VTree at mountPoint', () => {
     var document = new jsdom.JSDOM().window.document;
     var body = document.body;
     var unrelatedDiv = document.createElement("div");
+    body.appendChild(document.createElement("script"));
+    body.appendChild(document.createTextNode("test"));
     body.appendChild(unrelatedDiv);
     var unrelatedTxt = document.createTextNode("Not part of Miso app");
     unrelatedDiv.appendChild(unrelatedTxt);
@@ -921,6 +923,29 @@ test('Should copy DOM into VTree at mountPoint', () => {
     var succeeded = window['copyDOMIntoVTree'](true, misoDiv, currentNode, document);
     expect(currentNode.children[0].children[0].domRef).toEqual(txt);
     expect(succeeded).toEqual(true);
+});
+
+test('Should copy DOM into VTree at body w/ script / text siblings', () => {
+    var document = new jsdom.JSDOM().window.document;
+    var body = document.body;
+    var unrelatedDiv = document.createElement("div");
+    body.appendChild(document.createElement("script"));
+    body.appendChild(document.createTextNode("test"));
+    body.appendChild(unrelatedDiv);
+    var unrelatedTxt = document.createTextNode("Not part of Miso app");
+    unrelatedDiv.appendChild(unrelatedTxt);
+    var misoDiv = document.createElement("div");
+    body.appendChild(misoDiv);
+    var nestedDiv1 = document.createElement("div");
+    misoDiv.appendChild(nestedDiv1);
+    var nestedDiv2 = document.createElement("div");
+    nestedDiv1.appendChild(nestedDiv2);
+    var txt = document.createTextNode("foo");
+    nestedDiv2.appendChild(txt);
+    var currentNode = vnodeKids('div', [ vnodeKids('div', [ vtext("foo") ]) ]);
+    var succeeded = window['copyDOMIntoVTree'](true, body, currentNode, document);
+    expect(currentNode.children[0].children[0].domRef).toEqual(txt);
+    expect(succeeded).toEqual(false);
 });
 
 test('Should fail to mount on a text node', () => {

--- a/tests/diff.test.js
+++ b/tests/diff.test.js
@@ -823,7 +823,7 @@ test('Should copy simple nested DOM into VTree', () => {
     var txt = document.createTextNode("foo");
     nestedDiv.appendChild(txt);
     var currentNode = vnodeKids('div', [ vnodeKids('div', [ vtext("foo") ]) ]);
-    window['copyDOMIntoVTree'](body, currentNode, document);
+    window['copyDOMIntoVTree'](true, body, currentNode, document);
     expect(currentNode.children[0].children[0].text).toEqual('foo');
 });
 
@@ -835,7 +835,7 @@ test('Should fail because of expecting text node', () => {
     var nestedDiv = document.createElement("div");
     div.appendChild(nestedDiv);
     var currentNode = vnodeKids('div', [ vtext("foo") ]);
-    var res = window['copyDOMIntoVTree'](body, currentNode, document);
+    var res = window['copyDOMIntoVTree'](true, body, currentNode, document);
     expect(res).toEqual(false);
 });
 
@@ -847,7 +847,7 @@ test('Should fail because of expecting element', () => {
     var txt = document.createTextNode("foo");
     div.appendChild(txt);
     var currentNode = vnodeKids('div', [ vnode('div', []) ]);
-    var res = window['copyDOMIntoVTree'](body, currentNode, document);
+    var res = window['copyDOMIntoVTree'](true, body, currentNode, document);
     expect(res).toEqual(false);
 });
 
@@ -859,7 +859,7 @@ test('Should fail because of non-matching text', () => {
     var txt = document.createTextNode("foo");
     div.appendChild(txt);
     var currentNode = vnodeKids('div', [ vtext("bar") ]);
-    var res = window['copyDOMIntoVTree'](body, currentNode, document);
+    var res = window['copyDOMIntoVTree'](true, body, currentNode, document);
     expect(res).toEqual(false);
 });
 
@@ -871,7 +871,7 @@ test('Should fail because of non-matching DOM and VDOM', () => {
     var txt = document.createTextNode("foobar");
     div.appendChild(txt);
     var currentNode = vnodeKids('div', [ vtext("foo") ]);
-    var res = window['copyDOMIntoVTree'](body, currentNode, document);
+    var res = window['copyDOMIntoVTree'](true, body, currentNode, document);
     expect(res).toEqual(false);
 });
 
@@ -883,7 +883,7 @@ test('Should copy DOM into VTree with multiple consecutive text nodes and collap
     var txt = document.createTextNode("foobarbaz");
     div.appendChild(txt);
     var currentNode = vnodeKids('div', [ vtext("foo"), vtext("bar"), vtext("baz") ]);
-    window['copyDOMIntoVTree'](body, currentNode, document);
+    window['copyDOMIntoVTree'](true, body, currentNode, document);
     // Expect "foobarbaz" to be split up into three nodes in the DOM
     expect(div.childNodes[0].textContent).toEqual('foobarbaz');
 });
@@ -904,7 +904,7 @@ test('Should copy DOM into VTree at mountPoint', () => {
     var txt = document.createTextNode("foo");
     nestedDiv2.appendChild(txt);
     var currentNode = vnodeKids('div', [ vnodeKids('div', [ vtext("foo") ]) ]);
-    var succeeded = window['copyDOMIntoVTree'](misoDiv, currentNode, document);
+    var succeeded = window['copyDOMIntoVTree'](true, misoDiv, currentNode, document);
     expect(currentNode.children[0].children[0].domRef).toEqual(txt);
     expect(succeeded).toEqual(true);
 });

--- a/tests/diff.test.js
+++ b/tests/diff.test.js
@@ -875,7 +875,7 @@ test('Should fail because of non-matching DOM and VDOM', () => {
     expect(res).toEqual(false);
 });
 
-test('Should copy DOM into VTree with multiple consecutive text nodes', () => {
+test('Should copy DOM into VTree with multiple consecutive text nodes and collapse them', () => {
     var document = new jsdom.JSDOM().window.document;
     var body = document.body;
     var div = document.createElement("div");
@@ -885,9 +885,7 @@ test('Should copy DOM into VTree with multiple consecutive text nodes', () => {
     var currentNode = vnodeKids('div', [ vtext("foo"), vtext("bar"), vtext("baz") ]);
     window['copyDOMIntoVTree'](body, currentNode, document);
     // Expect "foobarbaz" to be split up into three nodes in the DOM
-    expect(div.childNodes[0].textContent).toEqual('foo');
-    expect(div.childNodes[1].textContent).toEqual('bar');
-    expect(div.childNodes[2].textContent).toEqual('baz');
+    expect(div.childNodes[0].textContent).toEqual('foobarbaz');
 });
 
 test('Should copy DOM into VTree at mountPoint', () => {

--- a/tests/diff.test.js
+++ b/tests/diff.test.js
@@ -888,6 +888,20 @@ test('Should copy DOM into VTree with multiple consecutive text nodes and collap
     expect(div.childNodes[0].textContent).toEqual('foobarbaz');
 });
 
+test('Should copy DOM into VTree with multiple consecutive text nodes and collapse them without mount point', () => {
+    var document = new jsdom.JSDOM().window.document;
+    var body = document.body;
+    var div = document.createElement("div");
+    body.appendChild(div);
+    var txt = document.createTextNode("foobarbaz");
+    div.appendChild(txt);
+    var currentNode = vnodeKids('div', [ vtext("foo"), vtext("bar"), vtext("baz"), vnodeKids('div',[]), vtext("foo"), vtext("bar"), vtext("baz"), ]);
+    window['copyDOMIntoVTree'](true, null, currentNode, document);
+    // Expect "foobarbaz" to be split up into three nodes in the DOM
+    expect(div.childNodes[0].textContent).toEqual('foobarbaz');
+    expect(div.childNodes[2].textContent).toEqual('foobarbaz');
+});
+
 test('Should copy DOM into VTree at mountPoint', () => {
     var document = new jsdom.JSDOM().window.document;
     var body = document.body;
@@ -907,4 +921,22 @@ test('Should copy DOM into VTree at mountPoint', () => {
     var succeeded = window['copyDOMIntoVTree'](true, misoDiv, currentNode, document);
     expect(currentNode.children[0].children[0].domRef).toEqual(txt);
     expect(succeeded).toEqual(true);
+});
+
+test('Should fail to mount on a text node', () => {
+    var document = new jsdom.JSDOM().window.document;
+    var body = document.body;
+    var misoTxt = document.createTextNode("foo");
+    body.appendChild(misoTxt);
+    var currentNode = vnodeKids('div', [ vnodeKids('div', [ vtext("foo") ]) ]);
+    var succeeded = window['copyDOMIntoVTree'](true, misoTxt, currentNode, document);
+    expect(succeeded).toEqual(false);
+});
+
+test('Should mount on an empty body', () => {
+    var document = new jsdom.JSDOM().window.document;
+    var body = document.body;
+    var currentNode = vnodeKids('div', [ vnodeKids('div', [ vtext("foo") ]) ]);
+    var succeeded = window['copyDOMIntoVTree'](true, null, currentNode, document);
+    expect(succeeded).toEqual(false);
 });


### PR DESCRIPTION
@niteria @FPtje @tysonzero 

This preserves the isomorphism between the DOM and HTML by normalizing both structures by collapsing sibling text nodes. It should* solve the "consecutive text node" problem during pre-rendering.

Solves #589 #520 .