### PR TITLE
Make miso+jsaddle work under Firefox

### DIFF
--- a/jsaddle-ffi/Miso/FFI.hs
+++ b/jsaddle-ffi/Miso/FFI.hs
@@ -220,7 +220,7 @@ jsStringToDouble = read . unpack
 
 delegateEvent :: JSVal -> JSVal -> JSM JSVal -> JSM ()
 delegateEvent mountPoint events getVTree = do
-  cb' <- function $ \_ _ [continuation] -> do
+  cb' <- asyncFunction $ \_ _ [continuation] -> do
     res <- getVTree
     _ <- call continuation global res
     pure ()


### PR DESCRIPTION
The github issue  #597 explains the rationale.
The gist is that sync functions don't work in jsaddle+Firefox and
miso doesn't need a sync function here, async is fine.