### PR TITLE
Add style_ and script_

### DIFF
--- a/frontend-src/Miso/Html/Internal.hs
+++ b/frontend-src/Miso/Html/Internal.hs
@@ -34,6 +34,7 @@ module Miso.Html.Internal (
   -- * Smart `View` constructors
   , node
   , text
+  , textRaw
   -- * Key patch internals
   , Key    (..)
   , ToKey  (..)
@@ -164,6 +165,10 @@ text t = View . const $ do
   set "type" ("vtext" :: JSString) vtree
   set "text" t vtree
   pure $ VTree vtree
+
+-- | For parity with server-side rendering. Don't use directly.
+textRaw :: MisoString -> View m
+textRaw = text
 
 -- | `IsString` instance
 instance IsString (View a) where

--- a/src/Miso/Html.hs
+++ b/src/Miso/Html.hs
@@ -34,7 +34,7 @@ module Miso.Html
    , module Miso.Html.Property
    ) where
 
-import Miso.Html.Element
+import Miso.Html.Element hiding (style_)
 import Miso.Html.Event
-import Miso.Html.Internal
+import Miso.Html.Internal hiding (textRaw)
 import Miso.Html.Property hiding (form_)

--- a/src/Miso/Html/Element.hs
+++ b/src/Miso/Html/Element.hs
@@ -51,7 +51,9 @@ module Miso.Html.Element
     , canvas_
     , math_
     , script_
+    , scriptRaw_
     , link_
+    , styleRaw_
     -- * Inputs
     , select_
     , option_
@@ -490,3 +492,9 @@ script_ = nodeHtml "script"
 -- | https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link
 link_ :: [Attribute action] -> View action
 link_ = flip (nodeHtml "link") []
+-- | https://developer.mozilla.org/en-US/docs/Web/HTML/Element/style
+styleRaw_ :: [Attribute action] -> MisoString -> View action
+styleRaw_ attrs rawText = node HTML "style" Nothing attrs [textRaw rawText]
+-- | https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script
+scriptRaw_ :: [Attribute action] -> MisoString -> View action
+scriptRaw_ attrs rawText = node HTML "script" Nothing attrs [textRaw rawText]

--- a/src/Miso/Html/Element.hs
+++ b/src/Miso/Html/Element.hs
@@ -489,8 +489,24 @@ q_ = nodeHtml "q"
 link_ :: [Attribute action] -> View action
 link_ = flip (nodeHtml "link") []
 -- | https://developer.mozilla.org/en-US/docs/Web/HTML/Element/style
+-- This takes the raw text to be put in the style tag.
+-- That means that if any part of the text is not trusted there's
+-- a potential CSS injection. Read more at
+-- https://owasp.org/www-project-web-security-testing-guide/latest/4-Web_Application_Security_Testing/11-Client_Side_Testing/05-Testing_for_CSS_Injection
+--
+-- You can also easily shoot yourself in the foot with something like:
+--
+--   style_ [] "</style>"
 style_ :: [Attribute action] -> MisoString -> View action
 style_ attrs rawText = node HTML "style" Nothing attrs [textRaw rawText]
 -- | https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script
+-- This takes the raw text to be put in the script tag.
+-- That means that if any part of the text is not trusted there's
+-- a potential JavaScript injection. Read more at
+-- https://owasp.org/www-community/attacks/xss/
+--
+-- You can also easily shoot yourself in the foot with something like:
+--
+--   script_ [] "</script>"
 script_ :: [Attribute action] -> MisoString -> View action
 script_ attrs rawText = node HTML "script" Nothing attrs [textRaw rawText]

--- a/src/Miso/Html/Element.hs
+++ b/src/Miso/Html/Element.hs
@@ -51,9 +51,8 @@ module Miso.Html.Element
     , canvas_
     , math_
     , script_
-    , scriptRaw_
     , link_
-    , styleRaw_
+    , Miso.Html.Element.style_
     -- * Inputs
     , select_
     , option_
@@ -486,15 +485,12 @@ u_ = nodeHtml "u"
 -- | https://developer.mozilla.org/en-US/docs/Web/HTML/Element/q
 q_ :: [Attribute action] -> [View action] -> View action
 q_ = nodeHtml "q"
--- | https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script
-script_ :: [Attribute action] -> [View action] -> View action
-script_ = nodeHtml "script"
 -- | https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link
 link_ :: [Attribute action] -> View action
 link_ = flip (nodeHtml "link") []
 -- | https://developer.mozilla.org/en-US/docs/Web/HTML/Element/style
-styleRaw_ :: [Attribute action] -> MisoString -> View action
-styleRaw_ attrs rawText = node HTML "style" Nothing attrs [textRaw rawText]
+style_ :: [Attribute action] -> MisoString -> View action
+style_ attrs rawText = node HTML "style" Nothing attrs [textRaw rawText]
 -- | https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script
-scriptRaw_ :: [Attribute action] -> MisoString -> View action
-scriptRaw_ attrs rawText = node HTML "script" Nothing attrs [textRaw rawText]
+script_ :: [Attribute action] -> MisoString -> View action
+script_ attrs rawText = node HTML "script" Nothing attrs [textRaw rawText]


### PR DESCRIPTION
This addresses #596

Test Plan: Run https://github.com/niteria/miso-isomorphic-example/tree/vtextraw
which uses style_ and script_.
The browser console prints "Successfully prendered page" with no errors.
Going between / and /flipped successfully toggles the color of the buttons.