### PR TITLE
Change Delegate Event to use Synchronous Function

### DIFF
--- a/jsaddle-ffi/Miso/FFI.hs
+++ b/jsaddle-ffi/Miso/FFI.hs
@@ -234,7 +234,7 @@ jsStringToDouble = read . unpack
 -- | Initialize event delegation from a mount point.
 delegateEvent :: JSVal -> JSVal -> JSM JSVal -> JSM ()
 delegateEvent mountPoint events getVTree = do
-  cb' <- asyncFunction $ \_ _ [continuation] -> do
+  cb' <- function $ \_ _ [continuation] -> do
     res <- getVTree
     _ <- call continuation global res
     pure ()


### PR DESCRIPTION
Async function breaks event prevent default and more in jsaddle mode. This changes the async function to a synchronous function.