### PR TITLE
Make config options in miso's pkgs instance configurable

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -6,6 +6,8 @@
 , system ? builtins.currentSystem
 , crossSystem ? null
 , crossOverlays ? []
+, allowBroken ? false
+, allowUnfree ? true
 }:
 let
   options =
@@ -17,7 +19,9 @@ let
         overlays
         system
         crossSystem
-        crossOverlays;
+        crossOverlays
+        allowBroken
+        allowUnfree;
     };
   pkgs = import ./nix options;
   armPkgs =

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -5,7 +5,8 @@ let
     url = "https://github.com/NixOS/nixpkgs/archive/${rev}.tar.gz";
     inherit sha256;
   };
-  config.allowUnfree = true;
+  config.allowUnfree = options.allowUnfree;
+  config.allowBroken = options.allowBroken;
   overlays = [ (import ./overlay.nix options) ] ++ options.overlays;
 in
   import nixpkgs


### PR DESCRIPTION
I have my own pkgs instance, then I want to use miso as part of my monorepo example. Since miso uses its own nixpkgs instance, my pkgs' config option is not recognized especially about `allowBroken` and `allowUnfree`. Be able to add these two options works in my case.