### PR TITLE
Add rawHtml node.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,5 +29,5 @@ jobs:
          signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
      - run: echo ${{matrix.os}}
      - run: nix-build -A pkgs.yarn default.nix && nix-env -i ./result
-     - run: nix-build --arg examples true
+     - run: nix-build
      - run: cd tests && yarn && yarn test

--- a/exe/Main.hs
+++ b/exe/Main.hs
@@ -62,4 +62,5 @@ viewModel x = div_ [] [
    button_ [ onClick AddOne ] [ text "+" ]
  , text (ms x)
  , button_ [ onClick SubtractOne ] [ text "-" ]
+ , rawHtml "<div><p>hey expandable!</div></p>"
  ]

--- a/ghcjs-src/Miso/String.hs
+++ b/ghcjs-src/Miso/String.hs
@@ -25,20 +25,22 @@ module Miso.String (
   ) where
 
 import           Data.Aeson
-import qualified Data.ByteString as B
-import qualified Data.ByteString.Lazy as BL
+import qualified Data.ByteString         as B
+import qualified Data.ByteString.Lazy    as BL
 import           Data.Char
 import           Data.JSString
+import qualified Data.JSString as JS
 import           Data.JSString.Text
 import           Data.Monoid
-import qualified Data.Text as T
-import qualified Data.Text.Encoding as T
-import qualified Data.Text.Lazy as LT
+import qualified Data.Text               as T
+import qualified Data.Text.Encoding      as T
+import qualified Data.Text.Lazy          as LT
 import qualified Data.Text.Lazy.Encoding as LT
-import           Prelude hiding (foldr)
+import           Prelude                 hiding (foldr)
+import           Text.StringLike         (StringLike(..))
 
 -- | String type swappable based on compiler
-type MisoString = JSString
+type MisoString = JS.JSString
 
 -- | `ToJSON` for `MisoString`
 instance ToJSON MisoString where
@@ -74,7 +76,7 @@ ms = toMisoString
 instance ToMisoString MisoString where
   toMisoString = id
 instance ToMisoString String where
-  toMisoString = pack
+  toMisoString = JS.pack
 instance ToMisoString T.Text where
   toMisoString = textToJSString
 instance ToMisoString LT.Text where
@@ -84,18 +86,18 @@ instance ToMisoString B.ByteString where
 instance ToMisoString BL.ByteString where
   toMisoString = toMisoString . LT.decodeUtf8
 instance ToMisoString Float where
-  toMisoString = pack . show
+  toMisoString = JS.pack . show
 instance ToMisoString Double where
-  toMisoString = pack . show
+  toMisoString = JS.pack . show
 instance ToMisoString Int where
-  toMisoString = pack . show
+  toMisoString = JS.pack . show
 instance ToMisoString Word where
-  toMisoString = pack . show
+  toMisoString = JS.pack . show
 
 instance FromMisoString MisoString where
   fromMisoStringEither = Right
 instance FromMisoString String where
-  fromMisoStringEither = Right . unpack
+  fromMisoStringEither = Right . JS.unpack
 instance FromMisoString T.Text where
   fromMisoStringEither = Right . textFromJSString
 instance FromMisoString LT.Text where
@@ -113,22 +115,33 @@ instance FromMisoString Int where
 instance FromMisoString Word where
   fromMisoStringEither = parseWord
 
-jsStringToDoubleEither :: JSString -> Either String Double
-jsStringToDoubleEither s = let d = read $ unpack s
+jsStringToDoubleEither :: JS.JSString -> Either String Double
+jsStringToDoubleEither s = let d = read $ JS.unpack s
                            in if isNaN d then Left "jsStringToDoubleEither: parse failed"
                                          else Right d
 
 
 parseWord   :: MisoString -> Either String Word
-parseWord s = case uncons s of
+parseWord s = case JS.uncons s of
                 Nothing     -> Left "parseWord: parse error"
-                Just (c,s') -> foldl' k (pDigit c) s'
+                Just (c,s') -> JS.foldl' k (pDigit c) s'
   where
     pDigit c | isDigit c = Right . fromIntegral . digitToInt $ c
              | otherwise = Left "parseWord: parse error"
     k ea c = (\a x -> 10*a + x) <$> ea <*> pDigit c
 
 parseInt   :: MisoString -> Either String Int
-parseInt s = case uncons s of
+parseInt s = case JS.uncons s of
                Just ('-',s') -> ((-1)*) . fromIntegral <$> parseWord s'
                _             ->           fromIntegral <$> parseWord s
+
+instance StringLike MisoString where
+  uncons = JS.uncons
+  toString = JS.unpack
+  fromChar = JS.singleton
+  strConcat = JS.concat
+  empty = JS.empty
+  strNull = JS.null
+  cons = JS.cons
+  append = JS.append
+  strMap = JS.map

--- a/miso.cabal
+++ b/miso.cabal
@@ -165,6 +165,7 @@ library
     network-uri,
     servant,
     servant-lucid,
+    tagsoup,
     text,
     transformers
   if impl(ghcjs) || flag (jsaddle)

--- a/src/Miso/FFI.hs
+++ b/src/Miso/FFI.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE ViewPatterns #-}
 {-# LANGUAGE LambdaCase #-}
@@ -54,12 +55,15 @@ module Miso.FFI
 import           Control.Concurrent
 import           Control.Monad.IO.Class
 import           Data.Aeson hiding (Object)
-import           Data.JSString (JSString)
 import qualified Data.JSString as JSS
 import           GHCJS.Marshal
 import           GHCJS.Types
 import qualified JavaScript.Object.Internal as OI
+#ifdef __GHCJS__
+import           Language.Javascript.JSaddle hiding (obj, val)
+#else
 import           Language.Javascript.JSaddle hiding (Success, obj, val)
+#endif
 import           Miso.String
 
 -- | Run given `JSM` action asynchronously, in a separate thread.

--- a/src/Miso/Subscription/WebSocket.hs
+++ b/src/Miso/Subscription/WebSocket.hs
@@ -39,7 +39,7 @@ import           Data.IORef
 import           Data.Maybe
 import           GHCJS.Marshal
 import           GHCJS.Foreign
-import           GHCJS.Types
+import           GHCJS.Types ()
 import           Prelude hiding (map)
 import           System.IO.Unsafe
 


### PR DESCRIPTION
This allows HTML to be fetched at runtime and rendered into the DOM, by way of the virtual DOM.

This works by accepting a raw string as HTML, then lexing it with `tagsoup` and parsing it w/ `parsec` into a `View a`. At this point `diff.js` takes over and constructs raw DOM nodes from the original HTML given.

```haskell
view = div_ [] [ rawHtml "<div>hey</div>" ]
```

will expand into

```haskell
view = div_ [] [ div_ [] [ "hey" ] ]
```

at runtime.