### PR TITLE
fix sample app .nix files for 1.7.1

### DIFF
--- a/sample-app-jsaddle/default.nix
+++ b/sample-app-jsaddle/default.nix
@@ -1,6 +1,5 @@
 with (import (builtins.fetchTarball {
-  url = "https://github.com/dmjio/miso/archive/ea25964565074e73d4052b56b60b6e101fa08bc5.tar.gz";
-  sha256 = "1yb9yvc0ln4yn1jk2k5kwwa1s32310abawz40yd8cqqkm1z7w6wg";
+  url = "https://github.com/dmjio/miso/archive/refs/tags/1.7.1.tar.gz";
 }) {});
 {
   dev = pkgs.haskell.packages.ghc865.callCabal2nix "app" ./. { miso = miso-jsaddle; };

--- a/sample-app-jsaddle/shell.nix
+++ b/sample-app-jsaddle/shell.nix
@@ -3,7 +3,7 @@ let
   reload-script = pkgs.writeScriptBin "reload" ''
       ${pkgs.haskell.packages.ghc865.ghcid}/bin/ghcid -c \
         '${pkgs.haskell.packages.ghc865.cabal-install}/bin/cabal new-repl' \
-        -T ':main'
+        -T ':run Main.main'
 '';
 in dev.env.overrideAttrs (old: {
   buildInputs = old.buildInputs ++ [reload-script];

--- a/sample-app/default.nix
+++ b/sample-app/default.nix
@@ -1,5 +1,4 @@
 with (import (builtins.fetchTarball {
-  url = "https://github.com/dmjio/miso/archive/ea25964565074e73d4052b56b60b6e101fa08bc5.tar.gz";
-  sha256 = "1yb9yvc0ln4yn1jk2k5kwwa1s32310abawz40yd8cqqkm1z7w6wg";
+  url = "https://github.com/dmjio/miso/archive/refs/tags/1.7.1.tar.gz";
 }) {});
 pkgs.haskell.packages.ghcjs.callCabal2nix "app" ./. {}


### PR DESCRIPTION
Hi, I just upgraded my Project (which I originally started based on sample-app-jsaddle) from 1.6 to 1.7.1 and noticed that, for me, the change to shell.nix resulted in an error like "could not find main" when I run nix-shell --run reload. The url and sha256 in default.nix was still pointing to a tarball for 1.6, so I had to fix that.

These files are what is working for me now.