### PR TITLE
Revert "Change Delegate Event to use Synchronous Function"

### DIFF
--- a/src/Miso/FFI.hs
+++ b/src/Miso/FFI.hs
@@ -240,7 +240,12 @@ jsStringToDouble = read . unpack
 -- | Initialize event delegation from a mount point.
 delegateEvent :: JSVal -> JSVal -> JSM JSVal -> JSM ()
 delegateEvent mountPoint events getVTree = do
+-- using asyncfunction on GHC causes an XHR request loop with JSaddle
+#ifdef __GHCJS__
+  cb' <- asyncFunction $ \_ _ [continuation] -> do
+#else
   cb' <- function $ \_ _ [continuation] -> do
+#endif
     res <- getVTree
     _ <- call continuation global res
     pure ()


### PR DESCRIPTION
This causes Firefox to spin indefinitely when using JSaddle.
Context: https://github.com/dmjio/miso/issues/597

Not sure why this was introduced again. Handling `e.preventDefault` or `e.stopPropagation` purely in JS would be best, but that's going to take more work than this fix.