### PR TITLE
Upgrade nixpkgs to version with fixed ghcjs

### DIFF
--- a/nix/nixpkgs.json
+++ b/nix/nixpkgs.json
@@ -1,4 +1,4 @@
 {
-  "rev" : "4dd5c93998da55002fdec1c715c680531420381c",
-  "sha256" : "06paxakic36nbdnwkkb1094fzp3lpzxxb1r57gmb3py6pb6xrcnh"
+  "rev" : "868282b4aa56a01ef9306d2c7cfdddf14a4d89f7",
+  "sha256" : "1712zds1gns0zpkc2apw2fy60fdyfp84gz6qh2m9l7np5dcw6m5h"
 }


### PR DESCRIPTION
Currently points to our nixpkgs fork with a `https://` ghcjs URL instead of a non-working `git://` URL. Technically can cheekily be switched back to non-fork as long as it's been well cached to avoid depending on a fork.