### PR TITLE
Fix GHC build with `text >=1.2.5`

### DIFF
--- a/src/Miso/FFI.hs
+++ b/src/Miso/FFI.hs
@@ -64,7 +64,7 @@ import           Language.Javascript.JSaddle hiding (obj, val)
 #else
 import           Language.Javascript.JSaddle hiding (Success, obj, val)
 #endif
-import           Miso.String
+import           Miso.String hiding (elem)
 
 -- | Run given `JSM` action asynchronously, in a separate thread.
 forkJSM :: JSM () -> JSM ()

--- a/src/Miso/Html/Types.hs
+++ b/src/Miso/Html/Types.hs
@@ -65,7 +65,7 @@ import           Text.HTML.TagSoup          (Tag(..))
 import           Miso.Effect
 import           Miso.Event
 import           Miso.FFI
-import           Miso.String hiding (reverse)
+import           Miso.String hiding (elem, reverse)
 
 -- | Core type for constructing a `VTree`, use this instead of `VTree` directly.
 data View action


### PR DESCRIPTION
Without this patch, we have
```
 $ cabal build --constraint='text >=1.2.5'
src/Miso/FFI.hs:95:35: error:
    Ambiguous occurrence ‘elem’
    It could refer to
       either ‘Prelude.elem’,
              imported from ‘Prelude’ at src/Miso/FFI.hs:14:8-15
              (and originally defined in ‘Data.Foldable’)
           or ‘Miso.String.elem’,
              imported from ‘Miso.String’ at src/Miso/FFI.hs:67:1-28
              (and originally defined in ‘Data.Text’)
   |
95 |   classSet <- ((JSS.pack "class") `elem`) <$> listProps obj
   |                                   ^^^^^^
```
where `elem` [was added](https://hackage.haskell.org/package/text-2.0.1/changelog) to `Data.Text` in 1.2.5.0.