### PR TITLE
Use Prelude.elem explicitly in FFI.hs

### DIFF
--- a/src/Miso/FFI.hs
+++ b/src/Miso/FFI.hs
@@ -92,7 +92,7 @@ objectToJSVal = toJSVal
 -- | Set property on object
 set :: ToJSVal v => MisoString -> v -> OI.Object -> JSM ()
 set (unpack -> "class") v obj = do
-  classSet <- ((JSS.pack "class") `elem`) <$> listProps obj
+  classSet <- ((JSS.pack "class") `Prelude.elem`) <$> listProps obj
   if classSet
     then do
       classStr <- fromJSValUnchecked =<< getProp (JSS.pack "class") obj


### PR DESCRIPTION
Despite the fact `elem` is being hidden, GHC 9.0.2 is upset. 

```
src/Miso/FFI.hs:95:35: error:
    Ambiguous occurrence 'elem'
    It could refer to
       either 'Prelude.elem',
              imported from 'Prelude' at src/Miso/FFI.hs:14:8-15
              (and originally defined in 'Data.Foldable')
           or 'Miso.String.elem',
              imported from 'Miso.String' at src/Miso/FFI.hs:67:1-28
              (and originally defined in 'Data.Text')
   |
95 |   classSet <- ((JSS.pack "class") `elem`) <$> listProps obj
```