### PR TITLE
Make 2048 an example on the website.

### DIFF
--- a/examples/haskell-miso.org/shared/Common.hs
+++ b/examples/haskell-miso.org/shared/Common.hs
@@ -140,6 +140,10 @@ examples = template v
           , a_ [ target_  "_blank"
                , href_  "http://flatris.haskell-miso.org/" ]
             [ text "Flatris" ]
+          , text " / "
+          , a_ [ target_  "_blank"
+               , href_  "http://2048.haskell-miso.org/" ]
+            [ text "2048" ]
          ]
        ]
 


### PR DESCRIPTION
- Adds [2048](https://2048.haskell-miso.org) to [haskell-miso.org](https://haskell-miso.org)