### PR TITLE
import MkLink and ToLink from HasLink class (fixes build with ghc 9.8)

### DIFF
--- a/src/Miso/Html/Types.hs
+++ b/src/Miso/Html/Types.hs
@@ -58,7 +58,7 @@ import           JavaScript.Object.Internal (Object(Object))
 import qualified Lucid                      as L
 import qualified Lucid.Base                 as L
 import           Prelude                    hiding (null)
-import           Servant.API                (Get, HasLink, MkLink, toLink)
+import           Servant.API                (Get, HasLink(MkLink, toLink))
 import           Text.HTML.TagSoup.Tree     (parseTree, TagTree(..))
 import           Text.HTML.TagSoup          (Tag(..))
 


### PR DESCRIPTION
It seems miso does not compile with GHC 9.8, this PR fixes that. 

Admittedly, since the upstream version of jsaddle also does not compile with 9.8 you currently also need something along the lines of 

```
packages:
    .
source-repository-package
    type: git
    location: git@github.com:noinia/jsaddle.git
    subdir: jsaddle
    tag: e034fd40cd07c23ad85f3b059e8e3d8b698e322a

package miso
    flags: +jsaddle
```

in your cabal.project (the only change in that repo w.r.t stock jsaddle is to get rid of the JavaScriptFFI language extention, which is deprecated/does nothing anyway)