### PR TITLE
Update Pixel Card Wars' URL to the production one

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ For constructing client and server applications, we recommend using one `cabal` 
   - [Link](http://fizruk.github.io/fpconf-2017-talk/miso-aframe-demo/dist/demo.jsexe/index.html) / [Source](https://github.com/fizruk/miso-aframe)
 
 ### Pixel Card Wars
-  - [Link](https://www.schplaf.org/hgames/darkcraw/) / [Source](https://github.com/smelc/miso-darkcraw)
+  - [Link](https://smelc3.itch.io/pixel-card-wars) / [Source](https://github.com/smelc/miso-darkcraw)
 
 ### Currency Converter
   - [Link](https://functora.github.io/apps/currency-converter) / [Source](https://github.com/functora/functora.github.io/tree/master/ghcjs/currency-converter)


### PR DESCRIPTION
The URL of the Pixel Card Wars game was down (this was the staging URL). Change the link to use the production URL.

# How to trust this PR

Click on the new link, witness it works.