### PR TITLE
Fix build with `text` 2.1.2

### DIFF
--- a/src/Miso/FFI.hs
+++ b/src/Miso/FFI.hs
@@ -64,7 +64,7 @@ import           Language.Javascript.JSaddle hiding (obj, val)
 #else
 import           Language.Javascript.JSaddle hiding (Success, obj, val)
 #endif
-import           Miso.String
+import           Miso.String hiding (show)
 
 -- | Run given `JSM` action asynchronously, in a separate thread.
 forkJSM :: JSM () -> JSM ()

--- a/src/Miso/Html/Types.hs
+++ b/src/Miso/Html/Types.hs
@@ -65,7 +65,7 @@ import           Text.HTML.TagSoup          (Tag(..))
 import           Miso.Effect
 import           Miso.Event
 import           Miso.FFI
-import           Miso.String                hiding (reverse, elem)
+import           Miso.String                hiding (reverse, elem, show )
 
 -- | Core type for constructing a `VTree`, use this instead of `VTree` directly.
 data View action

--- a/src/Miso/Subscription/History.hs
+++ b/src/Miso/Subscription/History.hs
@@ -29,7 +29,7 @@ import Miso.Concurrent
 import Miso.Effect (Sub)
 import Miso.FFI
 import qualified Miso.FFI.History as FFI
-import Miso.String
+import Miso.String hiding (show)
 import Network.URI hiding (path)
 import System.IO.Unsafe
 

--- a/text-src/Miso/String.hs
+++ b/text-src/Miso/String.hs
@@ -70,13 +70,13 @@ instance ToMisoString B.ByteString where
 instance ToMisoString BL.ByteString where
   toMisoString = toMisoString . LT.decodeUtf8
 instance ToMisoString Float where
-  toMisoString = T.pack . show
+  toMisoString = T.pack . Prelude.show
 instance ToMisoString Double where
-  toMisoString = T.pack . show
+  toMisoString = T.pack . Prelude.show
 instance ToMisoString Int where
-  toMisoString = T.pack . show
+  toMisoString = T.pack . Prelude.show
 instance ToMisoString Word where
-  toMisoString = T.pack . show
+  toMisoString = T.pack . Prelude.show
 
 instance FromMisoString MisoString where
   fromMisoStringEither = Right


### PR DESCRIPTION
https://hackage.haskell.org/package/text-2.1.2/changelog

We need to deal with `show` now being exported from `Data.Text`.

Strictly speaking, all old versions of Miso need a Hackage revision setting `text < 2.1.2`.