### PR TITLE
Hide `show` re-exports on text > 2.1.2 in Miso.String

### DIFF
--- a/src/Miso/FFI.hs
+++ b/src/Miso/FFI.hs
@@ -64,7 +64,7 @@ import           Language.Javascript.JSaddle hiding (obj, val)
 #else
 import           Language.Javascript.JSaddle hiding (Success, obj, val)
 #endif
-import           Miso.String hiding (show)
+import           Miso.String
 
 -- | Run given `JSM` action asynchronously, in a separate thread.
 forkJSM :: JSM () -> JSM ()

--- a/src/Miso/Html/Types.hs
+++ b/src/Miso/Html/Types.hs
@@ -65,7 +65,7 @@ import           Text.HTML.TagSoup          (Tag(..))
 import           Miso.Effect
 import           Miso.Event
 import           Miso.FFI
-import           Miso.String                hiding (reverse, elem, show )
+import           Miso.String                hiding (reverse, elem)
 
 -- | Core type for constructing a `VTree`, use this instead of `VTree` directly.
 data View action

--- a/src/Miso/Subscription/History.hs
+++ b/src/Miso/Subscription/History.hs
@@ -29,7 +29,7 @@ import Miso.Concurrent
 import Miso.Effect (Sub)
 import Miso.FFI
 import qualified Miso.FFI.History as FFI
-import Miso.String hiding (show)
+import Miso.String
 import Network.URI hiding (path)
 import System.IO.Unsafe
 

--- a/text-src/Miso/String.hs
+++ b/text-src/Miso/String.hs
@@ -73,13 +73,13 @@ instance ToMisoString B.ByteString where
 instance ToMisoString BL.ByteString where
   toMisoString = toMisoString . LT.decodeUtf8
 instance ToMisoString Float where
-  toMisoString = T.pack . Prelude.show
+  toMisoString = T.pack . show
 instance ToMisoString Double where
-  toMisoString = T.pack . Prelude.show
+  toMisoString = T.pack . show
 instance ToMisoString Int where
-  toMisoString = T.pack . Prelude.show
+  toMisoString = T.pack . show
 instance ToMisoString Word where
-  toMisoString = T.pack . Prelude.show
+  toMisoString = T.pack . show
 
 instance FromMisoString MisoString where
   fromMisoStringEither = Right

--- a/text-src/Miso/String.hs
+++ b/text-src/Miso/String.hs
@@ -35,7 +35,7 @@ import qualified Data.Text.Encoding      as T
 import qualified Data.Text.Lazy          as LT
 import qualified Data.Text.Lazy.Encoding as LT
 import           Text.Read(readEither)
-
+import           Prelude                 as P
 
 -- | String type swappable based on compiler
 type MisoString = Text
@@ -73,13 +73,13 @@ instance ToMisoString B.ByteString where
 instance ToMisoString BL.ByteString where
   toMisoString = toMisoString . LT.decodeUtf8
 instance ToMisoString Float where
-  toMisoString = T.pack . show
+  toMisoString = T.pack . P.show
 instance ToMisoString Double where
-  toMisoString = T.pack . show
+  toMisoString = T.pack . P.show
 instance ToMisoString Int where
-  toMisoString = T.pack . show
+  toMisoString = T.pack . P.show
 instance ToMisoString Word where
-  toMisoString = T.pack . show
+  toMisoString = T.pack . P.show
 
 instance FromMisoString MisoString where
   fromMisoStringEither = Right

--- a/text-src/Miso/String.hs
+++ b/text-src/Miso/String.hs
@@ -16,17 +16,20 @@ module Miso.String
   , FromMisoString (..)
   , fromMisoString
   , MisoString
-  , module Data.Monoid
-  , module Data.Text
+  , module S
   , ms
   ) where
 
 import qualified Data.ByteString         as B
 import qualified Data.ByteString.Lazy    as BL
-import           Data.Monoid
+import           Data.Monoid             as S
 import           Data.JSString
 import           Data.JSString.Text
-import           Data.Text
+#if MIN_VERSION_text(2,1,2)
+import           Data.Text               as S hiding (show)
+#else
+import           Data.Text               as S
+#endif 
 import qualified Data.Text               as T
 import qualified Data.Text.Encoding      as T
 import qualified Data.Text.Lazy          as LT


### PR DESCRIPTION
Hides external API changes (`show` re-export) for `Data.Text`