### PR TITLE
Initial commit of WASM support

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -2,3 +2,33 @@ packages:
   .
   examples/
   haskell-miso.org/
+
+index-state: 2025-02-11T14:26:56Z
+
+allow-newer:
+  all:base
+
+if arch(wasm32)
+  -- Required for TemplateHaskell. When using wasm32-wasi-cabal from
+  -- ghc-wasm-meta, this is superseded by the global cabal.config.
+  shared: True
+
+  -- https://github.com/haskellari/time-compat/issues/37
+  -- Older versions of time don't build on WASM.
+  constraints: time installed
+  allow-newer: time
+
+  -- https://github.com/haskellari/splitmix/pull/73
+  source-repository-package
+    type: git
+    location: https://github.com/amesgen/splitmix
+    tag: 5f5b766d97dc735ac228215d240a3bb90bc2ff75
+
+  package aeson
+    flags: -ordered-keymap
+
+  source-repository-package
+    type: git
+    location: https://github.com/haskell-wasm/foundation.git
+    tag: 8e6dd48527fb429c1922083a5030ef88e3d58dd3
+    subdir: basement

--- a/default.nix
+++ b/default.nix
@@ -23,11 +23,22 @@ let
 in
 {
   inherit pkgs;
-  deploy = pkgs.deploy rev;
+
+  #js
   miso-ghcjs = pkgs.haskell.packages.ghcjs86.miso;
-  miso-ghc = pkgs.haskell.packages.ghc865.miso;
   inherit (pkgs.haskell.packages.ghcjs86) miso-examples sample-app;
+  
+  #native
+  miso-ghc = pkgs.haskell.packages.ghc865.miso;
+  miso-examples-ghc = pkgs.haskell.packages.ghc865.miso-examples;
   inherit (pkgs.haskell.packages.ghc865) sample-app-jsaddle;
+
+  #hackage releases
   inherit release release-examples;
+
+  #website
   inherit (pkgs) haskell-miso;
+
+  #ci
+  deploy = pkgs.deploy rev;
 }

--- a/examples/canvas2d/Main.hs
+++ b/examples/canvas2d/Main.hs
@@ -18,7 +18,7 @@ data Action
   | SetTime Model
 
 main :: IO ()
-main = do
+main = run $ do
   [sun, moon, earth] <- replicateM 3 newImage
   setSrc sun "https://7b40c187-5088-4a99-9118-37d20a2f875e.mdnplay.dev/en-US/docs/Web/API/Canvas_API/Tutorial/Basic_animations/canvas_sun.png"
   setSrc moon "https://7b40c187-5088-4a99-9118-37d20a2f875e.mdnplay.dev/en-US/docs/Web/API/Canvas_API/Tutorial/Basic_animations/canvas_moon.png"

--- a/examples/compose-update/Main.hs
+++ b/examples/compose-update/Main.hs
@@ -1,6 +1,7 @@
-{-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE TupleSections #-}
+{-# LANGUAGE CPP               #-}
+{-# LANGUAGE RankNTypes        #-}
+{-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE TupleSections     #-}
 {-# LANGUAGE OverloadedStrings #-}
 module Main where
 
@@ -10,7 +11,6 @@ module Main where
 -- model which combines their effects.
 
 import Control.Monad
-import Data.Monoid
 
 import Miso
 import Miso.String
@@ -88,8 +88,12 @@ updateModel act =
      -- @(<=<) :: (b -> Effect Action c) -> (a -> Effect Action b) -> a -> Effect Action c
      liftedUpdateFirst <=< liftedUpdateSecond
 
+#if defined(wasm32_HOST_ARCH)
+foreign export javascript "hs_start" main :: IO ()
+#endif
+
 main :: IO ()
-main = startApp App { initialAction = NoOp, ..}
+main = run $ startApp App { initialAction = NoOp, ..}
   where
     model  = (0, 0)
     update = updateModel

--- a/examples/file-reader/Main.hs
+++ b/examples/file-reader/Main.hs
@@ -34,7 +34,7 @@ data Action
 
 -- | Main entry point
 main :: IO ()
-main = do
+main = run $ do
   startApp App { model = Model ""
                , initialAction = NoOp
                , ..

--- a/examples/mario/Main.hs
+++ b/examples/mario/Main.hs
@@ -8,32 +8,9 @@ module Main where
 import           Data.Bool
 import           Data.Function
 import qualified Data.Map as M
-import           Data.Monoid
 
 import           Miso
 import           Miso.String
-
-import qualified Language.Javascript.JSaddle.Warp as JSaddle
-
-#ifdef ghcjs_HOST_OS
-runApp :: JSM () -> IO ()
-runApp = JSaddle.run 8080
-
-#else
-import           Network.Wai.Application.Static
-import qualified Network.Wai as Wai
-import qualified Network.Wai.Handler.Warp as Warp
-import           Network.WebSockets
-
-runApp :: JSM () -> IO ()
-runApp f =
-    Warp.runSettings (Warp.setPort 8080 (Warp.setTimeout 3600 Warp.defaultSettings)) =<<
-        JSaddle.jsaddleOr defaultConnectionOptions (f >> syncPoint) app
-    where app req sendResp =
-            case Wai.pathInfo req of
-              ("imgs" : _) -> staticApp (defaultWebAppSettings "examples/mario") req sendResp
-              _ -> JSaddle.jsaddleApp req sendResp
-#endif
 
 data Action
   = GetArrows !Arrows
@@ -44,8 +21,12 @@ data Action
 spriteFrames :: [MisoString]
 spriteFrames = ["0 0", "-74px 0","-111px 0","-148px 0","-185px 0","-222px 0","-259px 0","-296px 0"]
 
+#if defined(wasm32_HOST_ARCH)
+foreign export javascript "hs_start" main :: IO ()
+#endif
+
 main :: IO ()
-main = runApp $ do
+main = run $ do
     time <- now
     let m = mario { time = time }
     startApp App { model = m

--- a/examples/mathml/Main.hs
+++ b/examples/mathml/Main.hs
@@ -1,5 +1,5 @@
-
 -- | Haskell language pragma
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 
@@ -8,21 +8,18 @@ module Main where
 
 -- | Miso framework import
 import Miso
-import Miso.String
 import Miso.Mathml
 
-data Model = Empty deriving Eq
-
-data Action
-  =  NoOp
-  deriving (Show, Eq)
+#if defined(wasm32_HOST_ARCH)
+foreign export javascript "hs_start" main :: IO ()
+#endif
 
 -- | Entry point for a miso application
 main :: IO ()
-main = startApp App {..}
+main = run $ startApp App {..}
   where
     initialAction = NoOp -- initial action to be executed on application load
-    model  = Empty                -- initial model
+    model  = Main.Empty           -- initial model
     update = updateModel          -- update function
     view   = viewModel            -- view function
     events = defaultEvents        -- default delegated events
@@ -30,13 +27,19 @@ main = startApp App {..}
     mountPoint = Nothing          -- mount point for application (Nothing defaults to 'body')
     logLevel = Off
 
+data Model = Empty deriving Eq
+
+data Action
+  =  NoOp
+  deriving (Show, Eq)
+
 -- | Updates model, optionally introduces side effects
 updateModel :: Action -> Model -> Effect Action Model
 updateModel NoOp = noEff
 
 -- | Constructs a virtual DOM from a model
 viewModel :: Model -> View Action
-viewModel x = nodeMathml "math" [] [
+viewModel _ = nodeMathml "math" [] [
     nodeMathml "msup" [] [
         nodeMathml "mi" [] [text "x"]
         , nodeMathml "mn" [] [text "2"]

--- a/examples/miso-examples.cabal
+++ b/examples/miso-examples.cabal
@@ -16,7 +16,20 @@ license-file:        LICENSE
 extra-source-files:
   mario/imgs/mario.png
 
+common common-options
+  if arch(wasm32)
+    ghc-options:
+      -no-hs-main -optl-mexec-model=reactor "-optl-Wl,--export=hs_start"
+  ghc-options:
+    -funbox-strict-fields -O2 -ferror-spans -fspecialise-aggressively -Wall
+
+common js-only
+  if arch(wasm32) || !(impl(ghcjs) || arch(javascript))
+     buildable: False
+
 executable simple
+  import:
+    common-options
   default-language:
     Haskell2010
   main-is:
@@ -32,10 +45,11 @@ executable simple
     base < 5,
     containers,
     miso,
-    transformers,
-    jsaddle-warp
+    transformers
 
 executable todo-mvc
+  import:
+    common-options
   default-language:
     Haskell2010
   main-is:
@@ -51,10 +65,11 @@ executable todo-mvc
     base < 5,
     containers,
     miso,
-    transformers,
-    jsaddle-warp
+    transformers
 
 executable threejs
+  import:
+    common-options, js-only
   default-language:
     Haskell2010
   main-is:
@@ -68,11 +83,13 @@ executable threejs
   build-depends:
     aeson,
     base < 5,
-    ghcjs-base,
     containers,
+    jsaddle,
     miso
 
 executable file-reader
+  import:
+    common-options, js-only
   default-language:
     Haskell2010
   main-is:
@@ -91,6 +108,8 @@ executable file-reader
     miso
 
 executable xhr
+  import:
+    common-options, js-only
   default-language:
     Haskell2010
   main-is:
@@ -109,6 +128,8 @@ executable xhr
     miso
 
 executable canvas2d
+  import:
+    common-options, js-only
   default-language:
     Haskell2010
   main-is:
@@ -126,6 +147,8 @@ executable canvas2d
     miso
 
 executable router
+  import:
+    common-options
   default-language:
     Haskell2010
   main-is:
@@ -142,10 +165,11 @@ executable router
     containers,
     miso,
     servant,
-    transformers,
-    jsaddle-warp
+    transformers
 
 executable websocket
+  import:
+    common-options
   default-language:
     Haskell2010
   main-is:
@@ -161,10 +185,11 @@ executable websocket
     base < 5,
     containers,
     miso,
-    transformers,
-    jsaddle-warp
+    transformers
 
 executable mario
+  import:
+    common-options
   default-language:
     Haskell2010
   main-is:
@@ -178,36 +203,11 @@ executable mario
   build-depends:
     base < 5,
     containers,
-    miso,
-    jsaddle-warp
-  if !impl(ghcjs) && !arch(javascript)
-    build-depends:
-      wai,
-      wai-app-static,
-      warp,
-      websockets,
-
-
-executable svg
-  default-language:
-    Haskell2010
-  main-is:
-    Main.hs
-  ghcjs-options:
-    -dedupe
-  cpp-options:
-    -DGHCJS_BROWSER
-  hs-source-dirs:
-    svg
-  other-modules:
-    Touch
-  build-depends:
-    base < 5,
-    containers,
-    aeson,
     miso
 
 executable compose-update
+  import:
+    common-options
   default-language:
     Haskell2010
   main-is:
@@ -223,6 +223,8 @@ executable compose-update
     miso
 
 executable mathml
+  import:
+    common-options
   default-language:
     Haskell2010
   main-is:
@@ -235,4 +237,25 @@ executable mathml
     mathml
   build-depends:
     base < 5,
+    miso
+
+executable svg
+  import:
+    common-options
+  other-modules:
+    Touch
+  default-language:
+    Haskell2010
+  main-is:
+    Main.hs
+  ghcjs-options:
+    -dedupe
+  cpp-options:
+    -DGHCJS_BROWSER
+  hs-source-dirs:
+    svg
+  build-depends:
+    base < 5,
+    containers,
+    aeson,
     miso

--- a/examples/router/Main.hs
+++ b/examples/router/Main.hs
@@ -9,18 +9,12 @@ module Main where
 
 import Data.Proxy
 import Servant.API
-#if MIN_VERSION_servant(0,14,1)
 import Servant.Links
-#elif MIN_VERSION_servant(0,10,0)
-import Servant.Utils.Links
-#endif
-
 import Miso
 
-import Language.Javascript.JSaddle.Warp as JSaddle
-
-runApp :: JSM () -> IO ()
-runApp = JSaddle.run 8080
+#if defined(wasm32_HOST_ARCH)
+foreign export javascript "hs_start" main :: IO ()
+#endif
 
 -- | Model
 data Model
@@ -39,7 +33,7 @@ data Action
 -- | Main entry point
 main :: IO ()
 main =
-  runApp $ do
+  run $ do
     currentURI <- getCurrentURI
     startApp App { model = Model currentURI, initialAction = NoOp, ..}
   where
@@ -89,11 +83,7 @@ type About = "about" :> View Action
 goAbout, goHome :: Action
 (goHome, goAbout) = (goto api home, goto api about)
   where
-#if MIN_VERSION_servant(0,10,0)
-    goto a b = ChangeURI (linkURI (safeLink a b))
-#else
-    goto a b = ChangeURI (safeLink a b)
-#endif
+    goto a b = ChangeURI $ linkURI (safeLink a b)
     home  = Proxy :: Proxy Home
     about = Proxy :: Proxy About
     api   = Proxy :: Proxy API

--- a/examples/simple/Main.hs
+++ b/examples/simple/Main.hs
@@ -11,10 +11,6 @@ import Miso
 import Miso.String
 
 import Control.Monad.IO.Class
-import Language.Javascript.JSaddle.Warp as JSaddle
-
-runApp :: JSM () -> IO ()
-runApp = JSaddle.run 8080
 
 -- | Type synonym for an application model
 type Model = Int
@@ -27,9 +23,13 @@ data Action
   | SayHelloWorld
   deriving (Show, Eq)
 
+#if defined(wasm32_HOST_ARCH)
+foreign export javascript "hs_start" main :: IO ()
+#endif
+
 -- | Entry point for a miso application
 main :: IO ()
-main = runApp $ miso $ \_ -> App {..}
+main = run $ miso $ \_ -> App {..}
   where
     initialAction = SayHelloWorld -- initial action to be executed on application load
     model  = 0                    -- initial model

--- a/examples/sse/client/Main.hs
+++ b/examples/sse/client/Main.hs
@@ -8,7 +8,7 @@ import Data.Proxy
 import Miso
 
 main :: IO ()
-main = do
+main = run $ do
   miso $ \currentURI ->
     App { initialAction = NoOp
         , model = Model currentURI "No event received"

--- a/examples/sse/server/Main.hs
+++ b/examples/sse/server/Main.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings          #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE PolyKinds                  #-}
@@ -87,11 +86,7 @@ app :: Chan ServerEvent -> Application
 app chan =
   serve
     (Proxy @API)
-#if MIN_VERSION_servant(0,11,0)
-    (static :<|> Tagged (sseApp chan) :<|> (serverHandlers :<|> Tagged handle404))
-#else
     (static :<|> sseApp chan :<|> (serverHandlers :<|> handle404))
-#endif
   where
     static = serveDirectory "static"
 

--- a/examples/sse/shared/Common.hs
+++ b/examples/sse/shared/Common.hs
@@ -1,12 +1,9 @@
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE CPP #-}
 module Common where
 
 import Data.Proxy
 import Servant.API
-#if MIN_VERSION_servant(0,10,0)
 import Servant.Utils.Links
-#endif
 
 import Miso
 import Miso.String
@@ -43,8 +40,4 @@ the404 =
 
 goHome :: URI
 goHome =
-#if MIN_VERSION_servant(0,10,0)
   linkURI (safeLink (Proxy :: Proxy ClientRoutes) (Proxy :: Proxy Home))
-#else
-  safeLink (Proxy :: Proxy ClientRoutes) (Proxy :: Proxy Home)
-#endif

--- a/examples/svg/Main.hs
+++ b/examples/svg/Main.hs
@@ -1,21 +1,24 @@
-{-# LANGUAGE OverloadedStrings          #-}
-{-# LANGUAGE RecordWildCards            #-}
-{-# LANGUAGE TypeFamilies               #-}
-{-# LANGUAGE TypeOperators              #-}
+{-# LANGUAGE CPP               #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE TypeFamilies      #-}
+{-# LANGUAGE TypeOperators     #-}
 module Main where
 
-import qualified Data.Map      as M
+import qualified Data.Map as M
 
 import           Control.Arrow
 import           Miso
-import           Miso.String   (MisoString, pack, ms)
-import           Miso.Svg      hiding (height_, id_, style_, width_)
+import           Miso.String (MisoString, pack, ms)
+import           Miso.Svg hiding (height_, id_, style_, width_)
 import           Touch
 
-trunc = truncate *** truncate
+#if defined(wasm32_HOST_ARCH)
+foreign export javascript "hs_start" main :: IO ()
+#endif
 
 main :: IO ()
-main = startApp App {..}
+main = run $ startApp App {..}
   where
     initialAction = Id
     model         = emptyModel
@@ -27,6 +30,9 @@ main = startApp App {..}
     subs          = [ mouseSub HandleMouse ]
     logLevel      = Off
     mountPoint    = Nothing
+
+trunc :: (Double, Double) -> (Int, Int)
+trunc = truncate *** truncate
 
 emptyModel :: Model
 emptyModel = Model (0,0)

--- a/examples/svg/Touch.hs
+++ b/examples/svg/Touch.hs
@@ -2,9 +2,7 @@
 {-# LANGUAGE RecordWildCards #-}
 module Touch where
 
-import Control.Monad
 import Data.Aeson.Types
-import Debug.Trace
 import Miso
 
 data Touch = Touch
@@ -41,4 +39,5 @@ touchDecoder = Decoder {..}
 onTouchMove :: (TouchEvent -> action) -> Attribute action
 onTouchMove = on "touchmove" touchDecoder
 
+onTouchStart :: (TouchEvent -> action) -> Attribute action
 onTouchStart = on "touchstart" touchDecoder

--- a/examples/three/Main.hs
+++ b/examples/three/Main.hs
@@ -4,12 +4,13 @@
 module Main where
 
 import           Control.Monad
+import           Control.Monad.IO.Class (liftIO)
 import           Data.IORef
-import qualified Data.Map      as M
-import           GHCJS.Types
+import qualified Data.Map as M
+
+import           Language.Javascript.JSaddle hiding ((<#))
 
 import           Miso
-import           Miso.String
 
 data Action
   = GetTime
@@ -52,7 +53,7 @@ initContext ref = do
   }
 
 main :: IO ()
-main = do
+main = run $ do
   stats <- newStats
   ref <- newIORef $ Context (pure ()) (pure ()) stats
   m <- now
@@ -85,11 +86,11 @@ updateModel
   -> Double
   -> Effect Action Double
 updateModel ref Init m = m <# do
-  initContext ref
+  liftIO (initContext ref)
   pure GetTime
 
 updateModel ref GetTime m = m <# do
-  Context {..} <- readIORef ref
+  Context {..} <- liftIO (readIORef ref)
   withStats stats $ do
     rotateCube
     renderScene

--- a/examples/todo-mvc/Main.hs
+++ b/examples/todo-mvc/Main.hs
@@ -13,23 +13,21 @@
 {-# LANGUAGE CPP                        #-}
 module Main where
 
+import           Control.Monad.IO.Class
 import           Data.Aeson hiding (Object)
 import           Data.Bool
 import qualified Data.Map as M
-import           Data.Monoid
 import           GHC.Generics
+
 import           Miso
 import           Miso.String (MisoString)
 import qualified Miso.String as S
 
-import           Control.Monad.IO.Class
-
-import Language.Javascript.JSaddle.Warp as JSaddle
-
-runApp :: JSM () -> IO ()
-runApp = JSaddle.run 8080
-
 default (MisoString)
+
+#if defined(wasm32_HOST_ARCH)
+foreign export javascript "hs_start" main :: IO ()
+#endif
 
 data Model = Model
   { entries :: [Entry]
@@ -86,7 +84,7 @@ data Msg
    deriving Show
 
 main :: IO ()
-main = runApp $ startApp App { initialAction = NoOp, ..}
+main = run $ startApp App { initialAction = NoOp, ..}
   where
     model      = emptyModel
     update     = updateModel

--- a/examples/websocket/Main.hs
+++ b/examples/websocket/Main.hs
@@ -21,13 +21,12 @@ import           Miso
 import           Miso.String  (MisoString)
 import qualified Miso.String  as S
 
-import Language.Javascript.JSaddle.Warp as JSaddle
-
-runApp :: JSM () -> IO ()
-runApp = JSaddle.run 8080
+#if defined(wasm32_HOST_ARCH)
+foreign export javascript "hs_start" main :: IO ()
+#endif
 
 main :: IO ()
-main = runApp $ startApp App { initialAction = Id, ..}
+main = run $ startApp App { initialAction = Id, ..}
   where
     model = Model (Message "") mempty
     events = defaultEvents

--- a/examples/xhr/Main.hs
+++ b/examples/xhr/Main.hs
@@ -126,7 +126,7 @@ data APIInfo
   } deriving (Show, Eq, Generic)
 
 instance FromJSON APIInfo where
-  parseJSON = genericParseJSON defaultOptions { fieldLabelModifier = camelTo '_' }
+  parseJSON = genericParseJSON defaultOptions { fieldLabelModifier = camelTo2 '_' }
 
 getGitHubAPIInfo :: IO APIInfo
 getGitHubAPIInfo = do

--- a/haskell-miso.org/client/Main.hs
+++ b/haskell-miso.org/client/Main.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE CPP             #-}
 module Main where
 
 import Common
@@ -7,8 +8,12 @@ import Data.Proxy
 import Miso
 import Miso.String
 
+#if defined(wasm32_HOST_ARCH)
+foreign export javascript "hs_start" main :: IO ()
+#endif
+
 main :: IO ()
-main = miso $ \currentURI -> App
+main = run $ miso $ \currentURI -> App
         { model = Model currentURI False
         , view = viewModel
         , ..

--- a/haskell-miso.org/client/shell.nix
+++ b/haskell-miso.org/client/shell.nix
@@ -1,0 +1,7 @@
+with (import ../../default.nix {});
+let
+  inherit (pkgs.haskell.packages) ghcjs86;
+  src = import ../../nix/haskell/packages/source.nix pkgs;
+  client = ghcjs86.callCabal2nix "haskell-miso" (src.haskell-miso-src) {};
+in
+  client.env

--- a/haskell-miso.org/haskell-miso.cabal
+++ b/haskell-miso.org/haskell-miso.cabal
@@ -1,9 +1,10 @@
+cabal-version:       2.2
 name:                haskell-miso
 version:             0.1.0.1
 synopsis:            https://haskell-miso.org
 description:         Website for the Miso web framework
 homepage:            https://haskell-miso.org
-license:             BSD3
+license:             BSD-3-Clause
 license-file:        LICENSE
 author:              David Johnson
 maintainer:          code@dmj.io
@@ -11,53 +12,71 @@ copyright:           David Johnson (c) 2016-2025
 category:            Web
 build-type:          Simple
 extra-source-files:  ChangeLog.md
-cabal-version:       >=1.10
 
-executable server
-  main-is:
-    Main.hs
+common server-only
   if impl(ghcjs) || arch(javascript)
     buildable: False
-  else
-    ghc-options:
-      -O2 -threaded -Wall -rtsopts
-    hs-source-dirs:
-      server, shared
-    build-depends:
-      aeson,
-      base < 5,
-      containers,
-      http-types,
-      lucid,
-      miso,
-      mtl,
-      network-uri,
-      servant,
-      servant-lucid,
-      servant-server,
-      text,
-      wai,
-      wai-app-static,
-      wai-extra,
-      warp
-    default-language:
-      Haskell2010
 
-executable client
+common client-only
+  if impl(ghcjs) || arch(javascript) || arch(wasm32)
+    buildable: True
+  else
+    buildable: False
+
+common common-options
+  if arch(wasm32)
+    ghc-options:
+      -no-hs-main -optl-mexec-model=reactor "-optl-Wl,--export=hs_start"
+  ghc-options:
+    -funbox-strict-fields -O2 -ferror-spans -fspecialise-aggressively
+
+common common-modules
+  other-modules:
+     Common
+
+executable server
+  import:
+     server-only, common-modules, common-options
   main-is:
     Main.hs
-  if !impl(ghcjs) && !arch(javascript)
-    buildable: False
-  else
-    ghcjs-options:
-      -dedupe -DGHCJS_GC_INTERVAL=5000
-    hs-source-dirs:
-      client, shared
-    build-depends:
-      aeson,
-      base < 5,
-      containers,
-      miso,
-      servant
-    default-language:
-      Haskell2010
+  ghc-options:
+    -threaded -Wall -rtsopts
+  hs-source-dirs:
+    server, shared
+  build-depends:
+    aeson,
+    base < 5,
+    containers,
+    http-types,
+    lucid,
+    miso,
+    mtl,
+    network-uri,
+    servant,
+    servant-lucid,
+    servant-server,
+    text,
+    wai,
+    wai-app-static,
+    wai-extra,
+    warp
+  default-language:
+    Haskell2010
+
+executable client
+  import:
+    client-only, common-modules, common-options
+  main-is:
+    Main.hs
+  ghcjs-options:
+    -dedupe -DGHCJS_GC_INTERVAL=5000
+  hs-source-dirs:
+    client, shared
+  build-depends:
+    aeson,
+    base < 5,
+    containers,
+    miso,
+    servant
+  default-language:
+    Haskell2010

--- a/haskell-miso.org/server/shell.nix
+++ b/haskell-miso.org/server/shell.nix
@@ -1,0 +1,7 @@
+with (import ../../default.nix {});
+let
+  inherit (pkgs.haskell.packages) ghc865;
+  src = import ../../nix/haskell/packages/source.nix pkgs;
+  server = ghc865.callCabal2nix "haskell-miso" (src.haskell-miso-src) {};
+in
+  server.env

--- a/haskell-miso.org/shared/Common.hs
+++ b/haskell-miso.org/shared/Common.hs
@@ -3,20 +3,15 @@
 {-# LANGUAGE TypeFamilies         #-}
 {-# LANGUAGE TypeOperators        #-}
 {-# LANGUAGE DataKinds            #-}
-{-# LANGUAGE CPP                  #-}
 module Common where
 
 import           Data.Bool
-import qualified Data.Map    as M
-import           Data.Monoid
+import qualified Data.Map as M
 import           Data.Proxy
-import           Servant.API
-#if MIN_VERSION_servant(0,10,0)
-import Servant.Utils.Links
-#endif
-
 import           Miso
 import           Miso.String
+import           Servant.API
+import           Servant.Links
 
 -- | We can pretty much share everything
 --
@@ -45,6 +40,11 @@ type ClientRoutes = Examples
   :<|> Home
 
 -- | Handlers
+handlers
+    :: (Model -> View Action)
+  :<|> (Model -> View Action)
+  :<|> (Model -> View Action)
+  :<|> (Model -> View Action)
 handlers = examples
   :<|> docs
   :<|> community
@@ -189,6 +189,7 @@ template content Model{..} =
   , footer
   ]
 
+middle :: View action
 middle =
   section_ [class_ "hero" ] [
     div_ [class_ "hero-body"] [
@@ -304,19 +305,11 @@ the404 = template v
 -- | Links
 goHome, goExamples, goDocs, goCommunity :: URI
 ( goHome, goExamples, goDocs, goCommunity ) =
-#if MIN_VERSION_servant(0,10,0)
     ( linkURI (safeLink routes homeProxy)
     , linkURI (safeLink routes examplesProxy)
     , linkURI (safeLink routes docsProxy)
     , linkURI (safeLink routes communityProxy)
     )
-#else
-    ( safeLink routes homeProxy
-    , safeLink routes examplesProxy
-    , safeLink routes docsProxy
-    , safeLink routes communityProxy
-    )
-#endif
 
 homeProxy :: Proxy Home
 homeProxy = Proxy
@@ -446,6 +439,7 @@ footer =
       ]
     ]
 
+newNav :: Bool -> View Action
 newNav navMenuOpen' =
   div_ [ class_ "container" ] [
     nav_ [class_ "navbar is-transparent"] [

--- a/miso.cabal
+++ b/miso.cabal
@@ -18,53 +18,101 @@ description:
 extra-source-files:
   README.md
 
+source-repository head
+   type: git
+   location: https://github.com/dmjio/miso.git
+
+common js-only-tests
+  if !(impl(ghcjs) || arch(javascript)) || !flag(tests)
+    buildable: False
+
+common jsaddle-selector
+  if arch(wasm32)
+    build-depends:
+      jsaddle-wasm
+  else
+    build-depends:
+      jsaddle-warp
+
+common string-selector
+  if impl(ghcjs) || arch(javascript) || flag (jsstring-only) || arch(wasm32)
+    hs-source-dirs:
+      jsstring-src
+  else
+    hs-source-dirs:
+      text-src
+
+common server
+  if !(impl(ghcjs) || arch(javascript))
+    build-depends:
+      servant-lucid
+
+common client
+  if impl(ghcjs) || arch(javascript)
+    build-depends:
+      ghcjs-base
+
+  if impl(ghcjs) || arch(javascript) || arch(wasm32)
+    js-sources:
+      jsbits/diff.js
+      jsbits/delegate.js
+      jsbits/isomorphic.js
+      jsbits/util.js
+
 flag tests
+  manual:
+    True
   default:
     False
   description:
     Builds Miso's tests
 
 flag jsstring-only
-  manual: True
+  manual:
+    True
   default:
     False
   description:
     Always set MisoString = JSString
 
 executable tests
+  import:
+    js-only-tests
   default-language:
     Haskell2010
   main-is:
     Main.hs
-  if !(impl(ghcjs) || arch(javascript)) || !flag(tests)
-    buildable: False
-  else
-    ghcjs-options:
-      -dedupe
-    cpp-options:
-      -DGHCJS_BROWSER
-    hs-source-dirs:
-      tests
-    build-depends:
-      aeson,
-      base < 5,
-      bytestring,
-      ghcjs-base,
-      QuickCheck,
-      quickcheck-instances,
-      miso,
-      http-types,
-      network-uri,
-      http-api-data,
-      containers,
-      scientific,
-      servant,
-      text,
-      unordered-containers,
-      transformers,
-      vector
+  ghcjs-options:
+    -dedupe
+  cpp-options:
+    -DGHCJS_BROWSER
+  hs-source-dirs:
+    tests
+  build-depends:
+    aeson,
+    base < 5,
+    bytestring,
+    ghcjs-base,
+    QuickCheck,
+    quickcheck-instances,
+    miso,
+    http-types,
+    network-uri,
+    http-api-data,
+    containers,
+    scientific,
+    servant,
+    text,
+    unordered-containers,
+    transformers,
+    vector
 
 library
+  import:
+    jsaddle-selector,
+    string-selector,
+    server,
+    client
   default-language:
     Haskell2010
   exposed-modules:
@@ -91,6 +139,7 @@ library
     Miso.FFI.Storage
     Miso.FFI.WebSocket
     Miso.JSBits
+    Miso.Runner
     Miso.Subscription
     Miso.Subscription.History
     Miso.Subscription.Keyboard
@@ -107,21 +156,17 @@ library
     Miso.Mathml.Element
     Miso.String
     Miso.WebSocket
+    Miso.Concurrent
+
+  -- dmj: see if common-stanzas can suport 'exposed-modules'
   if !(impl(ghcjs) || arch(javascript))
     exposed-modules:
       Miso.TypeLevel
-  other-modules:
-    Miso.Concurrent
+
   ghc-options:
     -Wall
   hs-source-dirs:
     src
-  if impl(ghcjs) || arch(javascript) || flag (jsstring-only)
-    hs-source-dirs:
-      jsstring-src
-  else
-    hs-source-dirs:
-      text-src
   build-depends:
     aeson,
     base < 5,
@@ -137,19 +182,3 @@ library
     tagsoup,
     text,
     transformers
-  if impl(ghcjs) || arch(javascript)
-    build-depends:
-      ghcjs-base
-  else
-    build-depends:
-      servant-lucid
-  if impl(ghcjs) || arch(javascript)
-    js-sources:
-      jsbits/diff.js
-      jsbits/delegate.js
-      jsbits/isomorphic.js
-      jsbits/util.js
-
-source-repository head
-   type: git
-   location: https://github.com/dmjio/miso.git

--- a/shell.nix
+++ b/shell.nix
@@ -1,1 +1,2 @@
-(import ./default.nix {}).miso-ghcjs.env
+{ pkg ? "ghcjs" }:
+(import ./default.nix {})."miso-${pkg}".env

--- a/src/Miso.hs
+++ b/src/Miso.hs
@@ -19,6 +19,7 @@ module Miso
   ( miso
   , startApp
   , sink
+  , run
   , module Miso.Effect
   , module Miso.Event
   , module Miso.Html
@@ -60,6 +61,7 @@ import           Miso.Event
 import           Miso.FFI
 import           Miso.Html
 import           Miso.Router
+import           Miso.Runner (run)
 import           Miso.Subscription
 #ifndef ghcjs_HOST_OS
 import           Miso.TypeLevel

--- a/src/Miso/Html/Event.hs
+++ b/src/Miso/Html/Event.hs
@@ -1,13 +1,4 @@
-{-# LANGUAGE RankNTypes                #-}
 {-# LANGUAGE OverloadedStrings         #-}
-{-# LANGUAGE FlexibleContexts          #-}
-{-# LANGUAGE FlexibleInstances         #-}
-{-# LANGUAGE MultiParamTypeClasses     #-}
-{-# LANGUAGE DataKinds                 #-}
-{-# LANGUAGE KindSignatures            #-}
-{-# LANGUAGE ExistentialQuantification #-}
-{-# LANGUAGE CPP                       #-}
-{-# LANGUAGE TypeFamilies              #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Miso.Html.Event

--- a/src/Miso/Html/Property.hs
+++ b/src/Miso/Html/Property.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE CPP #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Miso.Html.Property
@@ -124,10 +123,6 @@ module Miso.Html.Property
 
 import           Miso.Html.Types
 import           Miso.String (MisoString, intercalate)
-
-#if __GLASGOW_HASKELL__ < 841
-import           Data.Monoid ((<>))
-#endif
 
 -- | Set field to `Bool` value
 boolProp :: MisoString -> Bool -> Attribute action

--- a/src/Miso/Html/Types.hs
+++ b/src/Miso/Html/Types.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP                  #-}
 {-# LANGUAGE DataKinds            #-}
 {-# LANGUAGE DeriveFunctor        #-}
 {-# LANGUAGE FlexibleInstances    #-}
@@ -77,13 +76,8 @@ data View action
 
 -- | For constructing type-safe links
 instance HasLink (View a) where
-#if MIN_VERSION_servant(0,14,0)
   type MkLink (View a) b = MkLink (Get '[] ()) b
   toLink toA Proxy = toLink toA (Proxy :: Proxy (Get '[] ()))
-#else
-  type MkLink (View a) = MkLink (Get '[] ())
-  toLink _ = toLink (Proxy :: Proxy (Get '[] ()))
-#endif
 
 -- | Convenience class for using View
 class ToView v where toView :: v -> View action

--- a/src/Miso/Runner.hs
+++ b/src/Miso/Runner.hs
@@ -1,0 +1,19 @@
+{-# LANGUAGE CPP #-}
+module Miso.Runner (run) where
+
+#if defined(wasm32_HOST_ARCH)
+import qualified Language.Javascript.JSaddle.Wasm as J
+#else
+import qualified Language.Javascript.JSaddle.Warp as J
+#endif
+
+import           Language.Javascript.JSaddle
+
+-- | Entry point for a miso application
+#if defined(wasm32_HOST_ARCH)
+run :: JSM () -> IO ()
+run = J.run
+#else
+run :: JSM () -> IO ()
+run = J.run 8008
+#endif

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -23,7 +23,7 @@ import           Test.QuickCheck hiding (total)
 import           Test.QuickCheck.Instances
 import           Test.QuickCheck.Monadic
 
-import           Miso
+import           Miso hiding (run)
 
 instance Arbitrary Value where
   arbitrary = sized sizedArbitraryValue


### PR DESCRIPTION
- Supports building 8/12 examples w/ the GHC WASM backend
- Exports main functions for WASM in examples
- Adds wasm dep. entries to `cabal.project`
- Refactors nix infra
- Removes superfluous CPP (old servant `CPP` and `Monoid`)
- Adds `Miso.Runner` to abstract over various `jsaddle` backends
- Adds common stanzas to cabal files for readability
- Removes `wai` dep. in mario example.
- Migrates haskell-miso.org to Cabal 2.2 (adds shell.nix)
- haskell-miso.org client can be built w/ WASM
- Cleans up some -Wall warnings
- Exposes `Miso.Concurrent`
- shell.nix is now dynamic (can take "ghc" or "ghcjs" as an arg)
  - `"nix-shell --arg pkg ghcjs"`
  
There are still a few examples outstanding that we could use CPP and raw WASM FFI declarations to support (like the `xhr` example).

The haskell-miso.org server currently does not compile w/ WASM.

Builds eligible examples below
```
❯ nix shell 'gitlab:haskell-wasm/ghc-wasm-meta?host=gitlab.haskell.org'
❯ wasm32-wasi-cabal build examples --allow-newer
Configuration is affected by the following files:
- cabal.project
Up to date
```

```
❯ file dist-newstyle/*/*/*/*/*/*/*/*/*.wasm
dist-newstyle/build/wasm32-wasi/ghc-9.13.20250212/haskell-miso-0.1.0.1/x/client/build/client/client.wasm:                          WebAssembly (wasm) binary module version 0x1 (MVP)
dist-newstyle/build/wasm32-wasi/ghc-9.13.20250212/miso-examples-1.8.7.0/x/compose-update/build/compose-update/compose-update.wasm: WebAssembly (wasm) binary module version 0x1 (MVP)
dist-newstyle/build/wasm32-wasi/ghc-9.13.20250212/miso-examples-1.8.7.0/x/mario/build/mario/mario.wasm:                            WebAssembly (wasm) binary module version 0x1 (MVP)
dist-newstyle/build/wasm32-wasi/ghc-9.13.20250212/miso-examples-1.8.7.0/x/mathml/build/mathml/mathml.wasm:                         WebAssembly (wasm) binary module version 0x1 (MVP)
dist-newstyle/build/wasm32-wasi/ghc-9.13.20250212/miso-examples-1.8.7.0/x/router/build/router/router.wasm:                         WebAssembly (wasm) binary module version 0x1 (MVP)
dist-newstyle/build/wasm32-wasi/ghc-9.13.20250212/miso-examples-1.8.7.0/x/simple/build/simple/simple.wasm:                         WebAssembly (wasm) binary module version 0x1 (MVP)
dist-newstyle/build/wasm32-wasi/ghc-9.13.20250212/miso-examples-1.8.7.0/x/svg/build/svg/svg.wasm:                                  WebAssembly (wasm) binary module version 0x1 (MVP)
dist-newstyle/build/wasm32-wasi/ghc-9.13.20250212/miso-examples-1.8.7.0/x/todo-mvc/build/todo-mvc/todo-mvc.wasm:                   WebAssembly (wasm) binary module version 0x1 (MVP)
dist-newstyle/build/wasm32-wasi/ghc-9.13.20250212/miso-examples-1.8.7.0/x/websocket/build/websocket/websocket.wasm:                WebAssembly (wasm) binary module version 0x1 (MVP)
```

