### PR TITLE
Fix type application parse error on GHC 9+

### DIFF
--- a/haskell-miso.org/server/Main.hs
+++ b/haskell-miso.org/server/Main.hs
@@ -40,7 +40,7 @@ main = do
       compress = gzip def { gzipFiles = GzipCompress }
 
 app :: Application
-app = serve (Proxy @ API) (static :<|> serverHandlers :<|> pure misoManifest :<|> pure robotsTxt :<|> Tagged handle404)
+app = serve (Proxy @API) (static :<|> serverHandlers :<|> pure misoManifest :<|> pure robotsTxt :<|> Tagged handle404)
   where
     static = serveDirectoryWith (defaultWebAppSettings "static")
 


### PR DESCRIPTION
See https://downloads.haskell.org/~ghc/9.0-latest/docs/html/users_guide/9.0.1-notes.html.