### PR TITLE
Use `JSaddle.Warp.debug` when run from GHCI

### DIFF
--- a/src/Miso/Runner.hs
+++ b/src/Miso/Runner.hs
@@ -17,7 +17,11 @@ run :: JSM () -> IO ()
 run = J.run
 #else
 run :: JSM () -> IO ()
+#ifndef ghcjs_HOST_OS
 run x = getProgName >>= \case
     "<interactive>" -> J.debug 8008 x
     _ -> J.run 8008 x
+#else
+run = J.run 8008
+#endif
 #endif

--- a/src/Miso/Runner.hs
+++ b/src/Miso/Runner.hs
@@ -6,10 +6,10 @@ module Miso.Runner (run) where
 import qualified Language.Javascript.JSaddle.Wasm as J
 #else
 import qualified Language.Javascript.JSaddle.Warp as J
+import           System.Environment
 #endif
 
 import           Language.Javascript.JSaddle
-import           System.Environment
 
 -- | Entry point for a miso application
 #if defined(wasm32_HOST_ARCH)

--- a/src/Miso/Runner.hs
+++ b/src/Miso/Runner.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE LambdaCase #-}
 module Miso.Runner (run) where
 
 #if defined(wasm32_HOST_ARCH)
@@ -8,6 +9,7 @@ import qualified Language.Javascript.JSaddle.Warp as J
 #endif
 
 import           Language.Javascript.JSaddle
+import           System.Environment
 
 -- | Entry point for a miso application
 #if defined(wasm32_HOST_ARCH)
@@ -15,5 +17,7 @@ run :: JSM () -> IO ()
 run = J.run
 #else
 run :: JSM () -> IO ()
-run = J.run 8008
+run x = getProgName >>= \case
+    "<interactive>" -> J.debug 8008 x
+    _ -> J.run 8008 x
 #endif


### PR DESCRIPTION
The `jsaddle-warp` support added in #768 uses the `run` function.

While working on [similar support](https://github.com/tweag/ghc-wasm-miso-examples/pull/23) previously, I found that `debug` is much more useful than `run` in practice due to supporting live reloading, but it's meant to be used in GHCI, and with `cabal run` it just exits. With this PR, we use `debug` if and only if we're in GHCI. Matching on `"<interactive>"` is a bit ugly, but it's the only way I know of detecting this.

Most usefully, with this change, it's possible to use a command like `ghcid -c 'cabal repl simple' -Wr` for reloading on file save, or, if you're feeling fancy, `ghcid -c 'cabal repl --enable-multi-repl simple miso' -W -T Main.main`. This is _particularly_ nice with something like #749, which I'll try to get back to soon.

We might often want `debugOr` rather than just `debug`, in order to also serve static files. But, similarly to setting a port other than `8008`, maybe it's best for now if users just use their own CPP in that case. One step at a time.

We could also investigate upstream why `debug` can't be used everywhere (I expect it's due to forking to a background thread), but I'm hopeful that `jsaddle-warp` will be obsolete before too long, once we have [better GHCI support for Wasm](https://www.tweag.io/blog/2024-11-21-ghc-wasm-th-ghci/#what-comes-next).