### PR TITLE
Fix broken source link on haskell-miso.org

### DIFF
--- a/haskell-miso.org/shared/Common.hs
+++ b/haskell-miso.org/shared/Common.hs
@@ -417,7 +417,7 @@ footer =
               [ text " licensed." ]
          ]
          , p_ [] [ text "The source code for this website is located "
-                 , a_ [ href_  "https://github.com/dmjio/miso/tree/master/examples/haskell-miso.org"
+                 , a_ [ href_  "https://github.com/dmjio/miso/tree/master/haskell-miso.org"
                       , style_ $ M.singleton "color" "#363636"
                       ] [  text" here."]
                  ]


### PR DESCRIPTION
Didn't want to make a whole issue for such a minor change but the recent move of the haskell-miso.org source to the top-level directory broke the website's link to its source code. This fixes the issue.