### PR TITLE
Add upper bounds to miso.cabal file.

### DIFF
--- a/miso.cabal
+++ b/miso.cabal
@@ -54,20 +54,20 @@ common string-selector
 common jsaddle
   if !(impl(ghcjs) || arch(javascript) || arch(wasm32))
     build-depends:
-      jsaddle-warp
+      jsaddle-warp < 0.10
 
   if !(impl(ghcjs) || arch(javascript))
     build-depends:
-      file-embed
+      file-embed < 0.1
 
   if arch(wasm32)
     build-depends:
-      jsaddle-wasm
+      jsaddle-wasm < 0.2
 
 common client
   if impl(ghcjs) || arch(javascript)
     build-depends:
-      ghcjs-base
+      ghcjs-base -any
 
   if impl(ghcjs) || arch(javascript) || arch(wasm32)
     js-sources:
@@ -179,16 +179,16 @@ library
   hs-source-dirs:
     src
   build-depends:
-    aeson,
-    base < 5,
-    bytestring,
-    containers,
-    http-api-data,
-    http-types,
-    jsaddle,
-    lucid,
-    network-uri,
-    servant,
-    tagsoup,
-    text,
-    transformers
+    aeson         < 2.3,
+    base          < 5,
+    bytestring    < 0.13,
+    containers    < 0.9,
+    http-api-data < 0.9,
+    http-types    < 0.13,
+    jsaddle       < 0.10,
+    lucid         < 2.12,
+    network-uri   < 2.7,
+    servant       < 0.21,
+    tagsoup       < 0.15,
+    text          < 2.2,
+    transformers  < 0.7


### PR DESCRIPTION
Now that miso is supported by the GHC WASM backend (which is integrated with the cabal workflow). We should begin specifying version bounds for cabal's resolver as opposed to relying on nixpkgs to pin all versions.

cc @georgefst @hvr