### PR TITLE
Ensure that target exists before delegation.

### DIFF
--- a/jsbits/delegate.js
+++ b/jsbits/delegate.js
@@ -36,8 +36,10 @@ window['delegate'] = function (mount, events, getVTree) {
 };
 
 window['listener'] = function(e, mount, getVTree) {
-   getVTree(function (obj) {
-      window['delegateEvent'](e, obj, window['buildTargetToElement'](mount, e.target), []);
+    getVTree(function (obj) {
+	if (e.target) {
+	    window['delegateEvent'](e, obj, window['buildTargetToElement'](mount, e.target), []);
+	}
    });
 }
 


### PR DESCRIPTION
In some rare circumstances `event.target` can be `null` if diffing has removed a DOM node before an event handler is invoked. This can occur with high load events like mouse*. This check avoids null reference exceptions during delegation.

@brakubraku