### PR TITLE
Cleanup Subs

### DIFF
--- a/examples/components/Main.hs
+++ b/examples/components/Main.hs
@@ -4,10 +4,12 @@
 {-# LANGUAGE CPP #-}
 module Main where
 
-import           Control.Monad.IO.Class (liftIO)
+import Control.Monad
+import Control.Concurrent
+import Control.Monad.IO.Class (liftIO)
 
-import           Miso
-import           Miso.String
+import Miso
+import Miso.String
 
 type Model = Int
 
@@ -39,17 +41,28 @@ main = run (startComponent mainComponent)
 mainComponent :: Component "main" MainModel MainAction
 mainComponent = component app { logLevel = DebugPrerender }
 
+secs :: Int -> Int
+secs = (*1000000)
+
 app :: App MainModel MainAction
-app = defaultApp True updateModel1 viewModel1 MainNoOp
+app = (defaultApp True updateModel1 viewModel1 MainNoOp)
+  { subs = [ \_ -> forever $ threadDelay (secs 1) >> consoleLog "main app" ]
+  }
 
 component2 :: Component "component-2" Model Action
 component2 = component counterApp2
+  { subs = [ \_ -> forever $ threadDelay (secs 1) >> consoleLog "component-2 sub" ]
+  }
 
 component3 :: Component "component-3" (Bool, Model) Action
 component3 = component counterApp3
+  { subs = [ \_ -> forever $ threadDelay (secs 1) >> consoleLog "component-3 sub" ]
+  }
 
 component4 :: Component "component-4" Model Action
 component4 = component counterApp4
+  { subs = [ \_ -> forever $ threadDelay (secs 1) >> consoleLog "component-4 sub" ]
+  }
 
 -- | Constructs a virtual DOM from a model
 viewModel1 :: MainModel -> View MainAction

--- a/examples/components/Main.hs
+++ b/examples/components/Main.hs
@@ -44,24 +44,30 @@ mainComponent = component app { logLevel = DebugPrerender }
 secs :: Int -> Int
 secs = (*1000000)
 
+loggerSub :: MisoString -> Sub action
+loggerSub msg = \_ ->
+  forever $ do
+    liftIO $ threadDelay (secs 1)
+    consoleLog msg
+
 app :: App MainModel MainAction
 app = (defaultApp True updateModel1 viewModel1 MainNoOp)
-  { subs = [ \_ -> forever $ threadDelay (secs 1) >> consoleLog "main app" ]
+  { subs = [ loggerSub "main-app" ]
   }
 
 component2 :: Component "component-2" Model Action
 component2 = component counterApp2
-  { subs = [ \_ -> forever $ threadDelay (secs 1) >> consoleLog "component-2 sub" ]
+  { subs = [ loggerSub "component-2 sub" ]
   }
 
 component3 :: Component "component-3" (Bool, Model) Action
 component3 = component counterApp3
-  { subs = [ \_ -> forever $ threadDelay (secs 1) >> consoleLog "component-3 sub" ]
+  { subs = [ loggerSub "component-3 sub" ]
   }
 
 component4 :: Component "component-4" Model Action
 component4 = component counterApp4
-  { subs = [ \_ -> forever $ threadDelay (secs 1) >> consoleLog "component-4 sub" ]
+  { subs = [ loggerSub "component-4 sub" ]
   }
 
 -- | Constructs a virtual DOM from a model

--- a/jsbits/delegate.js
+++ b/jsbits/delegate.js
@@ -1,29 +1,4 @@
 window = typeof window === 'undefined' ? {} : window;
-window['oldCallbacks'] = [];
-window['currentCallbacks'] = [];
-
-/* Callbacks in ghcjs need to be released. With this function one can register
-   callbacks that should be released right before diffing.
-   */
-window['registerCallback'] = function registerCallback(cb) {
-  window['currentCallbacks'].push(cb);
-};
-
-/* Swaps out the new calbacks for old callbacks.
-The old callbacks should be cleared once the new callbacks have replaced them.
-*/
-window['swapCallbacks'] = function swapCallbacks() {
-  window['oldCallbacks'] = window['currentCallbacks'];
-  window['currentCallbacks'] = [];
-};
-
-/* This releases the old callbacks. */
-window['releaseCallbacks'] = function releaseCallbacks() {
-  for (var i in window['oldCallbacks'])
-    h$release(window['oldCallbacks'][i]);
-
-  window['oldCallbacks'] = [];
-};
 
 /* event delegation algorithm */
 window['delegate'] = function (mount, events, getVTree) {

--- a/jsbits/isomorphic.js
+++ b/jsbits/isomorphic.js
@@ -80,7 +80,7 @@ window['integrityCheck'] = function (result, vtree) {
             console.warn ('VText node content differs', vtree);
             result = false;
         } else {
-            console.info('VText nodes are identical proceed', '"' + vtree['text'] + '"');
+            console.info('VText nodes are identical', '"' + vtree['text'] + '"');
         }
     }
 
@@ -92,9 +92,9 @@ window['integrityCheck'] = function (result, vtree) {
             console.warn ('Integrity check failed, tags differ', vtree['tag'].toUpperCase(), vtree['domRef'].tagName);
             result = false;
         } else if (vtree['type'] === 'vnode') {
-            console.info('VNode tags are identical proceed', vtree['tag']);
+            console.info('VNode tags are identical', vtree['tag']);
         } else {
-            console.info('VComp tags are identical proceed', vtree['tag']);
+            console.info('VComp tags are identical', vtree['tag']);
         }
 
         // Child lengths must be identical

--- a/src/Miso.hs
+++ b/src/Miso.hs
@@ -63,7 +63,7 @@ import           Data.FileEmbed
 miso :: Eq model => (URI -> App model action) -> JSM ()
 miso f = withJS $ do
   app@App {..} <- f <$> getCurrentURI
-  common app $ \snk -> do
+  initialize app $ \snk -> do
     VTree (Object iv) <- runView Prerender (view model) snk
     let mount = getMountPoint mountPoint
     mountEl <- mountElement mount
@@ -81,7 +81,7 @@ misoComponent
   -> JSM ()
 misoComponent f = withJS $ do
   Component name app@App {..} <- f <$> getCurrentURI
-  common app $ \snk -> do
+  initialize app $ \snk -> do
     vtree@(VTree (Object jval)) <- runView Prerender (view model) snk
     mount <- getBody
     setBodyComponent name
@@ -92,7 +92,7 @@ misoComponent f = withJS $ do
 -- | Runs a miso application
 startApp :: Eq model => App model action -> JSM ()
 startApp app@App {..} = withJS $
-  common app $ \snk -> do
+  initialize app $ \snk -> do
     vtree <- runView DontPrerender (view model) snk
     let mount = getMountPoint mountPoint
     mountEl <- mountElement mount
@@ -103,7 +103,7 @@ startApp app@App {..} = withJS $
 -- | Runs a miso application (as a @Component@)
 -- Note: uses the 'name' as the mount point.
 startComponent :: Eq model => Component name model action -> JSM ()
-startComponent (Component name app@App{..}) = withJS $ common app $ \snk -> do
+startComponent (Component name app@App{..}) = withJS $ initialize app $ \snk -> do
   vtree <- runView DontPrerender (view model) snk
   mount <- getBody
   setBodyComponent name

--- a/src/Miso.hs
+++ b/src/Miso.hs
@@ -69,7 +69,6 @@ miso f = withJS $ do
     VTree (Object iv) <- runView Prerender (view model) snk
     let mount = getMountPoint mountPoint
     mountEl <- getBody
-    -- Initial diff can be bypassed, just copy DOM into VTree
     copyDOMIntoVTree (logLevel == DebugPrerender) mountEl iv
     ref <- liftIO $ newIORef $ VTree (Object iv)
     pure (mount, mountEl, ref)

--- a/src/Miso.hs
+++ b/src/Miso.hs
@@ -70,7 +70,6 @@ miso f = withJS $ do
     -- Initial diff can be bypassed, just copy DOM into VTree
     copyDOMIntoVTree (logLevel == DebugPrerender) mountEl iv
     ref <- liftIO $ newIORef $ VTree (Object iv)
-    registerSink mount mountEl ref snk
     pure (mount, mountEl, ref)
 
 -- | Runs a miso application (as a @Component@)
@@ -88,7 +87,6 @@ misoComponent f = withJS $ do
     setBodyComponent name
     copyDOMIntoVTree (logLevel == DebugPrerender) mount jval
     ref <- liftIO (newIORef vtree)
-    registerSink name mount ref snk
     pure (name, mount, ref)
 
 -- | Runs a miso application
@@ -100,7 +98,6 @@ startApp app@App {..} = withJS $
     mountEl <- mountElement mount
     diff mountEl Nothing (Just vtree)
     ref <- liftIO (newIORef vtree)
-    registerSink mount mountEl ref snk
     pure (mount, mountEl, ref)
 
 -- | Runs a miso application (as a @Component@)
@@ -112,7 +109,6 @@ startComponent (Component name app@App{..}) = withJS $ common app $ \snk -> do
   setBodyComponent name
   diff mount Nothing (Just vtree)
   ref <- liftIO (newIORef vtree)
-  registerSink name mount ref snk
   pure (name, mount, ref)
 
 withJS :: JSM a -> JSM ()

--- a/src/Miso/Effect.hs
+++ b/src/Miso/Effect.hs
@@ -24,7 +24,6 @@ module Miso.Effect
 
 import Data.Bifunctor
 
-import Control.Monad.IO.Class
 import Miso.FFI (JSM)
 
 -- | An effect represents the results of an update action.
@@ -41,7 +40,7 @@ data Effect action model = Effect model [Sub action]
 type Sub action = Sink action -> JSM ()
 
 -- | Function to asynchronously dispatch actions to the 'Miso.Types.update' function.
-type Sink action = action -> IO ()
+type Sink action = action -> JSM ()
 
 -- | Turn a subscription that consumes actions of type @a@ into a subscription
 -- that consumes actions of type @b@ using the supplied function of type @a -> b@.
@@ -71,7 +70,7 @@ noEff m = Effect m []
 
 -- | Smart constructor for an 'Effect' with exactly one action.
 (<#) :: model -> JSM action -> Effect action model
-(<#) m a = effectSub m $ \sink -> a >>= liftIO . sink
+(<#) m a = effectSub m $ \sink -> a >>= sink
 
 -- | `Effect` smart constructor, flipped
 (#>) :: JSM action -> model -> Effect action model
@@ -80,7 +79,7 @@ noEff m = Effect m []
 -- | Smart constructor for an 'Effect' with multiple actions.
 batchEff :: model -> [JSM action] -> Effect action model
 batchEff model actions = Effect model $
-  map (\a sink -> liftIO . sink =<< a) actions
+  map (\a sink -> sink =<< a) actions
 
 -- | Like '<#' but schedules a subscription which is an IO computation which has
 -- access to a 'Sink' which can be used to asynchronously dispatch actions to

--- a/src/Miso/FFI.hs
+++ b/src/Miso/FFI.hs
@@ -44,9 +44,6 @@ module Miso.FFI
    , delegateEvent
    , undelegateEvent
    , copyDOMIntoVTree
-   , swapCallbacks
-   , releaseCallbacks
-   , registerCallback
    , focus
    , blur
    , scrollIntoView
@@ -281,20 +278,6 @@ copyDOMIntoVTree :: Bool -> JSVal -> JSVal -> JSM ()
 copyDOMIntoVTree logLevel mountPoint vtree = void $ do
   doc <- getDoc
   jsg4 "copyDOMIntoVTree" logLevel mountPoint vtree doc
-
--- TODO For now, we do not free callbacks when compiling with JSaddle
-
--- | Pins down the current callbacks for clearing later
-swapCallbacks :: JSM ()
-swapCallbacks = pure ()
-
--- | Releases callbacks registered by the virtual DOM.
-releaseCallbacks :: JSM ()
-releaseCallbacks = pure ()
-
--- | Mock for callback registration
-registerCallback :: JSVal -> JSM ()
-registerCallback _ = pure ()
 
 -- | Fails silently if the element is not found.
 --

--- a/src/Miso/FFI.hs
+++ b/src/Miso/FFI.hs
@@ -18,7 +18,6 @@ module Miso.FFI
    , syncCallback1
    , asyncCallback
    , asyncCallback1
-   , callbackToJSVal
    , ghcjsPure
    , syncPoint
    , addEventListener
@@ -93,10 +92,6 @@ asyncCallback1 f = asyncFunction (\_ _ [x] -> f x)
 
 syncCallback1 :: (JSVal -> JSM ()) -> JSM Function
 syncCallback1 f = function (\_ _ [x] -> f x)
-
--- | Convert a Callback into a JSVal
-callbackToJSVal :: Function -> JSM JSVal
-callbackToJSVal = toJSVal
 
 -- | Set property on object
 set :: ToJSVal v => MisoString -> v -> OI.Object -> JSM ()

--- a/src/Miso/Html/Types.hs
+++ b/src/Miso/Html/Types.hs
@@ -125,7 +125,7 @@ onWithOptions options eventName Decoder{..} toAction =
    eventHandlerObject@(Object eo) <- create
    jsOptions <- toJSVal options
    decodeAtVal <- toJSVal decodeAt
-   cb <- callbackToJSVal <=< asyncCallback1 $ \e -> do
+   cb <- toJSVal <=< asyncCallback1 $ \e -> do
        Just v <- fromJSVal =<< objectToJSON decodeAtVal e
        case parseEither decoder v of
          Left s -> error $ "Parse error on " <> unpack eventName <> ": " <> s
@@ -143,7 +143,7 @@ onWithOptions options eventName Decoder{..} toAction =
 onCreated :: action -> Attribute action
 onCreated action =
   E $ \sink n -> do
-    cb <- callbackToJSVal =<< syncCallback (sink action)
+    cb <- toJSVal =<< syncCallback (sink action)
     set "onCreated" cb n
     registerCallback cb
 
@@ -156,7 +156,7 @@ onCreated action =
 onDestroyed :: action -> Attribute action
 onDestroyed action =
   E $ \sink n -> do
-    cb <- callbackToJSVal =<< syncCallback (sink action)
+    cb <- toJSVal =<< syncCallback (sink action)
     set "onDestroyed" cb n
     registerCallback cb
 
@@ -169,7 +169,7 @@ onDestroyed action =
 onBeforeDestroyed :: action -> Attribute action
 onBeforeDestroyed action =
   E $ \sink n -> do
-    cb <- callbackToJSVal =<< syncCallback (sink action)
+    cb <- toJSVal =<< syncCallback (sink action)
     set "onBeforeDestroyed" cb n
     registerCallback cb
 

--- a/src/Miso/Html/Types.hs
+++ b/src/Miso/Html/Types.hs
@@ -125,13 +125,12 @@ onWithOptions options eventName Decoder{..} toAction =
    eventHandlerObject@(Object eo) <- create
    jsOptions <- toJSVal options
    decodeAtVal <- toJSVal decodeAt
-   cb <- toJSVal <=< asyncCallback1 $ \e -> do
+   cb <- asyncCallback1 $ \e -> do
        Just v <- fromJSVal =<< objectToJSON decodeAtVal e
        case parseEither decoder v of
          Left s -> error $ "Parse error on " <> unpack eventName <> ": " <> s
          Right r -> sink (toAction r)
    set "runEvent" cb eventHandlerObject
-   registerCallback cb
    set "options" jsOptions eventHandlerObject
    set eventName eo (Object eventObj)
 
@@ -143,9 +142,8 @@ onWithOptions options eventName Decoder{..} toAction =
 onCreated :: action -> Attribute action
 onCreated action =
   E $ \sink n -> do
-    cb <- toJSVal =<< syncCallback (sink action)
+    cb <- syncCallback (sink action)
     set "onCreated" cb n
-    registerCallback cb
 
 -- | @onDestroyed action@ is an event that gets called after the DOM element
 -- is removed from the DOM. The @action@ is given the DOM element that was
@@ -156,9 +154,8 @@ onCreated action =
 onDestroyed :: action -> Attribute action
 onDestroyed action =
   E $ \sink n -> do
-    cb <- toJSVal =<< syncCallback (sink action)
+    cb <- syncCallback (sink action)
     set "onDestroyed" cb n
-    registerCallback cb
 
 -- | @onBeforeDestroyed action@ is an event that gets called before the DOM element
 -- is removed from the DOM. The @action@ is given the DOM element that was
@@ -169,9 +166,8 @@ onDestroyed action =
 onBeforeDestroyed :: action -> Attribute action
 onBeforeDestroyed action =
   E $ \sink n -> do
-    cb <- toJSVal =<< syncCallback (sink action)
+    cb <- syncCallback (sink action)
     set "onBeforeDestroyed" cb n
-    registerCallback cb
 
 -- | @style_ attrs@ is an attribute that will set the @style@
 -- attribute of the associated DOM node to @attrs@.

--- a/src/Miso/Html/Types.hs
+++ b/src/Miso/Html/Types.hs
@@ -37,7 +37,6 @@ module Miso.Html.Types (
     ) where
 
 import           Control.Monad
-import           Control.Monad.IO.Class (liftIO)
 import           Data.Aeson (ToJSON, toJSON)
 import           Data.Aeson.Types (parseEither)
 import qualified Data.Map.Strict as M
@@ -130,7 +129,7 @@ onWithOptions options eventName Decoder{..} toAction =
        Just v <- fromJSVal =<< objectToJSON decodeAtVal e
        case parseEither decoder v of
          Left s -> error $ "Parse error on " <> unpack eventName <> ": " <> s
-         Right r -> liftIO (sink (toAction r))
+         Right r -> sink (toAction r)
    set "runEvent" cb eventHandlerObject
    registerCallback cb
    set "options" jsOptions eventHandlerObject
@@ -144,7 +143,7 @@ onWithOptions options eventName Decoder{..} toAction =
 onCreated :: action -> Attribute action
 onCreated action =
   E $ \sink n -> do
-    cb <- callbackToJSVal =<< syncCallback (liftIO (sink action))
+    cb <- callbackToJSVal =<< syncCallback (sink action)
     set "onCreated" cb n
     registerCallback cb
 
@@ -157,7 +156,7 @@ onCreated action =
 onDestroyed :: action -> Attribute action
 onDestroyed action =
   E $ \sink n -> do
-    cb <- callbackToJSVal =<< syncCallback (liftIO (sink action))
+    cb <- callbackToJSVal =<< syncCallback (sink action)
     set "onDestroyed" cb n
     registerCallback cb
 
@@ -170,7 +169,7 @@ onDestroyed action =
 onBeforeDestroyed :: action -> Attribute action
 onBeforeDestroyed action =
   E $ \sink n -> do
-    cb <- callbackToJSVal =<< syncCallback (liftIO (sink action))
+    cb <- callbackToJSVal =<< syncCallback (sink action)
     set "onBeforeDestroyed" cb n
     registerCallback cb
 

--- a/src/Miso/Internal.hs
+++ b/src/Miso/Internal.hs
@@ -76,12 +76,10 @@ initialize App {..} getView = do
         oldName <- liftIO $ oldModel `seq` makeStableName oldModel
         newName <- liftIO $ newModel `seq` makeStableName newModel
         when (oldName /= newName && oldModel /= newModel) $ do
-          swapCallbacks
           newVTree <- runView DontPrerender (view newModel) eventSink
           oldVTree <- liftIO (readIORef viewRef)
           void waitForAnimationFrame
           diff mountEl (Just oldVTree) (Just newVTree)
-          releaseCallbacks
           liftIO (atomicWriteIORef viewRef newVTree)
         syncPoint
         loop newModel

--- a/src/Miso/Internal.hs
+++ b/src/Miso/Internal.hs
@@ -24,6 +24,7 @@ import           Control.Concurrent
 import           Control.Monad (forM, forM_, (<=<), when, forever, void)
 import           Control.Monad.IO.Class
 import qualified Data.Aeson as A
+import           Data.Foldable (toList)
 import           Data.IORef (IORef, newIORef, atomicModifyIORef', readIORef, atomicWriteIORef, modifyIORef')
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as M

--- a/src/Miso/Internal.hs
+++ b/src/Miso/Internal.hs
@@ -64,10 +64,7 @@ initialize App {..} getView = do
 
   -- init Subs, save threads for destruction later
   subThreads <- forM subs $ \sub -> forkJSM (sub eventSink)
-  -- Hack to get around `BlockedIndefinitelyOnMVar` exception
-  -- that occurs when no event handlers are present on a template
-  -- and `notify` is no longer in scope
-  void . liftIO . forkIO . forever $ threadDelay (1000000 * 86400) >> serve
+
   -- Retrieves reference view
   (mount, mountEl, viewRef) <- getView eventSink
   -- Program loop, blocking on SkipChan

--- a/src/Miso/Internal.hs
+++ b/src/Miso/Internal.hs
@@ -214,12 +214,11 @@ runView
   -> JSM VTree
 runView prerender (Embed (SomeComponent (Component name app)) (ComponentOptions {..})) snk = do
   let mount = name
-  -- By default components should be mounted sychronously.
-  -- We also include async mounting for tools like jsaddle-warp.
-  -- mounting causes a recursive diff to occur, creating subcomponents
-  -- and setting up infrastructure for each sub-component. During this
-  -- process we go between the haskell heap and the js heap.
-  -- It's important that things remain synchronous during this process.
+  -- Component mounting should be sychronous.
+  -- Mounting causes a recursive diff to occur,
+  -- creating sub components as detected, setting up
+  -- infrastructure for each sub-component. During this
+  -- process we go between the Haskell heap and the JS heap.
   mountCb <- do
     syncCallback1 $ \continuation -> do
       forM_ onMounted snk

--- a/src/Miso/Subscription/History.hs
+++ b/src/Miso/Subscription/History.hs
@@ -90,9 +90,9 @@ uriSub :: (URI -> action) -> Sub action
 uriSub = \f sink -> do
   void.forkJSM.forever $ do
     liftIO (wait chan)
-    liftIO . sink . f =<< getURI
+    sink . f =<< getURI
   windowAddEventListener "popstate" $ \_ ->
-      liftIO . sink . f =<< getURI
+    sink . f =<< getURI
 
 pushStateNoModel :: URI -> JSM ()
 {-# INLINE pushStateNoModel #-}

--- a/src/Miso/Subscription/Keyboard.hs
+++ b/src/Miso/Subscription/Keyboard.hs
@@ -88,14 +88,14 @@ keyboardSub f sink = do
           newKeys <- liftIO $ atomicModifyIORef' keySetRef $ \keys ->
              let !new = S.insert key keys
              in (new, new)
-          liftIO (sink (f newKeys))
+          sink (f newKeys)
 
       keyUpCallback keySetRef = \keyUpEvent -> do
           Just key <- fromJSVal =<< getProp "keyCode" (Object keyUpEvent)
           newKeys <- liftIO $ atomicModifyIORef' keySetRef $ \keys ->
              let !new = S.delete key keys
              in (new, new)
-          liftIO (sink (f newKeys))
+          sink (f newKeys)
 
       -- Assume keys are released the moment focus is lost. Otherwise going
       -- back and forth to the app can cause keys to get stuck.
@@ -103,4 +103,4 @@ keyboardSub f sink = do
           newKeys <- liftIO $ atomicModifyIORef' keySetRef $ \_ ->
             let !new = S.empty
             in (new, new)
-          liftIO (sink (f newKeys))
+          sink (f newKeys)

--- a/src/Miso/Subscription/Mouse.hs
+++ b/src/Miso/Subscription/Mouse.hs
@@ -11,7 +11,6 @@
 ----------------------------------------------------------------------------
 module Miso.Subscription.Mouse (mouseSub) where
 
-import Control.Monad.IO.Class
 import GHCJS.Marshal
 import JavaScript.Object
 import JavaScript.Object.Internal
@@ -27,4 +26,4 @@ mouseSub f = \sink -> do
     \mouseEvent -> do
       Just x <- fromJSVal =<< getProp "clientX" (Object mouseEvent)
       Just y <- fromJSVal =<< getProp "clientY" (Object mouseEvent)
-      liftIO (sink $ f (x,y))
+      sink $ f (x,y)

--- a/src/Miso/Subscription/SSE.hs
+++ b/src/Miso/Subscription/SSE.hs
@@ -17,7 +17,6 @@ module Miso.Subscription.SSE
  , SSE (..)
  ) where
 
-import           Control.Monad.IO.Class
 import           Data.Aeson
 import           Miso.Types (Sub)
 import           Miso.FFI
@@ -31,11 +30,11 @@ sseSub url f = \sink -> do
   es <- SSE.new url
   SSE.addEventListener es "message" $ \val -> do
     dat <- parse =<< SSE.data' val
-    (liftIO . sink) (f (SSEMessage dat))
+    sink (f (SSEMessage dat))
   SSE.addEventListener es "error" $ \_ ->
-    (liftIO . sink) (f SSEError)
+    sink (f SSEError)
   SSE.addEventListener es "close" $ \_ ->
-    (liftIO . sink) (f SSEClose)
+    sink (f SSEClose)
 
 -- | Server-sent events data
 data SSE message

--- a/src/Miso/Subscription/Window.hs
+++ b/src/Miso/Subscription/Window.hs
@@ -12,7 +12,6 @@
 module Miso.Subscription.Window where
 
 import Control.Monad
-import Control.Monad.IO.Class
 
 import GHCJS.Marshal
 import JavaScript.Object
@@ -29,13 +28,13 @@ import Data.Aeson.Types (parseEither)
 -- an event sink
 windowCoordsSub :: ((Int, Int) -> action) -> Sub action
 windowCoordsSub f = \sink -> do
-  liftIO . sink . f =<< (,) <$> windowInnerHeight <*> windowInnerWidth
+  sink . f =<< (,) <$> windowInnerHeight <*> windowInnerWidth
   windowAddEventListener "resize" $
     \windowEvent -> do
       target <- getProp "target" (Object windowEvent)
       Just w <- fromJSVal =<< getProp "innerWidth" (Object target)
       Just h <- fromJSVal =<< getProp "innerHeight" (Object target)
-      liftIO . sink $ f (h, w)
+      sink $ f (h, w)
 
 -- | @windowSub eventName decoder toAction@ is a subscription which parallels the
 -- attribute handler `on`, providing a subscription to listen to window level events.
@@ -55,4 +54,4 @@ windowSubWithOptions Options{..} eventName Decoder{..} toAction = \sink -> do
         Right r -> do
           when stopPropagation $ eventStopPropagation e
           when preventDefault $ eventPreventDefault e
-          liftIO (sink (toAction r))
+          sink (toAction r)

--- a/src/Miso/Types.hs
+++ b/src/Miso/Types.hs
@@ -55,7 +55,6 @@ module Miso.Types
   , module Miso.Effect
   ) where
 
-import           Control.Monad.IO.Class
 import           Control.Monad.Trans.Class (lift)
 import           Control.Monad.Trans.State.Strict (StateT(StateT), execStateT, mapStateT)
 import           Control.Monad.Trans.Writer.Strict (Writer, tell, mapWriter, runWriter)
@@ -193,7 +192,7 @@ toTransition f =
 -- Note that multiple IO action can be scheduled using
 -- @Control.Monad.Writer.Class.tell@ from the @mtl@ library.
 scheduleIO :: JSM action -> Transition action model ()
-scheduleIO ioAction = scheduleSub $ \sink -> ioAction >>= liftIO . sink
+scheduleIO ioAction = scheduleSub $ \sink -> ioAction >>= sink
 
 -- | Like 'scheduleIO' but doesn't cause an action to be dispatched to
 -- the 'update' function.
@@ -207,7 +206,7 @@ scheduleIO_ ioAction = scheduleSub $ \_sink -> ioAction
 --
 -- This is handy for scheduling IO computations that return a `Maybe` value
 scheduleIOFor_ :: Foldable f => JSM (f action) -> Transition action model ()
-scheduleIOFor_ io = scheduleSub $ \sink -> io >>= \m -> liftIO (for_ m sink)
+scheduleIOFor_ io = scheduleSub $ \sink -> io >>= flip for_ sink
 
 -- | Like 'scheduleIO' but schedules a subscription which is an IO
 -- computation that has access to a 'Sink' which can be used to


### PR DESCRIPTION
- Create 'ComponentState' to house component lifetime
- Add top-level 'unmount' function
- Remove duplicate calls to 'sink'
- Kill all threads associated with a 'Sub' on component unmount.
- Add example to component to show Sub cleanup
- Sink initial action after forking event loop 
- Remove `BlockedIndefinitelyOnMVar` hack (now that we store `Sink action` in a global `IORef`
- Use proper mount points, document top-level functions w/ mounting.
- Move `type Sink a = a -> IO ()` to `type Sink a = a -> JSM ()`