### PR TITLE
Split out events.

### DIFF
--- a/examples/todo-mvc/Main.hs
+++ b/examples/todo-mvc/Main.hs
@@ -89,7 +89,7 @@ main = run $ startApp App { initialAction = NoOp, ..}
     model      = emptyModel
     update     = updateModel
     view       = viewModel
-    events     = defaultEvents
+    events     = defaultEvents <> keyboardEvents
     mountPoint = Nothing
     subs       = []
     logLevel   = Off

--- a/examples/websocket/Main.hs
+++ b/examples/websocket/Main.hs
@@ -29,7 +29,7 @@ main :: IO ()
 main = run $ startApp App { initialAction = Id, ..}
   where
     model = Model (Message "") mempty
-    events = defaultEvents
+    events = defaultEvents <> keyboardEvents
     subs = [ websocketSub uri protocols HandleWebSocket ]
     update = updateModel
     view = appView

--- a/src/Miso/Event/Types.hs
+++ b/src/Miso/Event/Types.hs
@@ -59,28 +59,42 @@ newtype AllowDrop = AllowDrop Bool
 
 -- | Default delegated events
 defaultEvents :: M.Map MisoString Bool
-defaultEvents = M.fromList [
-    ("blur", True)
+defaultEvents = M.fromList
+  [ ("blur", True)
   , ("change", False)
   , ("click", False)
   , ("dblclick", False)
   , ("focus", False)
   , ("input", False)
-  , ("keydown", False)
+  , ("select", False)
+  , ("submit", False)
+  ]
+
+keyboardEvents :: M.Map MisoString Bool
+keyboardEvents = M.fromList
+  [ ("keydown", False)
   , ("keypress", False)
   , ("keyup", False)
-  , ("mouseup", False)
+  ]
+
+mouseEvents :: M.Map MisoString Bool
+mouseEvents = M.fromList
+  [ ("mouseup", False)
   , ("mousedown", False)
   , ("mouseenter", True)
   , ("mouseleave", False)
   , ("mouseover", False)
   , ("mouseout", False)
-  , ("dragstart", False)
+  ]
+
+dragEvents :: M.Map MisoString Bool
+dragEvents = M.fromList
+  [ ("dragstart", False)
   , ("dragover", False)
   , ("dragend", False)
   , ("dragenter", False)
   , ("dragleave", False)
   , ("drag", False)
   , ("drop", False)
-  , ("submit", False)
   ]
+

--- a/src/Miso/Html/Event.hs
+++ b/src/Miso/Html/Event.hs
@@ -46,6 +46,8 @@ module Miso.Html.Event
   , onDragOver
   -- * Drop events
   , onDrop
+  -- * Select events
+  , onSelect
   ) where
 
 import Miso.Html.Types ( Attribute, on, onWithOptions )
@@ -82,6 +84,10 @@ onInput = on "input" valueDecoder
 -- | https://developer.mozilla.org/en-US/docs/Web/Events/change
 onChange :: (MisoString -> action) -> Attribute action
 onChange = on "change" valueDecoder
+
+-- | https://developer.mozilla.org/en-US/docs/Web/Events/select
+onSelect :: (MisoString -> action) -> Attribute action
+onSelect = on "select" valueDecoder
 
 -- | https://developer.mozilla.org/en-US/docs/Web/Events/keydown
 onKeyDownWithInfo :: (KeyInfo -> action) -> Attribute action


### PR DESCRIPTION
For performance reasons its good if we don't listen on all mouse / drag events. It's best if users add these incrementally to their applications. This should reduce congestion in the event queue.

cc @georgefst @brakubraku