### PR TITLE
Normalize URI, drop prefix slash when parsing window.location.href

### DIFF
--- a/haskell-miso.org/shared/Common.hs
+++ b/haskell-miso.org/shared/Common.hs
@@ -418,7 +418,7 @@ hero content uri' navMenuOpen' =
                 ]
               ]
               [ a_
-                [ href_ "/"
+                [ href_ $ ms (uriPath uriHome)
                 , onPreventClick (ChangeURI uriHome)
                 , classList_
                   [ ("is-active", uriPath uri' == "")
@@ -430,7 +430,7 @@ hero content uri' navMenuOpen' =
               div_ [ classList_ [ ("nav-item",True)
                                 ]
                    ] [
-                a_ [ href_ "/examples"
+                a_ [ href_ $ ms (uriPath uriExamples)
                    , onPreventClick (ChangeURI uriExamples)
                    , textProp "current-uri-path" $ ms (uriPath uri')
                    , textProp "examples-uri-path" $ ms (uriPath uriExamples)
@@ -442,7 +442,7 @@ hero content uri' navMenuOpen' =
                                 ]
                    ]
               [
-                a_ [ href_ "/docs"
+                a_ [ href_ $ ms (uriPath uriDocs)
                    , onPreventClick (ChangeURI uriDocs)
                    , classList_ [ ("is-active", uriPath uri' == uriPath uriDocs)
                                 ]
@@ -453,7 +453,7 @@ hero content uri' navMenuOpen' =
                                 ]
                    ]
               [
-                a_ [ href_ "/community"
+                a_ [ href_ $ ms (uriPath uriCommunity)
                    , onPreventClick (ChangeURI uriCommunity)
                    , classList_ [ ("is-active", uriPath uri' == uriPath uriCommunity)
                                 ]

--- a/src/Miso/Subscription/History.hs
+++ b/src/Miso/Subscription/History.hs
@@ -46,7 +46,11 @@ getURI = do
   case parseURI href of
     Nothing  -> fail $ "Could not parse URI from window.location: " ++ href
     Just uri ->
-      pure uri
+      pure (dropPrefix uri)
+  where
+    dropPrefix u@URI{..}
+      | '/' : xs <- uriPath = u { uriPath = xs }
+      | otherwise = u
 
 -- | Pushes a new URI onto the History stack
 pushURI :: URI -> JSM ()


### PR DESCRIPTION
- Renames 'go' prefix to 'uri' for haskell-miso.org URIs
- Normalizes URI for client and server
- Fixes a bug where current page is not highlighted in nav
- All pages are now isomorphisms between the DOM and the VDOM