### PR TITLE
Add fixity for (<#) (#>) combinators

### DIFF
--- a/examples/components/Main.hs
+++ b/examples/components/Main.hs
@@ -105,11 +105,11 @@ viewModel1 x =
 updateModel1 :: MainAction -> MainModel -> Effect MainAction MainModel
 updateModel1 MainNoOp m = noEff m
 updateModel1 Toggle m = noEff (not m)
-updateModel1 UnMountMain m = do
+updateModel1 UnMountMain m =
     m <# do
         consoleLog "Component 2 was unmounted!"
         pure MainNoOp
-updateModel1 MountMain m = do
+updateModel1 MountMain m =
     m <# do
         consoleLog "Component 2 was mounted!"
         pure MainNoOp
@@ -119,17 +119,17 @@ counterApp2 = defaultApp 0 updateModel2 viewModel2 SayHelloWorld
 
 -- | Updates model, optionally introduces side effects
 updateModel2 :: Action -> Model -> Effect Action Model
-updateModel2 AddOne m = do
+updateModel2 AddOne m =
     noEff (m + 1)
-updateModel2 SubtractOne m = do
+updateModel2 SubtractOne m =
     noEff (m - 1)
 updateModel2 NoOp m = noEff m
 updateModel2 SayHelloWorld m = noEff m
-updateModel2 UnMount m = do
+updateModel2 UnMount m =
     m <# do
         consoleLog "Component 3 was unmounted!"
         pure NoOp
-updateModel2 Mount m = do
+updateModel2 Mount m =
     m <# do
         consoleLog "Component 3 was mounted!"
         pure NoOp
@@ -161,7 +161,7 @@ updateModel3 AddOne (t, n) =
     (t, n + 1) <# do
         mail component2 AddOne
         pure NoOp
-updateModel3 SubtractOne (t, n) = do
+updateModel3 SubtractOne (t, n) =
     (t, n - 1) <# do
         mail component2 SubtractOne
         pure NoOp
@@ -205,13 +205,12 @@ updateModel4 AddOne m =
     (m + 1) <# do
         mail component2 AddOne
         pure NoOp
-updateModel4 SubtractOne m = do
+updateModel4 SubtractOne m =
     (m - 1) <# do
         mail component2 SubtractOne
         pure NoOp
 updateModel4 SayHelloWorld m =
-    m <# do
-        liftIO (putStrLn "Hello World from Component 4") >> pure NoOp
+    m <# liftIO (putStrLn "Hello World from Component 4") >> pure NoOp
 updateModel4 _ m = noEff m
 
 -- | Constructs a virtual DOM from a model

--- a/examples/simple/Main.hs
+++ b/examples/simple/Main.hs
@@ -38,15 +38,13 @@ app = defaultApp 0 updateModel viewModel SayHelloWorld
 
 -- | UpdateModels model, optionally introduces side effects
 updateModel :: Action -> Model -> Effect Action Model
-updateModel (AddOne event) m = (m + 1) <# do
-  consoleLog $ ms (show event)
-  pure NoOp
-updateModel (SubtractOne event) m = (m - 1) <# do
-  consoleLog $ ms (show event)
-  pure NoOp
+updateModel (AddOne event) m = m + 1 <#
+  NoOp <$ consoleLog (ms (show event))
+updateModel (SubtractOne event) m = m - 1 <#
+  NoOp <$ consoleLog (ms (show event))
 updateModel NoOp m = noEff m
 updateModel SayHelloWorld m =
-    m <# do liftIO (putStrLn "Hello World") >> pure NoOp
+  m <# liftIO (putStrLn "Hello World") >> pure NoOp
 
 -- | Constructs a virtual DOM from a model
 viewModel :: Model -> View Action

--- a/examples/sse/shared/Common.hs
+++ b/examples/sse/shared/Common.hs
@@ -92,6 +92,6 @@ handleSseMsg SSEError = ServerMsg "SSE error"
 
 updateModel :: Action -> Model -> Effect Action Model
 updateModel (ServerMsg msg) m = pure (m{modelMsg = "Event received: " ++ msg})
-updateModel (HandleURI u) m = m{modelUri = u} <# pure NoOp
-updateModel (ChangeURI u) m = m <# (pushURI u >> pure NoOp)
+updateModel (HandleURI u) m = m { modelUri = u } <# pure NoOp
+updateModel (ChangeURI u) m = m <# NoOp <$ pushURI u
 updateModel NoOp m = noEff m

--- a/examples/svg/Main.hs
+++ b/examples/svg/Main.hs
@@ -30,7 +30,7 @@ emptyModel :: Model
 emptyModel = Model (0, 0)
 
 updateModel :: Action -> Model -> Effect Action Model
-updateModel (HandlePointer pointer) model = noEff  model { mouseCoords = coords pointer }
+updateModel (HandlePointer pointer) model = noEff model { mouseCoords = coords pointer }
 updateModel Id model = noEff model
 
 data Action

--- a/examples/todo-mvc/Main.hs
+++ b/examples/todo-mvc/Main.hs
@@ -89,15 +89,12 @@ data Msg
     deriving (Show)
 
 main :: IO ()
-main = run $ startApp App{initialAction = NoOp, ..}
-  where
-    model = emptyModel
-    update = updateModel
-    view = viewModel
-    events = defaultEvents <> keyboardEvents
-    mountPoint = Nothing
-    subs = []
-    logLevel = Off
+main = run $ startApp app
+  { events = defaultEvents <> keyboardEvents
+  }
+
+app :: App Model Msg
+app = defaultApp emptyModel updateModel viewModel NoOp
 
 updateModel :: Msg -> Model -> Effect Msg Model
 updateModel NoOp m = noEff m

--- a/examples/xhr/Main.hs
+++ b/examples/xhr/Main.hs
@@ -18,10 +18,9 @@ import Miso hiding (defaultOptions)
 import Miso.String
 
 -- | Model
-data Model = Model
+newtype Model = Model
     { info :: Maybe APIInfo
-    }
-    deriving (Eq, Show)
+    } deriving (Eq, Show)
 
 -- | Action
 data Action
@@ -32,28 +31,18 @@ data Action
 
 -- | Main entry point
 main :: IO ()
-main = do
-    startApp
-        App
-            { model = Model Nothing
-            , initialAction = NoOp
-            , mountPoint = Nothing
-            , ..
-            }
-  where
-    update = updateModel
-    events = defaultEvents
-    subs = []
-    view = viewModel
-    logLevel = Off
+main = run (startApp app)
+
+app :: App Model Action
+app = defaultApp emptyModel updateModel viewModel NoOp
+
+emptyModel :: Model
+emptyModel = Model Nothing
 
 -- | Update your model
 updateModel :: Action -> Model -> Effect Action Model
-updateModel FetchGitHub m =
-    m <# do
-        SetGitHub <$> getGitHubAPIInfo
-updateModel (SetGitHub apiInfo) m =
-    noEff m{info = Just apiInfo}
+updateModel FetchGitHub m = m <# SetGitHub <$> getGitHubAPIInfo
+updateModel (SetGitHub apiInfo) m = noEff m {info = Just apiInfo }
 updateModel NoOp m = noEff m
 
 -- | View function, with routing

--- a/src/Miso/Effect.hs
+++ b/src/Miso/Effect.hs
@@ -69,10 +69,12 @@ noEff :: model -> Effect action model
 noEff m = Effect m []
 
 -- | Smart constructor for an 'Effect' with exactly one action.
+infixl 0 <#
 (<#) :: model -> JSM action -> Effect action model
 (<#) m a = effectSub m $ \sink -> a >>= sink
 
 -- | `Effect` smart constructor, flipped
+infixr 0 #>
 (#>) :: JSM action -> model -> Effect action model
 (#>) = flip (<#)
 

--- a/text-src/Miso/String.hs
+++ b/text-src/Miso/String.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE TypeSynonymInstances #-}


### PR DESCRIPTION
- Refactor examples to take advantage of fixity changes
- Use defaultApp smart constructor with examples

```haskell
-- dmj: bind tightest to the `model` portion
infixl 0 <#
infixr 0 #>
```

This allows convenient syntax like

```haskell
m { uri = newUri } <# NoOp <$ pushURI u
```

and

```haskell
m - 1 <# consoleLog "substracting" >> pure NoOp
```

with requiring parens