### PR TITLE
Upgrade SSE example to use cabal-version 2.2

### DIFF
--- a/examples/sse/sse.cabal
+++ b/examples/sse/sse.cabal
@@ -21,17 +21,19 @@ common client-only
   else
     buildable: False
 
+common common-modules
+  other-modules:
+     Common
+
 executable server
   import:
-    server-only
+    server-only, common-modules
   main-is:
     Main.hs
   ghc-options:
     -O2 -threaded -Wall -rtsopts
   hs-source-dirs:
     server, shared
-  other-modules:
-    Common
   build-depends:
     aeson,
     base < 5,
@@ -52,13 +54,11 @@ executable server
 
 executable client
   import:
-    client-only
+    client-only, common-modules
   main-is:
     Main.hs
   hs-source-dirs:
     client, shared
-  other-modules:
-    Common
   build-depends:
     aeson,
     base < 5,

--- a/examples/sse/sse.cabal
+++ b/examples/sse/sse.cabal
@@ -1,58 +1,70 @@
+cabal-version:       2.2
 name:                sse
 version:             0.1.0.0
 synopsis:            Server sent events example
 homepage:            https://sse.haskell-miso.org
-license:             BSD3
+license:             BSD-3-Clause
 license-file:        LICENSE
 author:              David Johnson
 maintainer:          code@dmj.io
 copyright:           David Johnson (c) 2016-2025
 category:            Web
 build-type:          Simple
-cabal-version:       >=1.10
+
+common server-only
+  if impl(ghcjs) || arch(javascript) || arch(wasm32)
+    buildable: False
+
+common client-only
+  if impl(ghcjs) || arch(javascript) || arch(wasm32)
+    buildable: True
+  else
+    buildable: False
 
 executable server
+  import:
+    server-only
   main-is:
     Main.hs
-  if impl(ghcjs) || arch(javascript)
-    buildable: False
-  else
-    ghc-options:
-      -O2 -threaded -Wall -rtsopts
-    hs-source-dirs:
-      server, shared
-    build-depends:
-      aeson,
-      base < 5,
-      binary,
-      containers,
-      http-types,
-      miso,
-      mtl,
-      network-uri,
-      servant,
-      servant-server,
-      time,
-      wai,
-      wai-extra,
-      warp
-    default-language:
-      Haskell2010
+  ghc-options:
+    -O2 -threaded -Wall -rtsopts
+  hs-source-dirs:
+    server, shared
+  other-modules:
+    Common
+  build-depends:
+    aeson,
+    base < 5,
+    binary,
+    containers,
+    http-types,
+    miso,
+    mtl,
+    network-uri,
+    servant,
+    servant-server,
+    time,
+    wai,
+    wai-extra,
+    warp
+  default-language:
+    Haskell2010
 
 executable client
+  import:
+    client-only
   main-is:
     Main.hs
-  if !impl(ghcjs) && !arch(javascript)
-    buildable: False
-  else
-    hs-source-dirs:
-      client, shared
-    build-depends:
-      aeson,
-      base < 5,
-      containers,
-      network-uri,
-      miso,
-      servant
-    default-language:
-      Haskell2010
+  hs-source-dirs:
+    client, shared
+  other-modules:
+    Common
+  build-depends:
+    aeson,
+    base < 5,
+    containers,
+    network-uri,
+    miso,
+    servant
+  default-language:
+    Haskell2010


### PR DESCRIPTION
- Use `common-modules` for `Common`