### PR TITLE
Allow Components to sample each other's local state.

### DIFF
--- a/examples/components/Main.hs
+++ b/examples/components/Main.hs
@@ -34,6 +34,7 @@ data MainAction
     | Toggle
     | MountMain
     | UnMountMain
+    | SampleChild
 
 type MainModel = Bool
 
@@ -91,6 +92,7 @@ viewModel1 x =
         , "This is an example of component communication using the 'mail' / 'notify' functions"
         , br_ []
         , button_ [onClick Toggle] [text "Toggle Component 2"]
+        , button_ [onClick SampleChild] [text "Sample Child (unsafe)"]
         , if x
             then
                 embedWith
@@ -114,6 +116,13 @@ updateModel1 MountMain m =
     m <# do
         consoleLog "Component 2 was mounted!"
         pure MainNoOp
+updateModel1 SampleChild m =
+    m <# do
+      componentTwoModel <- sample component2
+      consoleLog $
+        "Sampling child component 2 from parent component main (unsafe)" <>
+          ms (show componentTwoModel)
+      pure MainNoOp
 
 counterApp2 :: App Model Action
 counterApp2 = defaultApp 0 updateModel2 viewModel2 SayHelloWorld
@@ -209,15 +218,12 @@ updateModel4 AddOne m =
         pure NoOp
 updateModel4 SubtractOne m =
     (m - 1) <# do
-        Just mainModel <- sample mainComponent
-        consoleLog $ "Sampling main model from compnoent 4: " <> ms (show mainModel)
         mail component2 SubtractOne
         pure NoOp
 updateModel4 Sample m =
     m <# do
-      result <- sample component2
-      forM_ result $ \componentTwoModel -> do
-        consoleLog $
+      componentTwoModel <- sample component2
+      consoleLog $
           "Sampling parent component 2 from child component 4: " <>
             ms (show componentTwoModel)
       pure NoOp

--- a/jsstring-src/Miso/String.hs
+++ b/jsstring-src/Miso/String.hs
@@ -1,10 +1,7 @@
-{-# LANGUAGE CPP #-}
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE ExistentialQuantification #-}
-{-# LANGUAGE TypeSynonymInstances #-}
-{-# LANGUAGE OverloadedStrings #-}
-{-# OPTIONS_GHC -fno-warn-orphans       #-}
+----------------------------------------------------------------------------
+{-# LANGUAGE CPP                  #-}
+{-# LANGUAGE FlexibleInstances    #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Miso.String
@@ -23,7 +20,8 @@ module Miso.String (
   , module Data.Monoid
   , ms
   ) where
-
+----------------------------------------------------------------------------
+import           Control.Exception (SomeException)
 #ifdef GHCJS_BOTH
 import           Data.Aeson
 #endif
@@ -41,30 +39,30 @@ import qualified Data.Text.Lazy          as LT
 import qualified Data.Text.Lazy.Encoding as LT
 import           Prelude                 hiding (foldr)
 import           Text.StringLike         (StringLike(..))
-
+----------------------------------------------------------------------------
 -- | String type swappable based on compiler
 type MisoString = JS.JSString
-
+----------------------------------------------------------------------------
 #ifdef GHCJS_BOTH
 -- | `ToJSON` for `MisoString`
 instance ToJSON MisoString where
   toJSON = String . textFromJSString
-
+----------------------------------------------------------------------------
 -- | `FromJSON` for `MisoString`
 instance FromJSON MisoString where
   parseJSON =
     withText "Not a valid string" $ \x ->
       pure (toMisoString x)
 #endif
-
+----------------------------------------------------------------------------
 -- | Convenience class for creating `MisoString` from other string-like types
 class ToMisoString str where
   toMisoString :: str -> MisoString
-
+----------------------------------------------------------------------------
 -- | Class used to parse a 'MisoString'. Like a safe 'Read' for 'MisoString'
 class FromMisoString t where
   fromMisoStringEither :: MisoString -> Either String t
-
+----------------------------------------------------------------------------
 -- | Reads a 'MisoString', throws an error when decoding
 -- fails. Use `fromMisoStringEither` for as a safe alternative.
 fromMisoString :: FromMisoString a => MisoString -> a
@@ -72,64 +70,85 @@ fromMisoString s =
   case fromMisoStringEither s of
     Left err -> error err
     Right x  -> x
-
+----------------------------------------------------------------------------
 -- | Convenience function, shorthand for `toMisoString`
 ms :: ToMisoString str => str -> MisoString
 ms = toMisoString
-
+----------------------------------------------------------------------------
 instance ToMisoString MisoString where
   toMisoString = id
+----------------------------------------------------------------------------
+instance ToMisoString SomeException where
+  toMisoString = toMisoString . show
+----------------------------------------------------------------------------
 instance ToMisoString String where
   toMisoString = JS.pack
+----------------------------------------------------------------------------
 instance ToMisoString T.Text where
   toMisoString = textToJSString
+----------------------------------------------------------------------------
 instance ToMisoString LT.Text where
   toMisoString = lazyTextToJSString
 instance ToMisoString B.ByteString where
   toMisoString = toMisoString . T.decodeUtf8
+----------------------------------------------------------------------------
 instance ToMisoString BL.ByteString where
   toMisoString = toMisoString . LT.decodeUtf8
+----------------------------------------------------------------------------
 instance ToMisoString B.Builder where
   toMisoString = toMisoString . B.toLazyByteString
+----------------------------------------------------------------------------
 instance ToMisoString Float where
   toMisoString = JS.pack . show
+----------------------------------------------------------------------------
 instance ToMisoString Double where
   toMisoString = JS.pack . show
+----------------------------------------------------------------------------
 instance ToMisoString Int where
   toMisoString = JS.pack . show
+----------------------------------------------------------------------------
 instance ToMisoString Word where
   toMisoString = JS.pack . show
-
+----------------------------------------------------------------------------
 instance FromMisoString MisoString where
   fromMisoStringEither = Right
+----------------------------------------------------------------------------
 instance FromMisoString String where
   fromMisoStringEither = Right . JS.unpack
+----------------------------------------------------------------------------
 instance FromMisoString T.Text where
   fromMisoStringEither = Right . textFromJSString
+----------------------------------------------------------------------------
 instance FromMisoString LT.Text where
   fromMisoStringEither = Right . lazyTextFromJSString
+----------------------------------------------------------------------------
 instance FromMisoString B.ByteString where
   fromMisoStringEither = fmap T.encodeUtf8 . fromMisoStringEither
+----------------------------------------------------------------------------
 instance FromMisoString BL.ByteString where
   fromMisoStringEither = fmap LT.encodeUtf8 . fromMisoStringEither
+----------------------------------------------------------------------------
 instance FromMisoString B.Builder where
   fromMisoStringEither = fmap B.byteString . fromMisoStringEither
+----------------------------------------------------------------------------
 instance FromMisoString Float where
   fromMisoStringEither = fmap realToFrac . jsStringToDoubleEither
+----------------------------------------------------------------------------
 instance FromMisoString Double where
   fromMisoStringEither = jsStringToDoubleEither
+----------------------------------------------------------------------------
 instance FromMisoString Int where
   fromMisoStringEither = parseInt
+----------------------------------------------------------------------------
 instance FromMisoString Word where
   fromMisoStringEither = parseWord
-
+----------------------------------------------------------------------------
 jsStringToDoubleEither :: JS.JSString -> Either String Double
 jsStringToDoubleEither s = let d = read $ JS.unpack s
                            in if isNaN d then Left "jsStringToDoubleEither: parse failed"
                                          else Right d
-
-
-parseWord   :: MisoString -> Either String Word
+----------------------------------------------------------------------------
+parseWord :: MisoString -> Either String Word
 parseWord s = case JS.uncons s of
                 Nothing     -> Left "parseWord: parse error"
                 Just (c,s') -> JS.foldl' k (pDigit c) s'
@@ -137,12 +156,12 @@ parseWord s = case JS.uncons s of
     pDigit c | isDigit c = Right . fromIntegral . digitToInt $ c
              | otherwise = Left "parseWord: parse error"
     k ea c = (\a x -> 10*a + x) <$> ea <*> pDigit c
-
+----------------------------------------------------------------------------
 parseInt   :: MisoString -> Either String Int
 parseInt s = case JS.uncons s of
                Just ('-',s') -> ((-1)*) . fromIntegral <$> parseWord s'
                _             ->           fromIntegral <$> parseWord s
-
+----------------------------------------------------------------------------
 instance StringLike MisoString where
   uncons = JS.uncons
   toString = JS.unpack
@@ -153,3 +172,4 @@ instance StringLike MisoString where
   cons = JS.cons
   append = JS.append
   strMap = JS.map
+----------------------------------------------------------------------------

--- a/miso.cabal
+++ b/miso.cabal
@@ -140,6 +140,7 @@ library
     Miso.Event
     Miso.Event.Decoder
     Miso.Event.Types
+    Miso.Exception
     Miso.FFI
     Miso.FFI.History
     Miso.FFI.SSE

--- a/sample-app/Main.hs
+++ b/sample-app/Main.hs
@@ -1,18 +1,17 @@
--- | Haskell language pragma
+----------------------------------------------------------------------------
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE CPP #-}
-
--- | Haskell module declaration
+----------------------------------------------------------------------------
 module Main where
-
+----------------------------------------------------------------------------
 -- | Miso framework import
 import Miso
 import Miso.String
-
+----------------------------------------------------------------------------
 -- | Type synonym for an application model
 type Model = Int
-
+----------------------------------------------------------------------------
 -- | Sum type for application events
 data Action
   = AddOne
@@ -20,11 +19,12 @@ data Action
   | NoOp
   | SayHelloWorld
   deriving (Show, Eq)
-
+-----------------------------------------------------------------------------
+-- | Required when using the WASM backnend
 #if defined(wasm32_HOST_ARCH)
 foreign export javascript "hs_start" main :: IO ()
 #endif
-
+----------------------------------------------------------------------------
 -- | Entry point for a miso application
 main :: IO ()
 main = startApp App {..}
@@ -35,9 +35,9 @@ main = startApp App {..}
     view   = viewModel            -- view function
     events = defaultEvents        -- default delegated events
     subs   = []                   -- empty subscription list
-    mountPoint = Nothing          -- mount point for application (Nothing defaults to *<body>*)
+    mountPoint = Nothing          -- mount point for application (Nothing defaults to /<body>/)
     logLevel = Off                -- used during prerendering to see if the VDOM and DOM are in sync (only used with @miso@ function)
-
+----------------------------------------------------------------------------
 -- | Updates model, optionally introduces side effects
 updateModel :: Action -> Model -> Effect Action Model
 updateModel AddOne m = noEff (m + 1)
@@ -45,11 +45,12 @@ updateModel SubtractOne m = noEff (m - 1)
 updateModel NoOp m = noEff m
 updateModel SayHelloWorld m = m <# do
   putStrLn "Hello World" >> pure NoOp
-
+----------------------------------------------------------------------------
 -- | Constructs a virtual DOM from a model
 viewModel :: Model -> View Action
-viewModel x = div_ [] [
-   button_ [ onClick AddOne ] [ text "+" ]
- , text (ms x)
- , button_ [ onClick SubtractOne ] [ text "-" ]
- ]
+viewModel x = div_ []
+  [ button_ [ onClick AddOne ] [ text "+" ]
+  , text (ms x)
+  , button_ [ onClick SubtractOne ] [ text "-" ]
+  ]
+----------------------------------------------------------------------------

--- a/src/Miso.hs
+++ b/src/Miso.hs
@@ -20,6 +20,8 @@ module Miso
   , misoComponent
     -- ** Sink
   , sink
+    -- ** Sampling
+  , sample
     -- ** Message Passing
   , mail
   , notify

--- a/src/Miso.hs
+++ b/src/Miso.hs
@@ -30,15 +30,17 @@ module Miso
   , module Miso.Effect
     -- * Event
   , module Miso.Event
-    -- * Mathml
-  , module Miso.Mathml
     -- * Html
   , module Miso.Html
   , module Miso.Render
+    -- * Mathml
+  , module Miso.Mathml
     -- * Router
   , module Miso.Router
     -- * Runner
   , module Miso.Runner
+    -- * Exception
+  , module Miso.Exception
     -- * Subs
   , module Miso.Subscription
     -- * Storage
@@ -49,6 +51,8 @@ module Miso
   , set
   , now
   , consoleLog
+  , consoleError
+  , consoleWarn
   , consoleLog'
   , getElementById
   , focus
@@ -68,6 +72,7 @@ import           Miso.String (MisoString)
 import           Miso.Diff (diff, mountElement)
 import           Miso.Effect
 import           Miso.Event
+import           Miso.Exception
 import           Miso.Html
 import           Miso.Render
 import           Miso.Router
@@ -83,7 +88,7 @@ import           Miso.FFI hiding (diff)
 -- | Runs an isomorphic miso application.
 -- Assumes the pre-rendered DOM is already present.
 -- Note: Uses @mountPoint@ as the @Component@ name.
--- Always mounts to *<body>*. Copies page into the virtual DOM.
+-- Always mounts to /<body>/. Copies page into the virtual DOM.
 miso :: Eq model => (URI -> App model action) -> JSM ()
 miso f = withJS $ do
   app@App {..} <- f <$> getCurrentURI
@@ -98,7 +103,7 @@ miso f = withJS $ do
 -- | Runs a miso application (as a @Component@)
 -- Assumes the pre-rendered DOM is already present.
 -- Note: Uses @name@ in @Component name model action@ as the @Component@ name.
--- Always mounts to *<body>*. Copies page into the virtual DOM.
+-- Always mounts to /<body>/. Copies page into the virtual DOM.
 misoComponent
   :: Eq model
   => (URI -> Component name model action)
@@ -114,7 +119,7 @@ misoComponent f = withJS $ do
     pure (name, mount, ref)
 -----------------------------------------------------------------------------
 -- | Runs a miso application
--- Initializes application at @mountPoint@ (defaults to @<body>@ when @Nothing@)
+-- Initializes application at @mountPoint@ (defaults to /<body>/ when @Nothing@)
 startApp :: Eq model => App model action -> JSM ()
 startApp app@App {..} = withJS $
   initialize app $ \snk -> do
@@ -126,7 +131,7 @@ startApp app@App {..} = withJS $
     pure (mount, mountEl, ref)
 -----------------------------------------------------------------------------
 -- | Runs a miso application (as a @Component@)
--- Initializes application at @name@ (defaults to @<body>@)
+-- Initializes application at @name@ (defaults to /<body>/)
 -- Ignores @mountPoint@ on the enclosing @App@, uses @name@ from @(Component name model action)@
 startComponent :: Eq model => Component name model action -> JSM ()
 startComponent (Component name app@App{..}) = withJS $ initialize app $ \snk -> do

--- a/src/Miso/Exception.hs
+++ b/src/Miso/Exception.hs
@@ -8,7 +8,7 @@
 -- Portability :  non-portable
 ----------------------------------------------------------------------------
 module Miso.Exception
-  ( -- * Exceptions
+  ( -- ** Types
     MisoException (..)
   ) where
 ----------------------------------------------------------------------------
@@ -24,7 +24,7 @@ import Miso.String (MisoString)
 -- * Not Mounted Exception
 --
 -- This occurs if a user tries to call @sample myComponent@ when @myComponent@ is currently
--- not mounted onto the DOM.
+-- not mounted on the DOM.
 --
 -- * Already Mounted Exception
 --
@@ -34,12 +34,14 @@ import Miso.String (MisoString)
 -- this exception will be raised.
 --
 -- Other exceptions can arise, but its up to the user to handle them in
--- the `update` function. All unhandled exceptions are caught in the event loop
+-- the @update@ function. All unhandled exceptions are caught in the event loop
 -- and logged to the console with /console.error()/
 --
 data MisoException
   = NotMountedException MisoString
+  -- ^ Thrown when a @Component@ is sampled, yet not mounted.
   | AlreadyMountedException MisoString
+  -- ^ Thrown when a @Component@ is attempted to be mounted twice.
   deriving (Show, Eq, Typeable)
 ----------------------------------------------------------------------------
 instance Exception MisoException

--- a/src/Miso/Exception.hs
+++ b/src/Miso/Exception.hs
@@ -1,0 +1,46 @@
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Miso.Exception
+-- Copyright   :  (C) 2016-2025 David M. Johnson
+-- License     :  BSD3-style (see the file LICENSE)
+-- Maintainer  :  David M. Johnson <code@dmj.io>
+-- Stability   :  experimental
+-- Portability :  non-portable
+----------------------------------------------------------------------------
+module Miso.Exception
+  ( -- * Exceptions
+    MisoException (..)
+  ) where
+----------------------------------------------------------------------------
+import Control.Exception
+import Data.Typeable
+----------------------------------------------------------------------------
+import Miso.String (MisoString)
+----------------------------------------------------------------------------
+-- | The @MisoException@ type is used to catch @Component@-related mounting errors.
+--
+-- The two mounting errors that can occur during the lifetime of a miso application are
+--
+-- * Not Mounted Exception
+--
+-- This occurs if a user tries to call @sample myComponent@ when @myComponent@ is currently
+-- not mounted onto the DOM.
+--
+-- * Already Mounted Exception
+--
+-- It is a requirement that all @Component@ be named uniquely
+-- (this is to avoid runaway recursion during mounting).
+-- If we detect a @Component@ is attempting to be mounted twice
+-- this exception will be raised.
+--
+-- Other exceptions can arise, but its up to the user to handle them in
+-- the `update` function. All unhandled exceptions are caught in the event loop
+-- and logged to the console with /console.error()/
+--
+data MisoException
+  = NotMountedException MisoString
+  | AlreadyMountedException MisoString
+  deriving (Show, Eq, Typeable)
+----------------------------------------------------------------------------
+instance Exception MisoException
+----------------------------------------------------------------------------

--- a/src/Miso/FFI.hs
+++ b/src/Miso/FFI.hs
@@ -25,7 +25,9 @@ module Miso.FFI
    , eventPreventDefault
    , eventStopPropagation
    , now
+   , consoleWarn
    , consoleLog
+   , consoleError
    , consoleLog'
    , jsonStringify
    , jsonParse
@@ -172,6 +174,26 @@ now = fromJSValUnchecked =<< (jsg "performance" # "now" $ ())
 consoleLog :: MisoString -> JSM ()
 consoleLog v = do
   _ <- jsg "console" # "log" $ [toJSString v]
+  pure ()
+-----------------------------------------------------------------------------
+-- | Outputs a warning message to the web console
+--
+-- See <https://developer.mozilla.org/en-US/docs/Web/API/Console/warn>
+--
+-- Console logging of JavaScript strings.
+consoleWarn :: MisoString -> JSM ()
+consoleWarn v = do
+  _ <- jsg "console" # "warn" $ [toJSString v]
+  pure ()
+-----------------------------------------------------------------------------
+-- | Outputs an error message to the web console
+--
+-- See <https://developer.mozilla.org/en-US/docs/Web/API/Console/error>
+--
+-- Console logging of JavaScript strings.
+consoleError :: MisoString -> JSM ()
+consoleError v = do
+  _ <- jsg "console" # "error" $ [toJSString v]
   pure ()
 -----------------------------------------------------------------------------
 -- | Console-logging of JSVal

--- a/src/Miso/Internal.hs
+++ b/src/Miso/Internal.hs
@@ -163,7 +163,7 @@ foldEffects update snk (e:es) old =
   case update e old of
     Effect n effects -> do
       forM_ effects $ \effect ->
-        forkJSM (effect snk `catch` exception)
+        effect snk `catch` exception
       foldEffects update snk es n
   where
     exception :: SomeException -> JSM ()

--- a/text-src/Miso/String.hs
+++ b/text-src/Miso/String.hs
@@ -23,6 +23,7 @@ module Miso.String
   , module S
   ) where
 ----------------------------------------------------------------------------
+import           Control.Exception (SomeException)
 import qualified Data.ByteString         as B
 import qualified Data.ByteString.Builder as B
 import qualified Data.ByteString.Lazy    as BL
@@ -69,6 +70,9 @@ ms = toMisoString
 ----------------------------------------------------------------------------
 instance ToMisoString MisoString where
   toMisoString = id
+----------------------------------------------------------------------------
+instance ToMisoString SomeException where
+  toMisoString = toMisoString . show
 ----------------------------------------------------------------------------
 instance ToMisoString String where
   toMisoString = T.pack


### PR DESCRIPTION
- Allows child components to sample a parent component's state
- Saves each component's local state into an `IORef` that gets updated during the event loop post-diffing.
- If the component being sampled is not currently mounted a `Nothing` is returned.
- Adds example usage of `sample` to components
- Consider `MonadFail` instead of `Maybe`