### PR TITLE
Intitial commit of DebugEvents

### DIFF
--- a/examples/svg/Main.hs
+++ b/examples/svg/Main.hs
@@ -18,7 +18,7 @@ foreign export javascript "hs_start" main :: IO ()
 
 main :: IO ()
 main = run $ startApp app
-  { events = pointerEvents
+  { events = M.insert "pointermove" False pointerEvents
   , subs = [ mouseSub HandlePointer ]
   }
 

--- a/haskell-miso.org/shared/Common.hs
+++ b/haskell-miso.org/shared/Common.hs
@@ -93,7 +93,7 @@ haskellMisoComponent ::
 haskellMisoComponent uri
   = component (app uri)
   { subs = [uriSub HandleURI]
-  , logLevel = DebugPrerender
+  , logLevel = DebugAll
   }
   
 app :: URI -> App Model Action

--- a/jsbits/delegate.js
+++ b/jsbits/delegate.js
@@ -37,7 +37,7 @@ window['delegateEvent'] = function (event, obj, stack, parentStack, debug) {
   /* base case, not found */
   if (!stack.length) {
      if (debug) {
-       console.warn('Event ' + event.name + ' did not find an event handler to dispatch on', obj, event);
+       console.warn('Event "' + event.type + '" did not find an event handler to dispatch on', obj, event);
      }
      return;
   }

--- a/jsbits/delegate.js
+++ b/jsbits/delegate.js
@@ -46,7 +46,7 @@ window['delegateEvent'] = function (event, obj, stack, parentStack, debug) {
     for (var o = 0; o < obj.children.length; o++) {
       if (obj['type'] === 'vcomp') continue;
       if (obj.children[o]['domRef'] === stack[1]) {
-        window['delegateEvent']( event, obj.children[o], stack.slice(1), parentStack, debug);
+        window['delegateEvent'](event, obj.children[o], stack.slice(1), parentStack, debug);
         break;
       }
     }

--- a/jsbits/delegate.js
+++ b/jsbits/delegate.js
@@ -19,7 +19,7 @@ window['listener'] = function(e, mount, getVTree, debug) {
    });
 }
 
-/* event delegation algorithm */
+/* event undelegation */
 window['undelegate'] = function (mount, events, getVTree, debug) {
   for (var event in events)
     mount.removeEventListener
@@ -29,7 +29,9 @@ window['undelegate'] = function (mount, events, getVTree, debug) {
       );
 };
 
-/* Accumulate parent stack as well for propagation */
+/* Finds event in virtual dom via pointer equality
+   Accumulate parent stack as well for propagation up the vtree
+ */
 window['delegateEvent'] = function (event, obj, stack, parentStack, debug) {
 
   /* base case, not found */

--- a/jsbits/delegate.js
+++ b/jsbits/delegate.js
@@ -1,38 +1,44 @@
 window = typeof window === 'undefined' ? {} : window;
 
 /* event delegation algorithm */
-window['delegate'] = function (mount, events, getVTree) {
+window['delegate'] = function (mount, events, getVTree, debug) {
   for (var event in events)
     mount.addEventListener
       ( events[event][0]
-      , function (e) { window['listener'](e, mount, getVTree); }
+      , function (e) { window['listener'](e, mount, getVTree, debug); }
       , events[event][1]
       );
 };
 
-window['listener'] = function(e, mount, getVTree) {
+/* the event listener shared by both delegator and undelegator */
+window['listener'] = function(e, mount, getVTree, debug) {
     getVTree(function (obj) {
-	if (e.target) {
-	    window['delegateEvent'](e, obj, window['buildTargetToElement'](mount, e.target), []);
-	}
+    	if (e.target) {
+    	    window['delegateEvent'](e, obj, window['buildTargetToElement'](mount, e.target), [], debug);
+    	}
    });
 }
 
 /* event delegation algorithm */
-window['undelegate'] = function (mount, events, getVTree) {
+window['undelegate'] = function (mount, events, getVTree, debug) {
   for (var event in events)
     mount.removeEventListener
       ( events[event][0]
-      , function (e) { window['listener'](e, mount, getVTree); }
+      , function (e) { window['listener'](e, mount, getVTree, debug); }
       , events[event][1]
       );
 };
 
 /* Accumulate parent stack as well for propagation */
-window['delegateEvent'] = function (event, obj, stack, parentStack) {
+window['delegateEvent'] = function (event, obj, stack, parentStack, debug) {
 
   /* base case, not found */
-  if (!stack.length) return;
+  if (!stack.length) {
+     if (debug) {
+       console.warn('Event ' + event.name + ' did not find an event handler to dispatch on', obj, event);
+     }
+     return;
+  }
 
   /* stack not length 1, recurse */
   else if (stack.length > 1) {
@@ -40,7 +46,7 @@ window['delegateEvent'] = function (event, obj, stack, parentStack) {
     for (var o = 0; o < obj.children.length; o++) {
       if (obj['type'] === 'vcomp') continue;
       if (obj.children[o]['domRef'] === stack[1]) {
-        delegateEvent( event, obj.children[o], stack.slice(1), parentStack );
+        window['delegateEvent']( event, obj.children[o], stack.slice(1), parentStack, debug);
         break;
       }
     }
@@ -50,7 +56,7 @@ window['delegateEvent'] = function (event, obj, stack, parentStack) {
   else {
     var eventObj = obj['events'][event.type];
     if (eventObj) {
-      var options = eventObj.options;
+      var options = eventObj['options'];
       if (options['preventDefault'])
         event.preventDefault();
       eventObj['runEvent'](event);
@@ -63,6 +69,7 @@ window['delegateEvent'] = function (event, obj, stack, parentStack) {
   }
 };
 
+/* Create a stack of ancestors used to index into the virtual DOM */
 window['buildTargetToElement'] = function buildTargetToElement (element, target) {
   var stack = [];
   while (element !== target) {
@@ -72,6 +79,7 @@ window['buildTargetToElement'] = function buildTargetToElement (element, target)
   return stack;
 };
 
+/* Propagate the event up the chain, invoking other event handlers as encountered */
 window['propagateWhileAble'] = function propagateWhileAble (parentStack, event) {
   for (var i = 0; i < parentStack.length; i++) {
     if (parentStack[i]['events'][event.type]) {
@@ -87,7 +95,9 @@ window['propagateWhileAble'] = function propagateWhileAble (parentStack, event) 
 };
 
 /* Walks down obj following the path described by `at`, then filters primitive
- values (string, numbers and booleans)*/
+   values (string, numbers and booleans). Sort of like JSON.stringify(), but
+   on an Event that is stripped of impure references.
+*/
 window['eventJSON'] = function eventJSON (at, obj) {
   /* If at is of type [[MisoString]] */
   if (typeof at[0] == 'object') {

--- a/src/Miso/Delegate.hs
+++ b/src/Miso/Delegate.hs
@@ -27,22 +27,24 @@ delegator
   :: JSVal
   -> IORef VTree
   -> M.Map MisoString Bool
+  -> Bool
   -> JSM ()
-delegator mountPointElement vtreeRef es = do
+delegator mountPointElement vtreeRef es debug = do
   evts <- toJSVal (M.toList es)
-  delegateEvent mountPointElement evts $ do
-    VTree (Object val) <- liftIO (readIORef vtreeRef)
-    pure val
+  delegateEvent mountPointElement evts debug $ do
+    VTree (Object vtree) <- liftIO (readIORef vtreeRef)
+    pure vtree
 -----------------------------------------------------------------------------
 -- | Entry point for deinitalizing event delegation
 undelegator
   :: JSVal
   -> IORef VTree
   -> M.Map MisoString Bool
+  -> Bool
   -> JSM ()
-undelegator mountPointElement vtreeRef es = do
-  evts <- toJSVal (M.toList es)
-  undelegateEvent mountPointElement evts $ do
-    VTree (Object val) <- liftIO (readIORef vtreeRef)
-    pure val
+undelegator mountPointElement vtreeRef es debug = do
+  events <- toJSVal (M.toList es)
+  undelegateEvent mountPointElement events debug $ do
+    VTree (Object vtree) <- liftIO (readIORef vtreeRef)
+    pure vtree
 -----------------------------------------------------------------------------

--- a/src/Miso/Effect.hs
+++ b/src/Miso/Effect.hs
@@ -158,7 +158,7 @@ fromTransition
 fromTransition act = \m ->
   case runWriter (execStateT act m) of
     (n, actions) -> Effect n actions
-
+-----------------------------------------------------------------------------
 -- | Convert an @update@ function to a @Transition@ computation.
 toTransition
     :: (model -> Effect action model) -- ^ model @update@ function

--- a/src/Miso/Event/Types.hs
+++ b/src/Miso/Event/Types.hs
@@ -14,8 +14,9 @@
 ----------------------------------------------------------------------------
 module Miso.Event.Types
   ( -- ** Types
+    Events
     -- *** KeyboardEvent
-    KeyInfo (..)
+  , KeyInfo (..)
   , KeyCode (..)
     -- *** CheckedEvent
   , Checked (..)
@@ -113,6 +114,9 @@ defaultOptions
 -- | Related to using drop-related events
 newtype AllowDrop = AllowDrop Bool
   deriving (Show, Eq, FromJSON)
+-----------------------------------------------------------------------------
+-- | Convenience type for Events
+type Events = M.Map MisoString Bool
 -----------------------------------------------------------------------------
 -- | Default delegated events
 defaultEvents :: M.Map MisoString Bool

--- a/src/Miso/FFI.hs
+++ b/src/Miso/FFI.hs
@@ -280,29 +280,31 @@ jsStringToDouble :: MisoString -> Double
 jsStringToDouble = read . unpack
 -----------------------------------------------------------------------------
 -- | Initialize event delegation from a mount point.
-delegateEvent :: JSVal -> JSVal -> JSM JSVal -> JSM ()
-delegateEvent mountPoint events getVTree =
-  delegate mountPoint events =<< function handler
+delegateEvent :: JSVal -> JSVal -> Bool -> JSM JSVal -> JSM ()
+delegateEvent mountPoint events debug getVTree =
+  delegate mountPoint events debug =<< function handler
     where
       handler _ _ [] = error "delegate: no args - impossible state"
       handler _ _ (continuation : _) =
         void (call continuation global =<< getVTree)
 -----------------------------------------------------------------------------
 -- | Deinitialize event delegation from a mount point.
-undelegateEvent :: JSVal -> JSVal -> JSM JSVal -> JSM ()
-undelegateEvent mountPoint events getVTree =
-  undelegate mountPoint events =<< function handler
+undelegateEvent :: JSVal -> JSVal -> Bool -> JSM JSVal -> JSM ()
+undelegateEvent mountPoint events debug getVTree =
+  undelegate mountPoint events debug =<< function handler
     where
       handler _ _ [] = error "undelegate: no args - impossible state"
       handler _ _ (continuation : _) =
         void (call continuation global =<< getVTree)
 -----------------------------------------------------------------------------
 -- | Call 'delegateEvent' JavaScript function
-delegate :: JSVal -> JSVal -> Function -> JSM ()
-delegate mountPoint events cb = () <$ jsg3 "delegate" mountPoint events cb
+delegate :: JSVal -> JSVal -> Bool -> Function -> JSM ()
+delegate mountPoint events debug callback =
+  void (jsg4 "delegate" mountPoint events callback debug)
 -----------------------------------------------------------------------------
-undelegate :: JSVal -> JSVal -> Function -> JSM ()
-undelegate mountPoint events cb = () <$ jsg3 "undelegate" mountPoint events cb
+undelegate :: JSVal -> JSVal -> Bool -> Function -> JSM ()
+undelegate mountPoint events debug callback
+  = void (jsg4 "undelegate" mountPoint events callback debug)
 -----------------------------------------------------------------------------
 -- | Copies DOM pointers into virtual dom
 -- entry point into isomorphic javascript

--- a/src/Miso/Html/Event.hs
+++ b/src/Miso/Html/Event.hs
@@ -63,12 +63,13 @@ module Miso.Html.Event
   , onPointerMove
   ) where
 -----------------------------------------------------------------------------
+import qualified Data.Map.Strict as M
 import           Data.Aeson.Types (parseEither)
 import           Language.Javascript.JSaddle
 -----------------------------------------------------------------------------
 import           Miso.Event
-import           Miso.FFI (syncCallback, set, eventJSON, asyncCallback1)
-import           Miso.Html.Types ( Attribute (E) )
+import           Miso.FFI (syncCallback, set, eventJSON, asyncCallback1, consoleError)
+import           Miso.Html.Types ( Attribute (Event) )
 import           Miso.String (MisoString, unpack)
 -----------------------------------------------------------------------------
 -- | Convenience wrapper for @onWithOptions defaultOptions@.
@@ -99,19 +100,28 @@ onWithOptions
   -> (r -> action)
   -> Attribute action
 onWithOptions options eventName Decoder{..} toAction =
-  E $ \sink n -> do
-   eventObj <- getProp "events" n
-   eventHandlerObject@(Object eo) <- create
-   jsOptions <- toJSVal options
-   decodeAtVal <- toJSVal decodeAt
-   cb <- asyncCallback1 $ \e -> do
-       Just v <- fromJSVal =<< eventJSON decodeAtVal e
-       case parseEither decoder v of
-         Left s -> error $ "Parse error on " <> unpack eventName <> ": " <> s
-         Right r -> sink (toAction r)
-   set "runEvent" cb eventHandlerObject
-   set "options" jsOptions eventHandlerObject
-   set eventName eo (Object eventObj)
+  Event $ \sink n events ->
+    case M.lookup eventName events of
+      Nothing ->
+        consoleError $ mconcat
+          [ "Event "
+          , eventName
+          , " is not being listened on. To use this event, "
+          , "add to the 'events' Map in 'App'"
+          ]
+      Just _ -> do
+        eventObj <- getProp "events" n
+        eventHandlerObject@(Object eo) <- create
+        jsOptions <- toJSVal options
+        decodeAtVal <- toJSVal decodeAt
+        cb <- asyncCallback1 $ \e -> do
+            Just v <- fromJSVal =<< eventJSON decodeAtVal e
+            case parseEither decoder v of
+              Left s -> error $ "Parse error on " <> unpack eventName <> ": " <> s
+              Right r -> sink (toAction r)
+        set "runEvent" cb eventHandlerObject
+        set "options" jsOptions eventHandlerObject
+        set eventName eo (Object eventObj)
 -----------------------------------------------------------------------------
 -- | @onCreated action@ is an event that gets called after the actual DOM
 -- element is created.
@@ -120,9 +130,9 @@ onWithOptions options eventName Decoder{..} toAction =
 -- otherwise the event may not be reliably called!
 onCreated :: action -> Attribute action
 onCreated action =
-  E $ \sink n -> do
-    cb <- syncCallback (sink action)
-    set "onCreated" cb n
+  Event $ \sink object _ -> do
+    callback <- syncCallback (sink action)
+    set "onCreated" callback object
 -----------------------------------------------------------------------------
 -- | @onDestroyed action@ is an event that gets called after the DOM element
 -- is removed from the DOM. The @action@ is given the DOM element that was
@@ -132,9 +142,9 @@ onCreated action =
 -- otherwise the event may not be reliably called!
 onDestroyed :: action -> Attribute action
 onDestroyed action =
-  E $ \sink n -> do
-    cb <- syncCallback (sink action)
-    set "onDestroyed" cb n
+  Event $ \sink object _ -> do
+    callback <- syncCallback (sink action)
+    set "onDestroyed" callback object
 -----------------------------------------------------------------------------
 -- | @onBeforeDestroyed action@ is an event that gets called before the DOM element
 -- is removed from the DOM. The @action@ is given the DOM element that was
@@ -144,9 +154,9 @@ onDestroyed action =
 -- otherwise the event may not be reliably called!
 onBeforeDestroyed :: action -> Attribute action
 onBeforeDestroyed action =
-  E $ \sink n -> do
-    cb <- syncCallback (sink action)
-    set "onBeforeDestroyed" cb n
+  Event $ \sink object _ -> do
+    callback <- syncCallback (sink action)
+    set "onBeforeDestroyed" callback object
 -----------------------------------------------------------------------------
 -- | blur event defined with custom options
 --

--- a/src/Miso/Html/Event.hs
+++ b/src/Miso/Html/Event.hs
@@ -104,9 +104,9 @@ onWithOptions options eventName Decoder{..} toAction =
     case M.lookup eventName events of
       Nothing ->
         consoleError $ mconcat
-          [ "Event "
+          [ "Event \""
           , eventName
-          , " is not being listened on. To use this event, "
+          , "\" is not being listened on. To use this event, "
           , "add to the 'events' Map in 'App'"
           ]
       Just _ -> do

--- a/src/Miso/Html/Types.hs
+++ b/src/Miso/Html/Types.hs
@@ -77,7 +77,7 @@ newtype VTree = VTree { getTree :: Object }
 -- | @prop k v@ is an attribute that will set the attribute @k@ of the DOM node associated with the vnode
 -- to @v@.
 prop :: ToJSON a => MisoString -> a -> Attribute action
-prop k v = P k (toJSON v)
+prop k v = Property k (toJSON v)
 -----------------------------------------------------------------------------
 -- | @style_ attrs@ is an attribute that will set the @style@
 -- attribute of the associated DOM node to @attrs@.
@@ -90,5 +90,5 @@ prop k v = P k (toJSON v)
 -- <https://developer.mozilla.org/en-US/docs/Web/CSS>
 --
 style_ :: Map MisoString MisoString -> Attribute action
-style_ = S
+style_ = Style
 -----------------------------------------------------------------------------

--- a/src/Miso/Internal.hs
+++ b/src/Miso/Internal.hs
@@ -90,7 +90,7 @@ initialize App {..} getView = do
         syncPoint
         loop newModel
   tid <- forkJSM (loop model)
-  registerComponent (ComponentState mount tid subThreads mountEl viewRef eventSink modelRef events)
+  registerComponent (ComponentState mount tid subThreads mountEl viewRef eventSink modelRef)
   delegator mountEl viewRef events (logLevel `elem` [DebugEvents, DebugAll])
   eventSink initialAction
   pure viewRef
@@ -112,7 +112,6 @@ data ComponentState model action
   , componentVTree      :: IORef VTree
   , componentSink       :: action -> JSM ()
   , componentModel      :: IORef model
-  , componentEvents     :: Events
   }
 -----------------------------------------------------------------------------
 -- | componentMap

--- a/src/Miso/Internal.hs
+++ b/src/Miso/Internal.hs
@@ -29,7 +29,7 @@ module Miso.Internal
 -----------------------------------------------------------------------------
 import           Control.Exception (throwIO, SomeException, fromException)
 import           Control.Concurrent (ThreadId, killThread)
-import           Control.Monad (forM, forM_, (<=<), when, void)
+import           Control.Monad (forM, forM_, when, void)
 import           Control.Monad.IO.Class
 import qualified Data.Aeson as A
 import           Data.Foldable (toList)
@@ -53,6 +53,7 @@ import           Miso.FFI hiding (diff)
 import           Miso.Html hiding (on)
 import           Miso.String hiding (reverse)
 import           Miso.Types hiding (componentName)
+import           Miso.Event (Events)
 import           Miso.Effect (Sink, Effect(Effect), Transition, scheduleIO_)
 -----------------------------------------------------------------------------
 -- | Helper function to abstract out initialization of @App@ between top-level API functions.
@@ -79,7 +80,7 @@ initialize App {..} getView = do
         oldName <- liftIO $ oldModel `seq` makeStableName oldModel
         newName <- liftIO $ newModel `seq` makeStableName newModel
         when (oldName /= newName && oldModel /= newModel) $ do
-          newVTree <- runView DontPrerender (view newModel) eventSink
+          newVTree <- runView DontPrerender (view newModel) eventSink events
           oldVTree <- liftIO (readIORef viewRef)
           void waitForAnimationFrame
           diff mountEl (Just oldVTree) (Just newVTree)
@@ -89,8 +90,8 @@ initialize App {..} getView = do
         syncPoint
         loop newModel
   tid <- forkJSM (loop model)
-  registerComponent (ComponentState mount tid subThreads mountEl viewRef eventSink modelRef)
-  delegator mountEl viewRef events
+  registerComponent (ComponentState mount tid subThreads mountEl viewRef eventSink modelRef events)
+  delegator mountEl viewRef events (logLevel `elem` [DebugEvents, DebugAll])
   eventSink initialAction
   pure viewRef
 -----------------------------------------------------------------------------
@@ -104,13 +105,14 @@ data Prerender
 -- | @Component@ state, data associated with the lifetime of a @Component@
 data ComponentState model action
   = ComponentState
-  { componentName :: MisoString
+  { componentName       :: MisoString
   , componentMainThread :: ThreadId
   , componentSubThreads :: [ThreadId]
-  , componentMount :: JSVal
-  , componentVTree :: IORef VTree
-  , componentSink :: action -> JSM ()
-  , componentModel :: IORef model
+  , componentMount      :: JSVal
+  , componentVTree      :: IORef VTree
+  , componentSink       :: action -> JSM ()
+  , componentModel      :: IORef model
+  , componentEvents     :: Events
   }
 -----------------------------------------------------------------------------
 -- | componentMap
@@ -217,7 +219,7 @@ drawComponent
   -> Sink action
   -> JSM (MisoString, JSVal, IORef VTree)
 drawComponent prerender name App {..} snk = do
-  vtree <- runView prerender (view model) snk
+  vtree <- runView prerender (view model) snk events
   el <- getComponent name
   when (prerender == DontPrerender) $
     diff el Nothing (Just vtree)
@@ -230,8 +232,8 @@ unmount
   -> App model action
   -> ComponentState model action
   -> JSM ()
-unmount mountCallback app ComponentState {..} = do
-  undelegator componentMount componentVTree (events app)
+unmount mountCallback App{..} ComponentState {..} = do
+  undelegator componentMount componentVTree events (logLevel `elem` [DebugEvents, DebugAll])
   freeFunction mountCallback
   liftIO $ do
     killThread componentMainThread
@@ -245,13 +247,13 @@ unmount mountCallback app ComponentState {..} = do
 -- (creating sub components as detected), setting up
 -- infrastructure for each sub-component. During this
 -- process we go between the Haskell heap and the JS heap.
---
 runView
   :: Prerender
   -> View action
   -> Sink action
+  -> Events
   -> JSM VTree
-runView prerender (Embed (SomeComponent (Component name app)) (ComponentOptions {..})) snk = do
+runView prerender (Embed (SomeComponent (Component name app)) (ComponentOptions {..})) snk _ = do
   let mount = name
   mountCb <- do
     syncCallback1 $ \continuation -> do
@@ -260,11 +262,12 @@ runView prerender (Embed (SomeComponent (Component name app)) (ComponentOptions 
       VTree vtree <- liftIO (readIORef vtreeRef)
       void $ call continuation global [vtree]
   unmountCb <- toJSVal =<< do
-    syncCallback1 $ \_ -> do
+    syncCallback $ do
       forM_ onUnmounted snk
       M.lookup mount <$> liftIO (readIORef componentMap) >>= \case
         Nothing -> pure ()
-        Just componentState -> unmount mountCb app componentState
+        Just componentState ->
+          unmount mountCb app componentState
   vcomp <- create
   cssObj <- create
   propsObj <- create
@@ -276,13 +279,13 @@ runView prerender (Embed (SomeComponent (Component name app)) (ComponentOptions 
   set "ns" HTML vcomp
   set "tag" ("div" :: JSString) vcomp
   set "key" componentKey vcomp
-  setAttrs vcomp attributes snk
+  setAttrs vcomp attributes snk (events app)
   flip (set "children") vcomp =<< toJSVal ([] :: [MisoString])
   set "data-component-id" mount vcomp
   flip (set "mount") vcomp =<< toJSVal mountCb
   set "unmount" unmountCb vcomp
   pure (VTree vcomp)
-runView prerender (Node ns tag key attrs kids) snk = do
+runView prerender (Node ns tag key attrs kids) snk events = do
   vnode <- create
   cssObj <- toJSVal =<< create
   propsObj <- toJSVal =<< create
@@ -294,28 +297,30 @@ runView prerender (Node ns tag key attrs kids) snk = do
   set "ns" ns vnode
   set "tag" tag vnode
   set "key" key vnode
-  setAttrs vnode attrs snk
+  setAttrs vnode attrs snk events
   flip (set "children") vnode
     =<< ghcjsPure . jsval
     =<< setKids
   pure $ VTree vnode
     where
       setKids = do
-        kidsViews <- traverse (toJSVal . getTree <=< flip (runView prerender) snk) kids
+        kidsViews <- forM kids $ \kid -> do
+          VTree (Object vtree) <- runView prerender kid snk events
+          pure vtree
         ghcjsPure (JSArray.fromList kidsViews)
-runView _ (Text t) _ = do
+runView _ (Text t) _ _ = do
   vtree <- create
   set "type" ("vtext" :: JSString) vtree
   set "text" t vtree
   pure $ VTree vtree
-runView prerender (TextRaw str) snk =
+runView prerender (TextRaw str) snk events =
   case parseView str of
     [] ->
-      runView prerender (Text (" " :: MisoString)) snk
+      runView prerender (Text (" " :: MisoString)) snk events
     [parent] ->
-      runView prerender parent snk
+      runView prerender parent snk events
     kids -> do
-      runView prerender (Node HTML "div" Nothing mempty kids) snk
+      runView prerender (Node HTML "div" Nothing mempty kids) snk events
 -----------------------------------------------------------------------------
 -- | Helper function for populating "props" and "css" fields on a virtual
 -- DOM node
@@ -323,17 +328,18 @@ setAttrs
   :: Object
   -> [Attribute action]
   -> Sink action
+  -> Events
   -> JSM ()
-setAttrs vnode attrs snk =
+setAttrs vnode attrs snk events =
   forM_ attrs $ \case
-    P k v -> do
+    Property k v -> do
       value <- toJSVal v
       o <- getProp "props" vnode
       set k value (Object o)
-    E attr -> attr snk vnode
-    S m -> do
+    Event attr -> attr snk vnode events
+    Style styles -> do
       cssObj <- getProp "css" vnode
-      forM_ (M.toList m) $ \(k,v) -> do
+      forM_ (M.toList styles) $ \(k,v) -> do
         set k v (Object cssObj)
 -----------------------------------------------------------------------------
 -- | Used to support RawText, inlining of HTML.
@@ -351,7 +357,7 @@ parseView html = reverse (go (parseTree html) [])
       go (TagBranch name attrs [] : next) views
     go (TagBranch name attrs kids : next) views =
       let
-        attrs' = [ P key $ A.String (fromMisoString value)
+        attrs' = [ Property key $ A.String (fromMisoString value)
                  | (key, value) <- attrs
                  ]
         newNode =

--- a/src/Miso/Render.hs
+++ b/src/Miso/Render.hs
@@ -112,15 +112,15 @@ renderBuilder (Embed (SomeComponent (Component mount App {..})) options) =
   ]
 ----------------------------------------------------------------------------
 renderAttrs :: Attribute action -> Builder
-renderAttrs (P key value) =
+renderAttrs (Property key value) =
   mconcat
   [ fromMisoString key
   , stringUtf8 "=\""
   , toHtmlFromJSON value
   , stringUtf8 "\""
   ]
-renderAttrs (E _) = mempty
-renderAttrs (S styles) =
+renderAttrs (Event _) = mempty
+renderAttrs (Style style) =
   mconcat
   [ "style"
   , stringUtf8 "=\""
@@ -131,7 +131,7 @@ renderAttrs (S styles) =
       , fromMisoString v
       , charUtf8 ';'
       ]
-    | (k,v) <- M.toList styles
+    | (k,v) <- M.toList style
     ]
   , stringUtf8 "\""
   ]

--- a/src/Miso/Types.hs
+++ b/src/Miso/Types.hs
@@ -105,6 +105,15 @@ defaultApp m u v a = App
 data LogLevel
   = Off
   | DebugPrerender
+  -- ^ Will warn if the structure or properties of the
+  -- DOM vs. Virtual DOM differ during prerendering.
+  | DebugEvents
+  -- ^ Will warn if an event cannot be routed to the Haskell event
+  -- handler that raised it. Also will warn if an event handler is
+  -- being used, yet it's not being listened for by the event
+  -- delegator mount point.
+  | DebugAll
+  -- ^ Logs on all of the above
   deriving (Show, Eq)
 -----------------------------------------------------------------------------
 -- | Core type for constructing a virtual DOM in Haskell
@@ -254,9 +263,9 @@ instance ToKey Word where toKey = Key . toMisoString
 -- like the @onclick@ attribute. The second argument represents the
 -- vnode the attribute is attached to.
 data Attribute action
-  = P MisoString Value
-  | E (Sink action -> Object -> JSM ())
-  | S (M.Map MisoString MisoString)
+  = Property MisoString Value
+  | Event (Sink action -> Object -> Events -> JSM ())
+  | Style (M.Map MisoString MisoString)
   deriving Functor
 -----------------------------------------------------------------------------
 -- | @IsString@ instance


### PR DESCRIPTION
- Checks that all event handlers defined are being listened for by top-level event delegation (local to the Component mount or top-level App mount).

- Adds a warning if an event that was raised did not find an event handler for dispatch.

- Fix detected bug (this feature already found a bug in the svg example). Adds "pointermove" to the top-level Events map

- Introduce 'Events' type (synonym for Map MisoString Bool)

- Adds DebugEvent and DebugAll

- Renames some ambiguous variables to be more descriptive.

- Passes event Map from App{..} into Event construct continuation.

~~- Adds `componentEvents` to `ComponentState`~~

- Renames P,E,S to Property, Event, Style.

This detects if an event, that a user is expecting to fire, is not being listened on by the top level event delegator DOM node (typically body).

```haskell
main :: IO ()
main = run $ startApp app
   { events = pointerEvents
   }
 
 viewModel :: Model -> View Action
 viewModel x =
     div_
         []
         [ button_ [onPointerDown AddOne] [text "+"]
         , text (ms x)
         , button_ [onPointerDown SubtractOne] [text "-"]
         , button [ onClick NoOp ] [ text "oops" ] 
         -- ^ since `"click"` is not in `pointerEvents`, 
         -- an error will be raised in `console.error`
         ]