### PR TITLE
Invoke unmount / mount hooks in post mounting / unmounting phases.

### DIFF
--- a/examples/components/Main.hs
+++ b/examples/components/Main.hs
@@ -55,7 +55,7 @@ loggerSub msg = \_ ->
 
 app :: App MainModel MainAction
 app =
-    (defaultApp True updateModel1 viewModel1 MainNoOp)
+    (defaultApp False updateModel1 viewModel1 MainNoOp)
         { subs = [loggerSub "main-app"]
         }
 
@@ -73,7 +73,7 @@ component3 =
             { subs = [loggerSub "component-3 sub"]
             }
 
-component4 :: Component "component-4" Model Action
+component4 :: Component "component-3" Model Action
 component4 =
     component
         counterApp4

--- a/examples/components/Main.hs
+++ b/examples/components/Main.hs
@@ -73,7 +73,7 @@ component3 =
             { subs = [loggerSub "component-3 sub"]
             }
 
-component4 :: Component "component-3" Model Action
+component4 :: Component "component-4" Model Action
 component4 =
     component
         counterApp4

--- a/jsbits/diff.js
+++ b/jsbits/diff.js
@@ -202,18 +202,7 @@ window['createElement'] = function (obj, doc, cb) {
 // mounts vcomp by calling into Haskell side.
 // unmount is handled with pre-destroy recursive hooks
 window['mountComponent'] = function (obj, doc) {
-    var componentId = obj['data-component-id'],
-        nodeList = doc.querySelectorAll ("[data-component-id='" + componentId + "']");
-
-    // dmj: bail out if duplicate mounting detected
-    if (nodeList.length > 0) {
-        console.error ('Duplicate component mounting detected');
-        console.error ('Component ' + componentId + ' is already mounted');
-        return;
-    }
-    // dmj, the component placeholder div[id=name] is already on the dom and vdom
-    // Now we gen the component and append it to the vdom and real dom
-    obj['domRef'].setAttribute('data-component-id', componentId);
+    obj['domRef'].setAttribute('data-component-id', obj['data-component-id']);
     // ^ we have to set this before 'mount()' is called, since `diff` requires it.
     obj['mount'](function(component) {
       // mount() gives us the VTree from the Haskell side, so we just attach it here

--- a/jsbits/diff.js
+++ b/jsbits/diff.js
@@ -202,7 +202,18 @@ window['createElement'] = function (obj, doc, cb) {
 // mounts vcomp by calling into Haskell side.
 // unmount is handled with pre-destroy recursive hooks
 window['mountComponent'] = function (obj, doc) {
-    obj['domRef'].setAttribute('data-component-id', obj['data-component-id']);
+    var componentId = obj['data-component-id'],
+        nodeList = doc.querySelectorAll ("[data-component-id='" + componentId + "']");
+
+    // dmj: bail out if duplicate mounting detected
+    if (nodeList.length > 0) {
+        console.error ('Duplicate component mounting detected');
+        console.error ('Component ' + componentId + ' is already mounted');
+        return;
+    }
+    // dmj, the component placeholder div[id=name] is already on the dom and vdom
+    // Now we gen the component and append it to the vdom and real dom
+    obj['domRef'].setAttribute('data-component-id', componentId);
     // ^ we have to set this before 'mount()' is called, since `diff` requires it.
     obj['mount'](function(component) {
       // mount() gives us the VTree from the Haskell side, so we just attach it here

--- a/jsbits/diff.js
+++ b/jsbits/diff.js
@@ -207,8 +207,8 @@ window['mountComponent'] = function (obj, doc) {
 
     // dmj: bail out if duplicate mounting detected
     if (nodeList.length > 0) {
-        console.error ('Duplicate component mounting detected');
-        console.error ('Component ' + componentId + ' is already mounted');
+        console.error
+          ('AlreadyMountedException: Component "' + componentId + "' is already mounted");
         return;
     }
     // dmj, the component placeholder div[id=name] is already on the dom and vdom


### PR DESCRIPTION
- Adds 'exception' handler to unify mounting exception handling
- Abstracts out vtree creation w/ 'createNode'
- Prefix FFI imports in Internal.hs
~~- Remove .querySelectorAll() checks in diff.js (perf)~~ (dmj: can't do this yet)