### PR TITLE
Make Component dynamic, remove Symbol parameterization

### DIFF
--- a/examples/components/Main.hs
+++ b/examples/components/Main.hs
@@ -39,10 +39,7 @@ data MainAction
 type MainModel = Bool
 
 main :: IO ()
-main = run (startComponent mainComponent)
-
-mainComponent :: Component "main" MainModel MainAction
-mainComponent = component app{logLevel = DebugPrerender}
+main = run $ startApp app { logLevel = DebugPrerender }
 
 secs :: Int -> Int
 secs = (* 1000000)
@@ -59,23 +56,23 @@ app =
         { subs = [loggerSub "main-app"]
         }
 
-component2 :: Component "component-2" Model Action
+component2 :: Component Model Action
 component2 =
-    component
+    component "component-2"
         counterApp2
             { subs = [loggerSub "component-2 sub"]
             }
 
-component3 :: Component "component-3" (Bool, Model) Action
+component3 :: Component (Bool, Model) Action
 component3 =
-    component
+    component "component-3"
         counterApp3
             { subs = [loggerSub "component-3 sub"]
             }
 
-component4 :: Component "component-4" Model Action
+component4 :: Component Model Action
 component4 =
-    component
+    component "component-4"
         counterApp4
             { subs = [loggerSub "component-4 sub"]
             }

--- a/examples/sse/client/Main.hs
+++ b/examples/sse/client/Main.hs
@@ -5,7 +5,7 @@ module Main where
 
 import Common (sseComponent)
 
-import Miso (misoComponent, run)
+import Miso (miso, run)
 
 main :: IO ()
-main = run (misoComponent sseComponent)
+main = run (miso sseComponent)

--- a/examples/sse/server/Main.hs
+++ b/examples/sse/server/Main.hs
@@ -64,7 +64,7 @@ sendEvents chan =
         threadDelay (10 ^ (6 :: Int))
 
 -- | Page for setting HTML doctype and header
-newtype Page = Page (Component "sse" Model Action)
+newtype Page = Page (Component Model Action)
 
 instance ToHtml Page where
     toHtml (Page x) =

--- a/examples/sse/shared/Common.hs
+++ b/examples/sse/shared/Common.hs
@@ -63,9 +63,8 @@ the404 =
 goHome :: URI
 goHome = allLinks' linkURI (Proxy :: Proxy ClientRoutes)
 
-sseComponent :: URI -> Component "sse" Model Action
+sseComponent :: URI -> App Model Action
 sseComponent currentURI =
-    component
         App
             { initialAction = NoOp
             , model = Model currentURI "No event received"

--- a/haskell-miso.org/client/Main.hs
+++ b/haskell-miso.org/client/Main.hs
@@ -5,11 +5,11 @@
 module Main where
 
 import Common (haskellMisoComponent)
-import Miso (misoComponent, run)
+import Miso (miso, run)
 
 #if defined(wasm32_HOST_ARCH)
 foreign export javascript "hs_start" main :: IO ()
 #endif
 
 main :: IO ()
-main = run (misoComponent haskellMisoComponent)
+main = run (miso haskellMisoComponent)

--- a/haskell-miso.org/server/Main.hs
+++ b/haskell-miso.org/server/Main.hs
@@ -11,8 +11,6 @@
 
 module Main where
 
-import Control.Monad.IO.Class (liftIO)
-
 import Common (
     Page (..),
     ServerRoutes,

--- a/haskell-miso.org/shared/Common.hs
+++ b/haskell-miso.org/shared/Common.hs
@@ -60,7 +60,7 @@ type ClientRoutes = Routes (View Action)
 type ServerRoutes = Routes (Get '[HTML] Page)
 
 -- | Component synonym
-type HaskellMisoComponent = Component "client" Model Action
+type HaskellMisoComponent = App Model Action
 
 -- | Links
 uriHome, uriExamples, uriDocs, uriCommunity, uri404 :: URI
@@ -91,7 +91,7 @@ haskellMisoComponent ::
     URI ->
     HaskellMisoComponent
 haskellMisoComponent uri
-  = component (app uri)
+  = (app uri)
   { subs = [uriSub HandleURI]
   , logLevel = DebugAll
   }

--- a/src/Miso/Internal.hs
+++ b/src/Miso/Internal.hs
@@ -131,7 +131,7 @@ componentMap = unsafePerformIO (newIORef mempty)
 -- to be accessed. Then we throw a @NotMountedException@, in the case the
 -- @Component@ being accessed is not available.
 sample
-  :: Component name model app
+  :: Component model app
   -> JSM model
 sample (Component name _) = do
   componentStateMap <- liftIO (readIORef componentMap)
@@ -142,7 +142,7 @@ sample (Component name _) = do
 -- | Like @mail@ but lifted to work with the @Transition@ interface.
 -- This function is used to send messages to @Component@s on other parts of the application
 notify
-  :: Component name m a
+  :: Component m a
   -> a
   -> Transition action model ()
 notify (Component name _) action = scheduleIO_ (void io)
@@ -191,7 +191,7 @@ sink name _ = \a ->
 -- >   m <# mail calendarComponent (NewCalendarEntry entry)
 --
 mail
-  :: Component name m a
+  :: Component m a
   -> a
   -> JSM ()
 mail (Component name _) action = do

--- a/src/Miso/Render.hs
+++ b/src/Miso/Render.hs
@@ -32,7 +32,7 @@ import           Miso.Types
 ----------------------------------------------------------------------------
 -- | HTML MimeType used for servant APIs
 --
--- > type Home = "home" :> Get '[HTML] (Component "home" model action)
+-- > type Home = "home" :> Get '[HTML] (Component model action)
 --
 data HTML
 ----------------------------------------------------------------------------
@@ -47,7 +47,7 @@ class ToHtml a where
   toHtml :: a -> L.ByteString
 ----------------------------------------------------------------------------
 -- | Render a @Component@ to a @L.ByteString@
-instance ToHtml (Component name model action) where
+instance ToHtml (Component model action) where
   toHtml = renderComponent
 ----------------------------------------------------------------------------
 -- | Render a @View@ to a @L.ByteString@
@@ -65,7 +65,7 @@ instance ToHtml a => MimeRender HTML a where
 renderView :: View a -> L.ByteString
 renderView = toLazyByteString . renderBuilder
 ----------------------------------------------------------------------------
-renderComponent :: Component name model action -> L.ByteString
+renderComponent :: Component model action -> L.ByteString
 renderComponent (Component _ App{..}) = renderView (view model)
 ----------------------------------------------------------------------------
 intercalate :: Builder -> [Builder] -> Builder


### PR DESCRIPTION
- Makes `Component` dynamic
- Removes `startComponent`, `misoComponent`
- Removes type level `Symbol` `"name"` on `Component`