### PR TITLE
Make initialAction optional

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,6 +53,9 @@ jobs:
      - name: (JS) Miso examples
        run: nix-build -A miso-examples
 
+     - name: (JS) Miso third-party examples (2048, flatris, etc.)
+       run: nix-build -A more-examples
+
      - name: (x86) Miso examples
        run: nix-build -A miso-examples-ghc
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,7 +54,7 @@ jobs:
        run: nix-build -A miso-examples
 
      - name: (JS) Miso third-party examples (2048, flatris, etc.)
-       run: nix-build -A more-examples
+       run: nix-build -A more-examples -j1
 
      - name: (x86) Miso examples
        run: nix-build -A miso-examples-ghc

--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ main :: IO ()
 main = run (startApp app)
 ----------------------------------------------------------------------------
 app :: App Model Action
-app = defaultApp emptyModel updateModel viewModel SayHelloWorld
+app = defaultApp emptyModel updateModel viewModel
 ----------------------------------------------------------------------------
 -- | Empty model
 emptyModel :: Model
@@ -281,7 +281,7 @@ updateModel :: Action -> Model -> Effect Action Model
 updateModel NoOp m          = noEff m
 updateModel AddOne m        = noEff (m + 1)
 updateModel SubtractOne m   = noEff (m - 1)
-updateModel SayHelloWorld m = m <# NoOp <$ consoleLog "Hello World"
+updateModel SayHelloWorld m = m <# NoOp <$ alert "Hello World"
 ----------------------------------------------------------------------------
 -- | Constructs a virtual DOM from a model
 viewModel :: Model -> View Action
@@ -289,6 +289,7 @@ viewModel x = div_ []
   [ button_ [ onClick AddOne ] [ text "+" ]
   , text (ms x)
   , button_ [ onClick SubtractOne ] [ text "-" ]
+  , button_ [ onClick SayHelloWorld ] [ text "Alert Hello World!" ]
   ]
 ----------------------------------------------------------------------------
 ```
@@ -334,9 +335,9 @@ data Action
 main :: IO ()
 main = run (startApp app)
 ----------------------------------------------------------------------------
--- | `defaultApp` takes as arguments the initial model, update function, view function and initial action.
+-- | `defaultApp` takes as arguments the initial model, update function, view function
 app :: App Model Action
-app = defaultApp emptyModel (fromTransition . updateModel) viewModel SayHelloWorld
+app = defaultApp emptyModel (fromTransition . updateModel) viewModel
 ----------------------------------------------------------------------------
 -- | Empty application state
 emptyModel :: Model
@@ -356,6 +357,7 @@ viewModel x = div_ []
   [ button_ [ onClick AddOne ] [ text "+" ]
   , text . ms $ x^.counter
   , button_ [ onClick SubtractOne ] [ text "-" ]
+  , button_ [ onClick SayHelloWorld ] [ text "Alert Hello World!" ]
   ]
 ----------------------------------------------------------------------------
 ```

--- a/default.nix
+++ b/default.nix
@@ -26,8 +26,11 @@ in with pkgs.haskell.lib;
   miso-examples-ghc = pkgs.haskell.packages.ghc865.miso-examples;
   inherit (pkgs.haskell.packages.ghc865) sample-app;
 
-  # miso wasm examples
-  # nix-build -A wasmExamples && ./result/bin/build.sh && nix-build -A svgWasm && http-server ./result/svg.wasmexe
+  # Miso wasm examples
+  # nix-build -A wasmExamples
+  #   && ./result/bin/build.sh
+  #   && nix-build -A svgWasm
+  #   && http-server ./result/svg.wasmexe
   inherit (pkgs)
     wasmExamples
     svgWasm

--- a/default.nix
+++ b/default.nix
@@ -64,4 +64,7 @@ in with pkgs.haskell.lib;
 
   # utils
   inherit (pkgs.haskell.packages.ghc865) miso-from-html;
+
+  # misc. examples
+  inherit (pkgs) more-examples;
 }

--- a/examples/canvas2d/Main.hs
+++ b/examples/canvas2d/Main.hs
@@ -26,7 +26,7 @@ main = run $ do
     setSrc earth "https://7b40c187-5088-4a99-9118-37d20a2f875e.mdnplay.dev/en-US/docs/Web/API/Canvas_API/Tutorial/Basic_animations/canvas_earth.png"
     startApp
         App
-            { initialAction = GetTime
+            { initialAction = Just GetTime
             , update = updateModel (sun, moon, earth)
             , ..
             }

--- a/examples/components/Main.hs
+++ b/examples/components/Main.hs
@@ -39,7 +39,10 @@ data MainAction
 type MainModel = Bool
 
 main :: IO ()
-main = run $ startApp app { logLevel = DebugPrerender }
+main = run $ startApp app
+  { logLevel = DebugPrerender
+  , subs = [loggerSub "main-app"]
+  }
 
 secs :: Int -> Int
 secs = (* 1000000)
@@ -51,10 +54,7 @@ loggerSub msg = \_ ->
         consoleLog msg
 
 app :: App MainModel MainAction
-app =
-    (defaultApp False updateModel1 viewModel1 MainNoOp)
-        { subs = [loggerSub "main-app"]
-        }
+app = defaultApp False updateModel1 viewModel1
 
 component2 :: Component Model Action
 component2 =
@@ -120,7 +120,7 @@ updateModel1 SampleChild m =
       pure MainNoOp
 
 counterApp2 :: App Model Action
-counterApp2 = defaultApp 0 updateModel2 viewModel2 SayHelloWorld
+counterApp2 = defaultApp 0 updateModel2 viewModel2
 
 -- | Updates model, optionally introduces side effects
 updateModel2 :: Action -> Model -> Effect Action Model
@@ -156,7 +156,7 @@ viewModel2 x =
         ]
 
 counterApp3 :: App (Bool, Model) Action
-counterApp3 = defaultApp (True, 0) updateModel3 viewModel3 SayHelloWorld
+counterApp3 = defaultApp (True, 0) updateModel3 viewModel3
 
 -- | Updates model, optionally introduces side effects
 updateModel3 :: Action -> (Bool, Model) -> Effect Action (Bool, Model)
@@ -199,7 +199,7 @@ viewModel3 (toggle, x) =
                ]
 
 counterApp4 :: App Model Action
-counterApp4 = defaultApp 0 updateModel4 viewModel4 SayHelloWorld
+counterApp4 = defaultApp 0 updateModel4 viewModel4
 
 -- | Updates model, optionally introduces side effects
 updateModel4 :: Action -> Model -> Effect Action Model

--- a/examples/components/Main.hs
+++ b/examples/components/Main.hs
@@ -14,7 +14,7 @@ import Miso.String
 
 type Model = Int
 
-#if defined(wasm32_HOST_ARCH)
+#ifdef WASM
 foreign export javascript "hs_start" main :: IO ()
 #endif
 

--- a/examples/compose-update/Main.hs
+++ b/examples/compose-update/Main.hs
@@ -100,15 +100,11 @@ foreign export javascript "hs_start" main :: IO ()
 #endif
 
 main :: IO ()
-main = run $ startApp App{initialAction = NoOp, ..}
+main = run $ startApp (defaultApp model update view)
   where
     model = (0, 0)
     update = updateModel
     view = viewModel
-    events = defaultEvents
-    subs = []
-    mountPoint = Nothing
-    logLevel = Off
 
 viewModel :: Model -> View Action
 viewModel (x, y) =

--- a/examples/file-reader/Main.hs
+++ b/examples/file-reader/Main.hs
@@ -40,7 +40,7 @@ main = run $ do
     startApp
         App
             { model = Model ""
-            , initialAction = NoOp
+            , initialAction = Nothing
             , ..
             }
   where

--- a/examples/mario/Main.hs
+++ b/examples/mario/Main.hs
@@ -30,22 +30,12 @@ main :: IO ()
 main = run $ do
     time <- now
     let m = mario{time = time}
-    startApp
-        App
-            { model = m
-            , initialAction = NoOp
-            , ..
-            }
-  where
-    update = updateMario
-    view = display
-    events = defaultEvents
-    subs =
-        [ arrowsSub GetArrows
-        , windowCoordsSub WindowCoords
-        ]
-    mountPoint = Nothing
-    logLevel = Off
+    startApp (defaultApp m updateMario display)
+      { subs =
+          [ arrowsSub GetArrows
+          , windowCoordsSub WindowCoords
+          ]
+      }
 
 data Model = Model
     { x :: !Double

--- a/examples/mathml/Main.hs
+++ b/examples/mathml/Main.hs
@@ -1,13 +1,8 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
-
--- \| Haskell module declaration
-
--- | Haskell language pragma
 module Main where
 
--- \| Miso framework import
 import Miso
 
 #if defined(wasm32_HOST_ARCH)
@@ -16,22 +11,15 @@ foreign export javascript "hs_start" main :: IO ()
 
 -- | Entry point for a miso application
 main :: IO ()
-main = run $ startApp App{..}
-  where
-    initialAction = NoOp -- initial action to be executed on application load
-    model = Main.Empty -- initial model
-    update = updateModel -- update function
-    view = viewModel -- view function
-    events = defaultEvents -- default delegated events
-    subs = [] -- empty subscription list
-    mountPoint = Nothing -- mount point for application (Nothing defaults to 'body')
-    logLevel = Off
+main = run $ startApp (defaultApp Main.Empty updateModel viewModel)
 
-data Model = Empty deriving (Eq)
+data Model
+  = Empty
+  deriving (Eq)
 
 data Action
-    = NoOp
-    deriving (Show, Eq)
+  = NoOp
+  deriving (Show, Eq)
 
 -- | Updates model, optionally introduces side effects
 updateModel :: Action -> Model -> Effect Action Model

--- a/examples/router/Main.hs
+++ b/examples/router/Main.hs
@@ -33,17 +33,11 @@ data Action
 
 -- | Main entry point
 main :: IO ()
-main =
-    run $ do
-        currentURI <- getCurrentURI
-        startApp App{model = Model currentURI, initialAction = NoOp, ..}
-  where
-    update = updateModel
-    events = defaultEvents
-    subs = [uriSub HandleURI]
-    view = viewModel
-    mountPoint = Nothing
-    logLevel = Off
+main = run $
+  miso $ \uri ->
+    (defaultApp (Model uri) updateModel viewModel)
+       { subs = [uriSub HandleURI]
+       }
 
 -- | Update your model
 updateModel :: Action -> Model -> Effect Action Model

--- a/examples/simple/Main.hs
+++ b/examples/simple/Main.hs
@@ -34,7 +34,7 @@ main = run $ startApp app
 
 -- | Application definition (uses 'defaultApp' smart constructor)
 app :: App Model Action
-app = defaultApp 0 updateModel viewModel SayHelloWorld
+app = defaultApp 0 updateModel viewModel
 
 -- | UpdateModels model, optionally introduces side effects
 updateModel :: Action -> Model -> Effect Action Model

--- a/examples/sse/shared/Common.hs
+++ b/examples/sse/shared/Common.hs
@@ -5,11 +5,9 @@
 module Common (
     -- * App
     sse,
-
     -- * Types
     Model,
     Action,
-
     -- * Exported links
     goHome,
     the404,
@@ -64,25 +62,18 @@ goHome :: URI
 goHome = allLinks' linkURI (Proxy :: Proxy ClientRoutes)
 
 sse :: URI -> App Model Action
-sse currentURI =
-        App
-            { initialAction = NoOp
-            , model = Model currentURI "No event received"
-            , ..
-            }
+sse currentURI
+  = app { subs =
+          [ sseSub "/sse" handleSseMsg
+          , uriSub HandleURI
+          ]
+        }
   where
-    update = updateModel
+    app = defaultApp (Model currentURI "No event received") updateModel view
     view m
         | Right r <- route (Proxy :: Proxy ClientRoutes) home modelUri m =
             r
         | otherwise = the404
-    events = defaultEvents
-    subs =
-        [ sseSub "/sse" handleSseMsg
-        , uriSub HandleURI
-        ]
-    mountPoint = Nothing
-    logLevel = Off
 
 handleSseMsg :: SSE String -> Action
 handleSseMsg (SSEMessage msg) = ServerMsg msg

--- a/examples/svg/Main.hs
+++ b/examples/svg/Main.hs
@@ -24,7 +24,7 @@ main = run $ startApp app
 
 -- | Application definition (uses 'defaultApp' smart constructor)
 app :: App Model Action
-app = defaultApp emptyModel updateModel viewModel Id
+app = defaultApp emptyModel updateModel viewModel
 
 emptyModel :: Model
 emptyModel = Model (0, 0)

--- a/examples/three/Main.hs
+++ b/examples/three/Main.hs
@@ -62,19 +62,9 @@ main = run $ do
     stats <- newStats
     ref <- newIORef $ Context (pure ()) (pure ()) stats
     m <- now
-    startApp
-        App
-            { model = m
-            , initialAction = Init
-            , update = updateModel ref
-            , mountPoint = Nothing
-            , logLevel = Off
-            , ..
-            }
-  where
-    events = defaultEvents
-    view = viewModel
-    subs = []
+    startApp (defaultApp m (updateModel ref) viewModel)
+      { initialAction = Just Init
+      }
 
 viewModel :: Double -> View action
 viewModel _ =

--- a/examples/todo-mvc/Main.hs
+++ b/examples/todo-mvc/Main.hs
@@ -94,7 +94,7 @@ main = run $ startApp app
   }
 
 app :: App Model Msg
-app = defaultApp emptyModel updateModel viewModel NoOp
+app = defaultApp emptyModel updateModel viewModel
 
 updateModel :: Msg -> Model -> Effect Msg Model
 updateModel NoOp m = noEff m

--- a/examples/websocket/Main.hs
+++ b/examples/websocket/Main.hs
@@ -37,7 +37,7 @@ main = run $ startApp app
       protocols = Protocols []
 
 app :: App Model Action
-app = defaultApp emptyModel updateModel appView Id
+app = defaultApp emptyModel updateModel appView
 
 emptyModel :: Model
 emptyModel = Model (Message "") mempty

--- a/examples/xhr/Main.hs
+++ b/examples/xhr/Main.hs
@@ -34,7 +34,7 @@ main :: IO ()
 main = run (startApp app)
 
 app :: App Model Action
-app = defaultApp emptyModel updateModel viewModel NoOp
+app = defaultApp emptyModel updateModel viewModel
 
 emptyModel :: Model
 emptyModel = Model Nothing

--- a/haskell-miso.org/shared/Common.hs
+++ b/haskell-miso.org/shared/Common.hs
@@ -97,7 +97,7 @@ haskellMisoComponent uri
   }
   
 app :: URI -> App Model Action
-app currentUri = defaultApp emptyModel updateModel viewModel NoOp
+app currentUri = defaultApp emptyModel updateModel viewModel
   where
     emptyModel = Model currentUri False
     viewModel m =

--- a/nix/haskell/packages/ghcjs/default.nix
+++ b/nix/haskell/packages/ghcjs/default.nix
@@ -10,7 +10,7 @@ self: super:
   sample-app-js = self.callCabal2nix "app" source.sample-app {};
   jsaddle = self.callCabal2nix "jsaddle" "${source.jsaddle}/jsaddle" {};
   jsaddle-warp = dontCheck (self.callCabal2nix "jsaddle-warp" "${source.jsaddle}/jsaddle-warp" {});
-  flatris = self.callCabal2nix "hs-flatris" source.flatris {};
+  flatris = self.callCabal2nix "flatris" source.flatris {};
   miso-plane =
     let
       miso-plane = self.callCabal2nix "miso-plane" source.miso-plane {};

--- a/nix/haskell/packages/source.nix
+++ b/nix/haskell/packages/source.nix
@@ -39,26 +39,26 @@ in
   flatris = fetchFromGitHub {
     owner = "dmjio";
     repo = "hs-flatris";
-    rev = "8ff07a4";
-    sha256 = "sha256-8CyAxOI/OfPOOidDg2sWBMlPBo8ujtpdnEowVi9QbZc=";
+    rev = "4d63a06";
+    sha256 = "sha256-wTMOtGQYsAGOW8UJr1V2WoXyo6QwUJIQQ4Fqimm1xfc=";
   };
   miso-plane = fetchFromGitHub {
     owner = "dmjio";
     repo = "miso-plane";
-    rev = "ca840da";
-    sha256 = "sha256-uh6gmuVX7YpeVmRShINJm5FJu5QSodxCPb6Yt18LNH4=";
+    rev = "3fd4f3a";
+    sha256 = "sha256-jbHn3BqrpuBt7KPvbHHzrG6t2cdDrYyFjHdLyD/vgAg=";
   };
   the2048 = fetchFromGitHub {
     owner = "dmjio";
     repo = "hs2048";
-    rev = "f9feab8";
-    sha256 = "sha256-lyR1XvYHvXePORnxG1+a8lEope2iC7WACZ0KmcWKpLk=";
+    rev = "25192e8";
+    sha256 = "sha256-sxAqm6VpuBPyFw19KM6/XAi8NmbIm/cYXr7SwAExumE=";
   };
   snake = fetchFromGitHub {
     owner = "dmjio";
     repo = "miso-snake";
-    rev = "ef3f3fd";
-    sha256 = "sha256-w8czHPy9TX4iTTVNc/qg3vUuZiVmTO2KHQK/lsgv3hI=";
+    rev = "712b91f";
+    sha256 = "sha256-kpI4aBnj5ehoRJAazMM+oHg9fj3XA69sP5bTk/pvFtQ=";
   };
   todomvc-common = fetchFromGitHub {
     owner = "tastejs";

--- a/nix/haskell/packages/source.nix
+++ b/nix/haskell/packages/source.nix
@@ -37,28 +37,28 @@ in
     sha256 = "sha256-jyJ7bdz0gNLOSzRxOWcv7eWGIwo3N/O4PcY7HyNF8Fo=";
   };
   flatris = fetchFromGitHub {
+    owner = "dmjio";
     repo = "hs-flatris";
-    owner = "ptigwe";
-    rev = "5b386e35db143205b4bd8d45cdf98423ed51b713";
-    sha256 = "0wll5fizkdmj2hgd71v9klnnr6wxvvf36imchh2chm1slqm78zca";
+    rev = "8ff07a4";
+    sha256 = "sha256-8CyAxOI/OfPOOidDg2sWBMlPBo8ujtpdnEowVi9QbZc=";
   };
   miso-plane = fetchFromGitHub {
-    repo = "miso-plane";
     owner = "dmjio";
-    rev = "a156422f710484ac89d22bd00f09ca706b6a65b8";
-    sha256 = "sha256-eQFlZ+9ndWxwMSpOl973Hl3VPmIcnxhWvSsmsyzpyEA=";
+    repo = "miso-plane";
+    rev = "ca840da";
+    sha256 = "sha256-uh6gmuVX7YpeVmRShINJm5FJu5QSodxCPb6Yt18LNH4=";
   };
   the2048 = fetchFromGitHub {
-    repo = "hs2048";
     owner = "dmjio";
-    rev = "07dbed79a012240bfe19b836b6d445bb16a0602a";
-    sha256 = "00rqix5g8s8y6ngxnjskvcyj19g639havn9pgpkdpxp8ni6g7xsm";
+    repo = "hs2048";
+    rev = "f9feab8";
+    sha256 = "sha256-lyR1XvYHvXePORnxG1+a8lEope2iC7WACZ0KmcWKpLk=";
   };
   snake = fetchFromGitHub {
-    repo = "miso-snake";
     owner = "dmjio";
-    rev = "c38947cd9417ab8bf8a8d3652d8bf549e35f14af";
-    sha256 = "17rdc7fisqgf8zq90c3cw9c08b1qac6wirqmwifw2a0xxbigz4qc";
+    repo = "miso-snake";
+    rev = "ef3f3fd";
+    sha256 = "sha256-w8czHPy9TX4iTTVNc/qg3vUuZiVmTO2KHQK/lsgv3hI=";
   };
   todomvc-common = fetchFromGitHub {
     owner = "tastejs";

--- a/sample-app/Main.hs
+++ b/sample-app/Main.hs
@@ -29,7 +29,7 @@ main :: IO ()
 main = run (startApp app)
 ----------------------------------------------------------------------------
 app :: App Model Action
-app = defaultApp emptyModel updateModel viewModel SayHelloWorld
+app = defaultApp emptyModel updateModel viewModel
 ----------------------------------------------------------------------------
 -- | Empty model
 emptyModel :: Model
@@ -40,7 +40,7 @@ updateModel :: Action -> Model -> Effect Action Model
 updateModel NoOp m          = noEff m
 updateModel AddOne m        = noEff (m + 1)
 updateModel SubtractOne m   = noEff (m - 1)
-updateModel SayHelloWorld m = m <# NoOp <$ consoleLog "Hello World"
+updateModel SayHelloWorld m = m <# NoOp <$ alert "Hello World"
 ----------------------------------------------------------------------------
 -- | Constructs a virtual DOM from a model
 viewModel :: Model -> View Action

--- a/src/Miso.hs
+++ b/src/Miso.hs
@@ -92,7 +92,7 @@ miso :: Eq model => (URI -> App model action) -> JSM ()
 miso f = withJS $ do
   app@App {..} <- f <$> getCurrentURI
   initialize app $ \snk -> do
-    VTree (Object vtree) <- runView Prerender (view model) snk events
+    VTree (Object vtree) <- runView Prerender (view model) snk logLevel events
     let name = getMountPoint mountPoint
     setBodyComponent name
     mount <- getBody
@@ -105,7 +105,7 @@ miso f = withJS $ do
 startApp :: Eq model => App model action -> JSM ()
 startApp app@App {..} = withJS $
   initialize app $ \snk -> do
-    vtree <- runView DontPrerender (view model) snk events
+    vtree <- runView DontPrerender (view model) snk logLevel events
     let name = getMountPoint mountPoint
     setBodyComponent name
     mount <- mountElement name

--- a/src/Miso.hs
+++ b/src/Miso.hs
@@ -55,6 +55,7 @@ module Miso
   , getElementById
   , focus
   , blur
+  , alert
   ) where
 -----------------------------------------------------------------------------
 import           Control.Monad (void)
@@ -92,12 +93,12 @@ miso f = withJS $ do
   app@App {..} <- f <$> getCurrentURI
   initialize app $ \snk -> do
     VTree (Object vtree) <- runView Prerender (view model) snk events
-    let mount = getMountPoint mountPoint
-    setBodyComponent mount
-    body <- getBody
-    copyDOMIntoVTree (logLevel `elem` [DebugPrerender, DebugAll]) body vtree
+    let name = getMountPoint mountPoint
+    setBodyComponent name
+    mount <- getBody
+    copyDOMIntoVTree (logLevel `elem` [DebugPrerender, DebugAll]) mount vtree
     viewRef <- liftIO $ newIORef $ VTree (Object vtree)
-    pure (mount, body, viewRef)
+    pure (name, mount, viewRef)
 -----------------------------------------------------------------------------
 -- | Runs a miso application
 -- Initializes application at @mountPoint@ (defaults to /<body>/ when @Nothing@)
@@ -105,12 +106,12 @@ startApp :: Eq model => App model action -> JSM ()
 startApp app@App {..} = withJS $
   initialize app $ \snk -> do
     vtree <- runView DontPrerender (view model) snk events
-    let mount = getMountPoint mountPoint
-    setBodyComponent mount
-    mountEl <- mountElement mount
-    diff mountEl Nothing (Just vtree)
-    ref <- liftIO (newIORef vtree)
-    pure (mount, mountEl, ref)
+    let name = getMountPoint mountPoint
+    setBodyComponent name
+    mount <- mountElement name
+    diff mount Nothing (Just vtree)
+    viewRef <- liftIO (newIORef vtree)
+    pure (name, mount, viewRef)
 -----------------------------------------------------------------------------
 -- | Used when compiling with jsaddle to make miso's JavaScript present in
 -- the execution context.

--- a/src/Miso/Event/Decoder.hs
+++ b/src/Miso/Event/Decoder.hs
@@ -118,6 +118,7 @@ pointerDecoder = Decoder {..}
     decoder = withObject "pointerDecoder" $ \o ->
       PointerEvent
         <$> o .: "pointerType"
+        <*> o .: "pointerId"
         <*> o .: "isPrimary"
         <*> pair o "x" "y"
         <*> pair o "screenX" "screenY"

--- a/src/Miso/Event/Types.hs
+++ b/src/Miso/Event/Types.hs
@@ -65,6 +65,7 @@ newtype Checked = Checked Bool
 data PointerEvent
   = PointerEvent
   { pointerType :: PointerType
+  , pointerId :: Int
   , isPrimary :: Bool
   , coords :: (Int, Int)
   -- ^ clientX (or x), clientY (or y)

--- a/src/Miso/Event/Types.hs
+++ b/src/Miso/Event/Types.hs
@@ -169,6 +169,7 @@ pointerEvents = M.fromList
   [ ("pointerup", False)
   , ("pointerdown", False)
   , ("pointerenter", True)
+  , ("pointercancel", False)
   , ("pointerleave", False)
   , ("pointerover", False)
   , ("pointerout", False)

--- a/src/Miso/Internal.hs
+++ b/src/Miso/Internal.hs
@@ -92,7 +92,7 @@ initialize App {..} getView = do
   componentMainThread <- FFI.forkJSM (eventLoop model)
   registerComponent ComponentState {..}
   delegator componentMount componentVTree events (logLevel `elem` [DebugEvents, DebugAll])
-  componentSink initialAction
+  forM_ initialAction componentSink
   pure componentVTree
 -----------------------------------------------------------------------------
 -- | Prerender avoids calling @diff@

--- a/src/Miso/Subscription/Keyboard.hs
+++ b/src/Miso/Subscription/Keyboard.hs
@@ -61,7 +61,7 @@ toArrows (up, down, left, right) set' = Arrows
 arrowsSub :: (Arrows -> action) -> Sub action
 arrowsSub = directionSub ([38], [40], [37], [39])
 -----------------------------------------------------------------------------
--- | Maps @Arrows@ onto a Keyboard subscription for directions
+-- | Maps @Arrows@ onto a Keyboard subscription for directions (W+A+S+D keys)
 wasdSub :: (Arrows -> action) -> Sub action
 wasdSub = directionSub ([87], [83], [65], [68])
 -----------------------------------------------------------------------------

--- a/src/Miso/Types.hs
+++ b/src/Miso/Types.hs
@@ -236,7 +236,7 @@ instance ToKey Word where toKey = Key . toMisoString
 -- vnode the attribute is attached to.
 data Attribute action
   = Property MisoString Value
-  | Event (Sink action -> Object -> Events -> JSM ())
+  | Event (Sink action -> Object -> LogLevel -> Events -> JSM ())
   | Style (M.Map MisoString MisoString)
   deriving Functor
 -----------------------------------------------------------------------------

--- a/src/Miso/Types.hs
+++ b/src/Miso/Types.hs
@@ -67,8 +67,8 @@ data App model action = App
   , events :: M.Map MisoString Bool
   -- ^ List of delegated events that the body element will listen for.
   --   You can start with 'Miso.Event.Types.defaultEvents' and modify as needed.
-  , initialAction :: action
-  -- ^ Initial action that is run after the application has loaded
+  , initialAction :: Maybe action
+  -- ^ Initial action that is run after the application has loaded, optional since *1.9*
   , mountPoint :: Maybe MisoString
   -- ^ Id of the root element for DOM diff.
   -- If 'Nothing' is provided, the entire document body is used as a mount point.
@@ -84,17 +84,16 @@ defaultApp
   :: model
   -> (action -> model -> Effect action model)
   -> (model -> View action)
-  -> action
   -> App model action
-defaultApp m u v a = App
-  { initialAction = a
-  , model = m
+defaultApp m u v = App
+  { model = m
   , view = v
   , update = u
   , subs = []
   , events = defaultEvents
   , mountPoint = Nothing
   , logLevel = Off
+  , initialAction = Nothing
   }
 -----------------------------------------------------------------------------
 -- | Optional Logging for debugging miso internals (useful to see if prerendering is successful)


### PR DESCRIPTION
- `defaultApp` no longer takes `a`
- Refactor examples to account for optionality
- Updates third-party examples to support this (updates them w/ latest code too, e.g. `PointerEvent`)
- Puts third-party examples under CI
- `DebugEvent` should only be on optionally