### PR TITLE
Introduce 1ms delay during unmount.

### DIFF
--- a/src/Miso/Internal.hs
+++ b/src/Miso/Internal.hs
@@ -28,7 +28,7 @@ module Miso.Internal
   ) where
 -----------------------------------------------------------------------------
 import           Control.Exception (throwIO)
-import           Control.Concurrent (ThreadId, killThread)
+import           Control.Concurrent (ThreadId, killThread, threadDelay)
 import           Control.Monad (forM, forM_, when, void)
 import           Control.Monad.IO.Class
 import qualified Data.Aeson as A
@@ -254,6 +254,8 @@ runView prerender (Embed attributes (SomeComponent (Component key mount app))) s
       M.lookup mount <$> liftIO (readIORef componentMap) >>= \case
         Nothing -> pure ()
         Just componentState -> do
+          liftIO (threadDelay (millis 1))
+          -- dmj ^ introduce 1ms delay to account for recursive component unmounting
           unmount mountCallback app componentState
   vcomp <- createNode "vcomp" HTML key "div"
   setAttrs vcomp attributes snk (logLevel app) (events app)
@@ -358,4 +360,8 @@ registerComponent :: MonadIO m => ComponentState model action -> m ()
 registerComponent componentState = liftIO
   $ modifyIORef' componentMap
   $ M.insert (componentName componentState) componentState
+-----------------------------------------------------------------------------
+-- | Millisecond helper, converts microseconds to milliseconds
+millis :: Int -> Int
+millis = (*1000)
 -----------------------------------------------------------------------------


### PR DESCRIPTION
In scenarios (like the `components` example) where deeply nested components undergo unmounting in rapid succession, a delay must be introduced to ensure that unmount actions are processed by the parent before the thread is killed. Otherwise, this can lead to scenarios where a middle child does not have enough time to process both the unmount action from its own child and the relaying of its unmount action to its parent.

Introducing a `threadDelay` will both buy us time and invoke the thread scheduler to ensure other thread stacks have time to evaluate thunks on their heaps before their own destruction (this includes thunks that write to parent sinks).

Tested on both JS and WASM (single threaded environments, and `-threaded` with `jsaddle-warp`)