### PR TITLE
var module = module || {}; -> module = {};

### DIFF
--- a/jsbits/miso.js
+++ b/jsbits/miso.js
@@ -1,5 +1,6 @@
 /* module export pattern */
-var module = module || {};
+module = {};
+
 module['exports'] = (function () {
   /* virtual-dom diffing algorithm, applies patches as detected */
   var diff = function (currentObj, newObj, parent, doc) {
@@ -800,6 +801,3 @@ module['exports'] = (function () {
   };
 
 })();
-
-/* keep closure compiler from renaming things */
-window['module'] = module;

--- a/jsbits/miso.js
+++ b/jsbits/miso.js
@@ -1,4 +1,5 @@
-module = {};
+/* account for node.js running tests, or a browser / wasm environment */
+module = typeof module === 'undefined' ? {} : module;
 
 /* module export pattern */
 module['exports'] = (function () {

--- a/jsbits/miso.js
+++ b/jsbits/miso.js
@@ -1,6 +1,6 @@
-/* module export pattern */
 module = {};
 
+/* module export pattern */
 module['exports'] = (function () {
   /* virtual-dom diffing algorithm, applies patches as detected */
   var diff = function (currentObj, newObj, parent, doc) {

--- a/src/Miso/FFI.hs
+++ b/src/Miso/FFI.hs
@@ -225,7 +225,7 @@ eventJSON
     -> JSVal -- ^ object with impure references to the DOM
     -> JSM JSVal
 eventJSON x y = do
-  moduleExports <- jsg "window" ! "module" ! "exports"
+  moduleExports <- jsg "module" ! "exports"
   moduleExports # "eventJSON" $ [x,y]
 -----------------------------------------------------------------------------
 -- | Retrieves the component id
@@ -268,7 +268,7 @@ diff
   -- ^ document
   -> JSM ()
 diff (Object a) (Object b) c d = do
-  moduleExports <- jsg "window" ! "module" ! "exports"
+  moduleExports <- jsg "module" ! "exports"
   void $ moduleExports # "diff" $ [a,b,c,d]
 -----------------------------------------------------------------------------
 -- | Helper function for converting Integral types to JavaScript strings
@@ -306,14 +306,14 @@ delegate :: JSVal -> JSVal -> Bool -> Function -> JSM ()
 delegate mountPoint events debug callback = do
   d <- toJSVal debug
   cb <- toJSVal callback
-  moduleExports <- jsg "window" ! "module" ! "exports"
+  moduleExports <- jsg "module" ! "exports"
   void $ moduleExports # "delegate" $ [mountPoint,events,cb,d]
 -----------------------------------------------------------------------------
 undelegate :: JSVal -> JSVal -> Bool -> Function -> JSM ()
 undelegate mountPoint events debug callback = do
   d <- toJSVal debug
   cb <- toJSVal callback
-  moduleExports <- jsg "window" ! "module" ! "exports"
+  moduleExports <- jsg "module" ! "exports"
   void $ moduleExports # "undelegate" $ [mountPoint,events,cb,d]
 -----------------------------------------------------------------------------
 -- | Copies DOM pointers into virtual dom
@@ -322,7 +322,7 @@ copyDOMIntoVTree :: Bool -> JSVal -> JSVal -> JSM ()
 copyDOMIntoVTree logLevel mountPoint vtree = void $ do
   doc <- getDocument
   ll <- toJSVal logLevel
-  moduleExports <- jsg "window" ! "module" ! "exports"
+  moduleExports <- jsg "module" ! "exports"
   void $ moduleExports # "copyDOMIntoVTree" $ [ll, mountPoint, vtree, doc]
 -----------------------------------------------------------------------------
 -- | Fails silently if the element is not found.
@@ -330,7 +330,7 @@ copyDOMIntoVTree logLevel mountPoint vtree = void $ do
 -- Analogous to @document.getElementById(id).focus()@.
 focus :: MisoString -> JSM ()
 focus x = do
-  moduleExports <- jsg "window" ! "module" ! "exports"
+  moduleExports <- jsg "module" ! "exports"
   void $ moduleExports # "callFocus" $ [x]
 -----------------------------------------------------------------------------
 -- | Fails silently if the element is not found.
@@ -338,7 +338,7 @@ focus x = do
 -- Analogous to @document.getElementById(id).blur()@
 blur :: MisoString -> JSM ()
 blur x = do
-  moduleExports <- jsg "window" ! "module" ! "exports"
+  moduleExports <- jsg "module" ! "exports"
   void $ moduleExports # "callBlur" $ [x]
 -----------------------------------------------------------------------------
 -- | Calls @document.getElementById(id).scrollIntoView()@
@@ -356,6 +356,6 @@ alert a = () <$ jsg1 "alert" a
 setBodyComponent :: MisoString -> JSVal -> JSM ()
 setBodyComponent name document = do
   component <- toJSVal name
-  moduleExports <- jsg "window" ! "module" ! "exports"
+  moduleExports <- jsg "module" ! "exports"
   void $ moduleExports # "setBodyComponent" $ [component, document]
 -----------------------------------------------------------------------------

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -24,7 +24,6 @@ in
     buildCommand = ''
       mkdir -p $out
       cp -v ${miso-ghcjs.src}/jsbits/miso.js $out
-      ${pkgs.gnused}/bin/sed -i '1d' $out/miso.js
       cp -v ${src}/package.json $out
       cp -v ${src}/miso.spec.js $out
       cp -r ${deps}/libexec/miso/node_modules $out

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -24,6 +24,7 @@ in
     buildCommand = ''
       mkdir -p $out
       cp -v ${miso-ghcjs.src}/jsbits/miso.js $out
+      ${pkgs.gnused}/bin/sed -i '1d' $out/miso.js
       cp -v ${src}/package.json $out
       cp -v ${src}/miso.spec.js $out
       cp -r ${deps}/libexec/miso/node_modules $out


### PR DESCRIPTION
By removing `var` we keep `module` named `"module"` top-level and exported globally. It no longer gets GC'd in the WASM context. Also allows us to truly drop `window` usage from miso.js, and not use it in the FFI calls.