### PR TITLE
Add code coverage for focus / blur utils.

### DIFF
--- a/jsbits/miso.js
+++ b/jsbits/miso.js
@@ -771,18 +771,20 @@ module['exports'] = (function () {
   }
 
   /* various utilities */
-  var callFocus = function (id) {
-    setTimeout(function(){
-      var ele = document.getElementById(id);
-      if (ele && ele.focus) ele.focus()
-    }, 50);
+  var callFocus = function (id, doc, delay) {
+    var setFocus = function () {
+      var e = doc.getElementById(id);
+      if (e && e.focus) e.focus();
+    }
+    delay > 0 ? setTimeout (setFocus, delay) : setFocus ();
   }
 
-  var callBlur = function (id) {
-    setTimeout(function(){
-      var ele = document.getElementById(id);
-      if (ele && ele.blur) ele.blur()
-    }, 50);
+  var callBlur = function (id, doc, delay) {
+    var setBlur = function () {
+      var e = doc.getElementById(id);
+      if (e && e.blur) e.blur();
+    }
+    delay > 0 ? setTimeout (setBlur, delay) : setBlur ();
   }
 
   var setBodyComponent = function (componentId, doc) {

--- a/src/Miso.hs
+++ b/src/Miso.hs
@@ -94,7 +94,7 @@ miso f = withJS $ do
   initialize app $ \snk -> do
     VTree (Object vtree) <- runView Prerender (view model) snk logLevel events
     let name = getMountPoint mountPoint
-    setBodyComponent name =<< getDocument
+    setBodyComponent name
     mount <- getBody
     copyDOMIntoVTree (logLevel `elem` [DebugPrerender, DebugAll]) mount vtree
     viewRef <- liftIO $ newIORef $ VTree (Object vtree)
@@ -107,7 +107,7 @@ startApp app@App {..} = withJS $
   initialize app $ \snk -> do
     vtree <- runView DontPrerender (view model) snk logLevel events
     let name = getMountPoint mountPoint
-    setBodyComponent name =<< getDocument
+    setBodyComponent name
     mount <- mountElement name
     diff mount Nothing (Just vtree)
     viewRef <- liftIO (newIORef vtree)

--- a/src/Miso/FFI.hs
+++ b/src/Miso/FFI.hs
@@ -331,7 +331,10 @@ copyDOMIntoVTree logLevel mountPoint vtree = void $ do
 focus :: MisoString -> JSM ()
 focus x = do
   moduleExports <- jsg "module" ! "exports"
-  void $ moduleExports # "callFocus" $ [x]
+  doc <- getDocument
+  el <- toJSVal x
+  delay <- toJSVal (50 :: Int)
+  void $ moduleExports # "callFocus" $ [el,doc,delay]
 -----------------------------------------------------------------------------
 -- | Fails silently if the element is not found.
 --
@@ -339,7 +342,10 @@ focus x = do
 blur :: MisoString -> JSM ()
 blur x = do
   moduleExports <- jsg "module" ! "exports"
-  void $ moduleExports # "callBlur" $ [x]
+  doc <- getDocument
+  el <- toJSVal x
+  delay <- toJSVal (50 :: Int)
+  void $ moduleExports # "callBlur" $ [el,doc,delay]
 -----------------------------------------------------------------------------
 -- | Calls @document.getElementById(id).scrollIntoView()@
 scrollIntoView :: MisoString -> JSM ()
@@ -353,9 +359,10 @@ alert :: MisoString -> JSM ()
 alert a = () <$ jsg1 "alert" a
 -----------------------------------------------------------------------------
 -- | Sets the body with data-component-id
-setBodyComponent :: MisoString -> JSVal -> JSM ()
-setBodyComponent name document = do
+setBodyComponent :: MisoString -> JSM ()
+setBodyComponent name = do
+  doc <- getDocument
   component <- toJSVal name
   moduleExports <- jsg "module" ! "exports"
-  void $ moduleExports # "setBodyComponent" $ [component, document]
+  void $ moduleExports # "setBodyComponent" $ [component, doc]
 -----------------------------------------------------------------------------

--- a/tests/miso.spec.js
+++ b/tests/miso.spec.js
@@ -1489,3 +1489,17 @@ test('Should set body[data-component-id] via setBodyComponent()', () => {
   expect(document.body.getAttribute('data-component-id')).toEqual('component-one');
 });
 
+test('Should call callFocus() and callBlur()', () => {
+  var document = new jsdom.JSDOM().window.document;
+  var child = document.createElement('input');
+  child['id'] = 'foo';
+  document.body.appendChild(child);
+  miso.callFocus('blah', document, 0); /* missing case */
+  miso.callFocus('foo', document, 0); /* found case */
+  miso.callFocus('foo', document, 1); /* found case */
+  expect(document.activeElement).toEqual(child);
+  miso.callBlur('blah', document, 0); /* missing case */
+  miso.callBlur('foo', document, 0); /* found case */
+  miso.callBlur('foo', document, 1); /* found case */
+  expect(document.activeElement).toEqual(document.body);
+});


### PR DESCRIPTION
- Adds test for `callFocus()` / `callBlur()`
- Adds optional timeout defaults
- Moves document out of setBodyComponent haskell function and into the FFI call