### PR TITLE
Unify param ordering between Effect and App

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ main :: IO ()
 main = run (startApp app)
 ----------------------------------------------------------------------------
 -- | `defaultApp` takes as arguments the initial model, update function, view function
-app :: App Effect Model Action
+app :: App Effect Model Action ()
 app = defaultApp emptyModel updateModel viewModel
 ----------------------------------------------------------------------------
 -- | Empty application state
@@ -286,7 +286,7 @@ emptyModel :: Model
 emptyModel = Model 0
 ----------------------------------------------------------------------------
 -- | Updates model, optionally introduces side effects
-updateModel :: Action -> Effect Action Model ()
+updateModel :: Action -> Effect Model Action ()
 updateModel = \case
   AddOne        -> counter += 1
   SubtractOne   -> counter -= 1

--- a/examples/canvas2d/Main.hs
+++ b/examples/canvas2d/Main.hs
@@ -4,6 +4,7 @@
 
 module Main where
 
+import Control.Monad
 import Control.Monad.State
 import GHCJS.Types
 import JavaScript.Web.Canvas
@@ -38,7 +39,7 @@ main = run $ do
 updateModel
   :: (Image, Image, Image)
   -> Action
-  -> Effect Action Model ()
+  -> Effect Model Action ()
 updateModel _ GetTime = do
   m <- get
   m <# do

--- a/examples/components/Main.hs
+++ b/examples/components/Main.hs
@@ -52,24 +52,24 @@ loggerSub msg = \_ ->
         liftIO $ threadDelay (secs 10)
         consoleLog msg
 
-app :: App Effect MainModel MainAction
+app :: App Effect MainModel MainAction ()
 app = defaultApp False updateModel1 viewModel1
 
-component2 :: Component Effect Model Action
+component2 :: Component Effect Model Action ()
 component2 =
     component "component-2"
         counterApp2
             { subs = [loggerSub "component-2 sub"]
             }
 
-component3 :: Component Effect (Bool, Model) Action
+component3 :: Component Effect (Bool, Model) Action ()
 component3 =
     component "component-3"
         counterApp3
             { subs = [loggerSub "component-3 sub"]
             }
 
-component4 :: Component Effect Model Action
+component4 :: Component Effect Model Action ()
 component4 =
     component "component-4"
         counterApp4
@@ -99,7 +99,7 @@ viewModel1 x =
         ]
 
 -- | Updates model, optionally introduces side effects
-updateModel1 :: MainAction -> Effect MainAction MainModel ()
+updateModel1 :: MainAction -> Effect MainModel MainAction ()
 updateModel1 Toggle = modify not
 updateModel1 UnMountMain =
   io (consoleLog "Component 2 was unmounted!")
@@ -112,11 +112,11 @@ updateModel1 SampleChild = do
         "Sampling child component 2 from parent component main (unsafe): " <>
           ms (show componentTwoModel)
 
-counterApp2 :: App Effect Model Action
+counterApp2 :: App Effect Model Action ()
 counterApp2 = defaultApp 0 updateModel2 viewModel2
 
 -- | Updates model, optionally introduces side effects
-updateModel2 :: Action -> Effect Action Model ()
+updateModel2 :: Action -> Effect Model Action ()
 updateModel2 AddOne = modify (+1)
 updateModel2 SubtractOne = modify (subtract 1)
 updateModel2 UnMount =
@@ -142,11 +142,11 @@ viewModel2 x =
           ] 
         ]
 
-counterApp3 :: App Effect (Bool, Model) Action
+counterApp3 :: App Effect (Bool, Model) Action ()
 counterApp3 = defaultApp (True, 0) updateModel3 viewModel3
 
 -- | Updates model, optionally introduces side effects
-updateModel3 :: Action -> Effect Action (Bool, Model) ()
+updateModel3 :: Action -> Effect (Bool, Model) Action ()
 updateModel3 AddOne = do
   modify (fmap (+1))
   io (notify component2 AddOne)
@@ -180,11 +180,11 @@ viewModel3 (toggle, x) =
                | toggle
                ]
 
-counterApp4 :: App Effect Model Action
+counterApp4 :: App Effect Model Action ()
 counterApp4 = defaultApp 0 updateModel4 viewModel4
 
 -- | Updates model, optionally introduces side effects
-updateModel4 :: Action -> Effect Action Model ()
+updateModel4 :: Action -> Effect Model Action ()
 updateModel4 AddOne = do
   modify (+1)
   io (notify component2 AddOne)

--- a/examples/file-reader/Main.hs
+++ b/examples/file-reader/Main.hs
@@ -39,7 +39,7 @@ main :: IO ()
 main = run $ startApp (defaultApp (Model "") updateModel viewModel)
 
 -- | Update your model
-updateModel :: Action -> Effect Action Model ()
+updateModel :: Action -> Effect Model Action ()
 updateModel ReadFile = do
     m <- get
     m <# do

--- a/examples/mario/Main.hs
+++ b/examples/mario/Main.hs
@@ -71,7 +71,7 @@ mario =
         , window = (0, 0)
         }
 
-updateMario :: Action -> Effect Action Model ()
+updateMario :: Action -> Effect Model Action ()
 updateMario Start = get >>= step
 updateMario (GetArrows arrs) = modify newModel
   where
@@ -86,7 +86,7 @@ updateMario (WindowCoords coords) = modify newModel
   where
     newModel m = m { window = coords }
 
-step :: Model -> Effect Action Model ()
+step :: Model -> Effect Model Action ()
 step m@Model{..} = k <# Time <$> now
   where
     k =

--- a/examples/router/Main.hs
+++ b/examples/router/Main.hs
@@ -40,7 +40,7 @@ main = run $
        }
 
 -- | Update your model
-updateModel :: Action -> Effect Action Model ()
+updateModel :: Action -> Effect Model Action ()
 updateModel (HandleURI u) = modify $ \m -> m { uri = u }
 updateModel (ChangeURI u) = scheduleIO_ (pushURI u)
 

--- a/examples/simple/Main.hs
+++ b/examples/simple/Main.hs
@@ -31,11 +31,11 @@ main = run $ startApp app
   }
 
 -- | Application definition (uses 'defaultApp' smart constructor)
-app :: App Effect Model Action
+app :: App Effect Model Action ()
 app = defaultApp 0 updateModel viewModel
 
 -- | UpdateModels model, optionally introduces side effects
-updateModel :: Action -> Effect Action Model ()
+updateModel :: Action -> Effect Model Action ()
 updateModel (AddOne event) = do
   modify (+1)
   io $ consoleLog (ms (show event))

--- a/examples/sse/server/Main.hs
+++ b/examples/sse/server/Main.hs
@@ -64,7 +64,7 @@ sendEvents chan =
         threadDelay (10 ^ (6 :: Int))
 
 -- | Page for setting HTML doctype and header
-newtype Page = Page (App Effect Model Action)
+newtype Page = Page (App Effect Model Action ())
 
 instance ToHtml Page where
     toHtml (Page x) =

--- a/examples/sse/shared/Common.hs
+++ b/examples/sse/shared/Common.hs
@@ -60,7 +60,7 @@ the404 =
 goHome :: URI
 goHome = allLinks' linkURI (Proxy :: Proxy ClientRoutes)
 
-sse :: URI -> App Effect Model Action
+sse :: URI -> App Effect Model Action ()
 sse currentURI
   = app { subs =
           [ sseSub "/sse" handleSseMsg
@@ -79,7 +79,7 @@ handleSseMsg (SSEMessage msg) = ServerMsg msg
 handleSseMsg SSEClose = ServerMsg "SSE connection closed"
 handleSseMsg SSEError = ServerMsg "SSE error"
 
-updateModel :: Action -> Effect Action Model ()
+updateModel :: Action -> Effect Model Action ()
 updateModel (ServerMsg msg) = modify update
   where
     update m = m { modelMsg = "Event received: " ++ msg }

--- a/examples/svg/Main.hs
+++ b/examples/svg/Main.hs
@@ -24,13 +24,13 @@ main = run $ startApp app
   }
 
 -- | Application definition (uses 'defaultApp' smart constructor)
-app :: App Effect Model Action
+app :: App Effect Model Action ()
 app = defaultApp emptyModel updateModel viewModel
 
 emptyModel :: Model
 emptyModel = Model (0, 0)
 
-updateModel :: Action -> Effect Action Model ()
+updateModel :: Action -> Effect Model Action ()
 updateModel (HandlePointer pointer) = modify update
   where
     update m = m { mouseCoords = coords pointer }

--- a/examples/three/Main.hs
+++ b/examples/three/Main.hs
@@ -86,7 +86,7 @@ viewModel _ =
 updateModel ::
     IORef Context ->
     Action ->
-    Effect Action Double ()
+    Effect Double Action ()
 updateModel ref Init = do
   io (initContext ref)
   issue GetTime

--- a/examples/todo-mvc/Main.hs
+++ b/examples/todo-mvc/Main.hs
@@ -95,10 +95,10 @@ main = run $ startApp app
   , initialAction = Just FocusOnInput
   }
 
-app :: App Effect Model Msg
+app :: App Effect Model Msg ()
 app = defaultApp emptyModel updateModel viewModel
 
-updateModel :: Msg -> Effect Msg Model ()
+updateModel :: Msg -> Effect Model Msg ()
 updateModel NoOp = pure ()
 updateModel FocusOnInput = io (focus "input-box")
 updateModel (CurrentTime time) = io $ consoleLog $ S.ms (show time)

--- a/examples/websocket/Main.hs
+++ b/examples/websocket/Main.hs
@@ -37,13 +37,13 @@ main = run $ startApp app
       url = URL "wss://echo.websocket.org"
       protocols = Protocols []
 
-app :: App Effect Model Action
+app :: App Effect Model Action ()
 app = defaultApp emptyModel updateModel appView
 
 emptyModel :: Model
 emptyModel = Model (Message "") mempty
 
-updateModel :: Action -> Effect Action Model ()
+updateModel :: Action -> Effect Model Action ()
 updateModel (HandleWebSocket (WebSocketMessage (Message m))) =
   modify $ \model -> model { received = m }
 updateModel (SendMessage msg) =

--- a/examples/xhr/Main.hs
+++ b/examples/xhr/Main.hs
@@ -33,14 +33,14 @@ data Action
 main :: IO ()
 main = run (startApp app)
 
-app :: App Effect Model Action
+app :: App Effect Model Action ()
 app = defaultApp emptyModel updateModel viewModel
 
 emptyModel :: Model
 emptyModel = Model Nothing
 
 -- | Update your model
-updateModel :: Action -> Effect Action Model ()
+updateModel :: Action -> Effect Model Action ()
 updateModel FetchGitHub = do
   scheduleIO (SetGitHub <$> getGitHubAPIInfo)
 updateModel (SetGitHub apiInfo) =

--- a/haskell-miso.org/shared/Common.hs
+++ b/haskell-miso.org/shared/Common.hs
@@ -61,7 +61,7 @@ type ClientRoutes = Routes (View Action)
 type ServerRoutes = Routes (Get '[HTML] Page)
 
 -- | Component synonym
-type HaskellMisoComponent = App Effect Model Action
+type HaskellMisoComponent = App Effect Model Action ()
 
 -- | Links
 uriHome, uriExamples, uriDocs, uriCommunity, uri404 :: URI
@@ -97,7 +97,7 @@ haskellMisoComponent uri
   , logLevel = DebugAll
   }
   
-app :: URI -> App Effect Model Action
+app :: URI -> App Effect Model Action ()
 app currentUri = defaultApp emptyModel updateModel viewModel
   where
     emptyModel = Model currentUri False
@@ -106,7 +106,7 @@ app currentUri = defaultApp emptyModel updateModel viewModel
           Left _ -> the404 m
           Right v -> v
 
-updateModel :: Action -> Effect Action Model ()
+updateModel :: Action -> Effect Model Action ()
 updateModel = \case
   HandleURI u ->
     modify $ \m -> m { uri = u }

--- a/nix/haskell/packages/source.nix
+++ b/nix/haskell/packages/source.nix
@@ -39,26 +39,26 @@ in
   flatris = fetchFromGitHub {
     owner = "dmjio";
     repo = "hs-flatris";
-    rev = "0b0e9ca";
-    sha256 = "sha256-lCVbACOAAz77k1tI4DXRAMDJLJiWaPb7o7uio1YGAIk=";
+    rev = "088a95d";
+    sha256 = "sha256-5R/LTgH+jVHQWT1Mk9erC7wJPj2R1z7snrNQeun7eCs=";
   };
   miso-plane = fetchFromGitHub {
     owner = "dmjio";
     repo = "miso-plane";
-    rev = "55e8445";
-    sha256 = "sha256-6QU+SvE5Rpr/YJpp4+A0iwu3CwMYtZ0OdEdMJHHeo5U=";
+    rev = "225ce5b7ddd57e716b96f8029dbef16d7dda15fd";
+    sha256 = "sha256-DuDDM0ePZCIASX8TB0YxIivXMhV7x7uaPb/HbJJILUs=";
   };
   the2048 = fetchFromGitHub {
     owner = "dmjio";
     repo = "hs2048";
-    rev = "f5729cb";
-    sha256 = "sha256-EJWAIFMhplF97jhY0wQ0ms0ZHrgnYWszPp8GE23RkC0=";
+    rev = "8a6c951e75bea7502287b809e66bfe8f1db77a7c";
+    sha256 = "sha256-O3AqxsyrwvUMb7Nnz3KDUgRYJtgJouunnONqR3SIgNQ=";
   };
   snake = fetchFromGitHub {
     owner = "dmjio";
     repo = "miso-snake";
-    rev = "e83f9be";
-    sha256 = "sha256-QvekR9JjHtHJW+52No2q8cZ9niXkakgFHmdOX3fd/n8=";
+    rev = "5740e0f";
+    sha256 = "sha256-qStRWDP0jFccPhVUWoP7o1P8+MvJq7cJSDUuBmUfsyg=";
   };
   todomvc-common = fetchFromGitHub {
     owner = "tastejs";

--- a/sample-app/Main.hs
+++ b/sample-app/Main.hs
@@ -31,7 +31,7 @@ main :: IO ()
 main = run (startApp app)
 ----------------------------------------------------------------------------
 -- | `defaultApp` takes as arguments the initial model, update function, view function
-app :: App Effect Model Action
+app :: App Effect Model Action ()
 app = defaultApp emptyModel updateModel viewModel
 ----------------------------------------------------------------------------
 -- | Empty application state
@@ -39,7 +39,7 @@ emptyModel :: Model
 emptyModel = Model 0
 ----------------------------------------------------------------------------
 -- | Updates model, optionally introduces side effects
-updateModel :: Action -> Effect Action Model ()
+updateModel :: Action -> Effect Model Action ()
 updateModel = \case
   AddOne        -> counter += 1
   SubtractOne   -> counter -= 1

--- a/src/Miso.hs
+++ b/src/Miso.hs
@@ -87,7 +87,7 @@ import           Miso.FFI hiding (diff)
 -- Assumes the pre-rendered DOM is already present.
 -- Note: Uses @mountPoint@ as the @Component@ name.
 -- Always mounts to /<body>/. Copies page into the virtual DOM.
-miso :: Eq model => (URI -> App effect model action) -> JSM ()
+miso :: Eq model => (URI -> App effect model action a) -> JSM ()
 miso f = withJS $ do
   app@App {..} <- f <$> getCurrentURI
   initialize app $ \snk -> do
@@ -101,7 +101,7 @@ miso f = withJS $ do
 -----------------------------------------------------------------------------
 -- | Runs a miso application
 -- Initializes application at @mountPoint@ (defaults to /<body>/ when @Nothing@)
-startApp :: Eq model => App effect model action -> JSM ()
+startApp :: Eq model => App effect model action a -> JSM ()
 startApp app@App {..} = withJS $
   initialize app $ \snk -> do
     vtree <- runView DontPrerender (view model) snk logLevel events

--- a/src/Miso/Effect.hs
+++ b/src/Miso/Effect.hs
@@ -63,21 +63,21 @@ mapSub :: (a -> b) -> Sub a -> Sub b
 mapSub f sub = \g -> sub (g . f)
 -----------------------------------------------------------------------------
 -- | Smart constructor for an 'Effect' with no actions.
-noEff :: model -> Effect action model ()
+noEff :: model -> Effect model action ()
 noEff = put
 -----------------------------------------------------------------------------
 -- | Smart constructor for an 'Effect' with exactly one action.
 infixl 0 <#
-(<#) :: model -> JSM action -> Effect action model ()
+(<#) :: model -> JSM action -> Effect model action ()
 (<#) m action = put m >> tell [ \sink -> sink =<< action ]
 -----------------------------------------------------------------------------
 -- | `Effect` smart constructor, flipped
 infixr 0 #>
-(#>) :: JSM action -> model -> Effect action model ()
+(#>) :: JSM action -> model -> Effect model action ()
 (#>) = flip (<#)
 -----------------------------------------------------------------------------
 -- | Smart constructor for an 'Effect' with multiple actions.
-batchEff :: model -> [JSM action] -> Effect action model ()
+batchEff :: model -> [JSM action] -> Effect model action ()
 batchEff model actions = put model >> do
   forM_ actions $ \action ->
     tell [ \sink -> sink =<< action ]
@@ -90,7 +90,7 @@ batchEff model actions = put model >> do
 -- widget which has an associated callback. The callback can then call the sink
 -- to turn events into actions. To do this without accessing a sink requires
 -- going via a @'Sub'scription@ which introduces a leaky-abstraction.
-effectSub :: model -> Sub action -> Effect action model ()
+effectSub :: model -> Sub action -> Effect model action ()
 effectSub model sub = do
   put model
   tell [sub]
@@ -129,11 +129,11 @@ effectSub model sub = do
 --   , ...
 --   }
 -- @
-newtype Effect action model a = Effect (StateT model (Writer [Sub action]) a)
+newtype Effect model action a = Effect (StateT model (Writer [Sub action]) a)
   deriving (Functor, Applicative, Monad, MonadState model, MonadWriter [Sub action])
 -----------------------------------------------------------------------------
 -- | @MonadFail@ instance for @Effect@
-instance MonadFail (Effect action model) where
+instance MonadFail (Effect model action) where
   fail s = do
     io $ consoleError (ms s)
     Fail.fail s
@@ -141,7 +141,7 @@ instance MonadFail (Effect action model) where
 -- | Internal function used to unwrap an 'Effect'
 runEffect
     :: model
-    -> Effect action model a
+    -> Effect model action a
     -> (model, [Sub action])
 runEffect m (Effect action) = runWriter (execStateT action m)
 -----------------------------------------------------------------------------
@@ -149,7 +149,7 @@ runEffect m (Effect action) = runWriter (execStateT action m)
 --
 -- Note that multiple IO action can be scheduled using
 -- @Control.Monad.Writer.Class.tell@ from the @mtl@ library.
-scheduleIO :: JSM action -> Effect action model ()
+scheduleIO :: JSM action -> Effect model action ()
 scheduleIO action = scheduleSub (\sink -> action >>= sink)
 -----------------------------------------------------------------------------
 -- | Like 'scheduleIO' but doesn't cause an action to be dispatched to
@@ -157,13 +157,13 @@ scheduleIO action = scheduleSub (\sink -> action >>= sink)
 --
 -- This is handy for scheduling IO computations where you don't care
 -- about their results or when they complete.
-scheduleIO_ :: JSM () -> Effect action model ()
+scheduleIO_ :: JSM () -> Effect model action ()
 scheduleIO_ action = scheduleSub (\_ -> action)
 -----------------------------------------------------------------------------
 -- | Like 'scheduleIO_ but generalized to any instance of 'Foldable'
 --
 -- This is handy for scheduling IO computations that return a `Maybe` value
-scheduleIOFor_ :: Foldable f => JSM (f action) -> Effect action model ()
+scheduleIOFor_ :: Foldable f => JSM (f action) -> Effect model action ()
 scheduleIOFor_ action = scheduleSub $ \sink -> action >>= flip for_ sink
 -----------------------------------------------------------------------------
 -- | Like 'scheduleIO' but schedules a subscription which is an IO
@@ -175,7 +175,7 @@ scheduleIOFor_ action = scheduleSub $ \sink -> action >>= flip for_ sink
 -- can then call the sink to turn events into actions. To do this
 -- without accessing a sink requires going via a @'Sub'scription@
 -- which introduces a leaky-abstraction.
-scheduleSub :: Sub action -> Effect action model ()
+scheduleSub :: Sub action -> Effect model action ()
 scheduleSub sub = Effect $ lift $ tell [ sub ]
 ----------------------------------------------------------------------------- 
 -- | A synonym for @tell@, specialized to @Effect@
@@ -187,7 +187,7 @@ scheduleSub sub = Effect $ lift $ tell [ sub ]
 -- @since 1.9.0.0
 --
 -- Used to issue new @action@
-issue :: action -> Effect action model ()
+issue :: action -> Effect model action ()
 issue action = tell [ \sink -> sink action ]
 -----------------------------------------------------------------------------
 -- | A shorter synonym for @scheduleIO_@
@@ -200,6 +200,6 @@ issue action = tell [ \sink -> sink action ]
 --
 -- This is handy for scheduling IO computations where you don't care
 -- about their results or when they complete.
-io :: JSM () -> Effect action model ()
+io :: JSM () -> Effect model action ()
 io = scheduleIO_
 -----------------------------------------------------------------------------

--- a/src/Miso/Effect.hs
+++ b/src/Miso/Effect.hs
@@ -180,7 +180,7 @@ scheduleSub sub = Effect $ lift $ tell [ sub ]
 ----------------------------------------------------------------------------- 
 -- | A synonym for @tell@, specialized to @Effect@
 --
--- > update :: Action -> Effect Action Model ()
+-- > update :: Action -> Effect Model Action ()
 -- > update = \case
 -- >   Click -> issue HelloWorld
 --
@@ -192,7 +192,7 @@ issue action = tell [ \sink -> sink action ]
 -----------------------------------------------------------------------------
 -- | A shorter synonym for @scheduleIO_@
 --
--- > update :: Action -> Effect Action Model ()
+-- > update :: Action -> Effect Model Action ()
 -- > update = \case
 -- >   HelloWorld -> io (consoleLog "Hello World")
 --

--- a/src/Miso/Internal.hs
+++ b/src/Miso/Internal.hs
@@ -143,7 +143,7 @@ sample (Component _ name _) = do
 -- This function is used to send messages to @Component@s on other parts of the application
 notify
   :: Component effect model action a
-  -> a
+  -> action
   -> JSM ()
 notify (Component _ name _) action = io
   where

--- a/src/Miso/Internal.hs
+++ b/src/Miso/Internal.hs
@@ -59,7 +59,7 @@ import           Miso.Effect (Sink, Effect, runEffect)
 -- | Helper function to abstract out initialization of @App@ between top-level API functions.
 initialize
   :: Eq model
-  => App effect model action
+  => App effect model action a
   -> (Sink action -> JSM (MisoString, JSVal, IORef VTree))
   -- ^ Callback function is used to perform the creation of VTree
   -> JSM (IORef VTree)
@@ -131,7 +131,7 @@ componentMap = unsafePerformIO (newIORef mempty)
 -- to be accessed. Then we throw a @NotMountedException@, in the case the
 -- @Component@ being accessed is not available.
 sample
-  :: Component effect model app
+  :: Component effect model action a
   -> JSM model
 sample (Component _ name _) = do
   componentStateMap <- liftIO (readIORef componentMap)
@@ -142,7 +142,7 @@ sample (Component _ name _) = do
 -- | Like @mail@ but lifted to work with the @Transition@ interface.
 -- This function is used to send messages to @Component@s on other parts of the application
 notify
-  :: Component effect m a
+  :: Component effect model action a
   -> a
   -> JSM ()
 notify (Component _ name _) action = io
@@ -154,8 +154,8 @@ notify (Component _ name _) action = io
 -----------------------------------------------------------------------------
 -- | Helper for processing effects in the event loop.
 foldEffects
-  :: (effect action model () -> Effect action model ())
-  -> (action -> effect action model ())
+  :: (effect model action a -> Effect model action a)
+  -> (action -> effect model action a)
   -> Sink action
   -> [action]
   -> model
@@ -179,7 +179,10 @@ foldEffects f update snk (e:es) o =
 -- It is recommended to use the @mail@ or @notify@ functions by default
 -- when message passing with @App@ and @Component@
 --
-sink :: MisoString -> App effect action model -> Sink action
+sink
+  :: MisoString
+  -> App effect model action a
+  -> Sink action
 sink name _ = \a ->
   M.lookup name <$> liftIO (readIORef componentMap) >>= \case
     Just ComponentState {..} -> componentSink a
@@ -192,8 +195,8 @@ sink name _ = \a ->
 -- >   m <# mail calendarComponent (NewCalendarEntry entry)
 --
 mail
-  :: Component effect m a
-  -> a
+  :: Component effect model action a
+  -> action
   -> JSM ()
 mail (Component _ name _) action = do
   dispatch <- liftIO (readIORef componentMap)
@@ -206,7 +209,7 @@ mail (Component _ name _) action = do
 drawComponent
   :: Prerender
   -> MisoString
-  -> App effect model action
+  -> App effect model action a
   -> Sink action
   -> JSM (MisoString, JSVal, IORef VTree)
 drawComponent prerender name App {..} snk = do
@@ -219,7 +222,7 @@ drawComponent prerender name App {..} snk = do
 -- | Helper function for cleanly destroying a @Component@
 unmount
   :: Function
-  -> App effect model action
+  -> App effect model action a
   -> ComponentState model action
   -> JSM ()
 unmount mountCallback App{..} ComponentState {..} = do

--- a/src/Miso/Render.hs
+++ b/src/Miso/Render.hs
@@ -47,7 +47,7 @@ class ToHtml a where
   toHtml :: a -> L.ByteString
 ----------------------------------------------------------------------------
 -- | Render a @Component@ to a @L.ByteString@
-instance ToHtml (Component effect model action) where
+instance ToHtml (Component effect model action a) where
   toHtml = renderComponent
 ----------------------------------------------------------------------------
 -- | Render a @View@ to a @L.ByteString@
@@ -65,7 +65,7 @@ instance ToHtml a => MimeRender HTML a where
 renderView :: View a -> L.ByteString
 renderView = toLazyByteString . renderBuilder
 ----------------------------------------------------------------------------
-renderComponent :: Component effect model action -> L.ByteString
+renderComponent :: Component effect model action a -> L.ByteString
 renderComponent (Component _ _ App {..}) = renderView (view model)
 ----------------------------------------------------------------------------
 intercalate :: Builder -> [Builder] -> Builder

--- a/src/Miso/Types.hs
+++ b/src/Miso/Types.hs
@@ -149,8 +149,8 @@ component = Component Nothing
 embed
   :: Eq model
   => Component effect model action a
-  -> [Attribute action]
-  -> View action
+  -> [Attribute b]
+  -> View b
 embed comp attrs = Embed attrs (SomeComponent comp)
 -----------------------------------------------------------------------------
 -- | Used in the @view@ function to @embed@ @Component@s in @App@, with @Key@
@@ -158,8 +158,8 @@ embedKeyed
   :: Eq model
   => Component effect model action a
   -> Key
-  -> [Attribute action]
-  -> View action
+  -> [Attribute b]
+  -> View b
 embedKeyed comp key attrs
   = Embed attrs
   $ SomeComponent comp { componentKey = Just key }

--- a/src/Miso/Types.hs
+++ b/src/Miso/Types.hs
@@ -54,10 +54,10 @@ import           Miso.Event.Types
 import           Miso.String (MisoString, toMisoString)
 -----------------------------------------------------------------------------
 -- | Application entry point
-data App effect model action = App
+data App effect model action a = App
   { model :: model
   -- ^ initial model
-  , update :: action -> effect action model ()
+  , update :: action -> effect model action a
   -- ^ Function to update model, optionally providing effects.
   --   See the @Transition@ monad for succinctly expressing model transitions.
   , view :: model -> View action
@@ -74,7 +74,7 @@ data App effect model action = App
   -- If 'Nothing' is provided, the entire document body is used as a mount point.
   , logLevel :: LogLevel
   -- ^ Debugging for prerendering and event delegation
-  , translate :: effect action model () -> Effect action model ()
+  , translate :: effect model action a -> Effect model action a
   -- ^ natural transformation to allow others to use their own
   -- custom Monad stack.
   }
@@ -86,9 +86,9 @@ getMountPoint = fromMaybe "body"
 -- | Smart constructor for @App@ with sane defaults.
 defaultApp
   :: model
-  -> (action -> Effect action model ())
+  -> (action -> Effect model action a)
   -> (model -> View action)
-  -> App Effect model action
+  -> App Effect model action a
 defaultApp m u v = App
   { model = m
   , update = u
@@ -126,33 +126,43 @@ data View action
 -----------------------------------------------------------------------------
 -- | Existential wrapper used to allow the nesting of @Component@ in @App@
 data SomeComponent
-   = forall effect model action . Eq model
-  => SomeComponent (Component effect model action)
+   = forall effect model action a . Eq model
+  => SomeComponent (Component effect model action a)
 -----------------------------------------------------------------------------
 -- | Used with @component@ to parameterize @App@ by @name@
-data Component effect model action
+data Component effect model action a
   = Component
   { componentKey :: Maybe Key
   , componentName :: MisoString
-  , componentApp :: App effect model action
+  , componentApp :: App effect model action a
   }
 -----------------------------------------------------------------------------
 -- | Smart constructor for parameterizing @App@ by @name@
 -- Needed when calling @embed@ and @embedWith@
 component
-  :: forall effect model action
-   . MisoString  
-  -> App effect model action
-  -> Component effect model action
+  :: MisoString  
+  -> App effect model action a
+  -> Component effect model action a
 component = Component Nothing
 -----------------------------------------------------------------------------
 -- | Used in the @view@ function to @embed@ @Component@s in @App@
-embed :: Eq model => Component effect model a -> [Attribute action] -> View action
+embed
+  :: Eq model
+  => Component effect model action a
+  -> [Attribute action]
+  -> View action
 embed comp attrs = Embed attrs (SomeComponent comp)
 -----------------------------------------------------------------------------
 -- | Used in the @view@ function to @embed@ @Component@s in @App@, with @Key@
-embedKeyed :: Eq model => Component effect model a -> Key -> [Attribute action] -> View action
-embedKeyed comp key attrs = Embed attrs $ SomeComponent comp { componentKey = Just key }
+embedKeyed
+  :: Eq model
+  => Component effect model action a
+  -> Key
+  -> [Attribute action]
+  -> View action
+embedKeyed comp key attrs
+  = Embed attrs
+  $ SomeComponent comp { componentKey = Just key }
 -----------------------------------------------------------------------------
 -- | For constructing type-safe links
 instance HasLink (View a) where
@@ -168,12 +178,12 @@ instance ToView (View action) where
   type ToViewAction (View action) = action
   toView = id
 -----------------------------------------------------------------------------
-instance ToView (Component effect model action) where
-  type ToViewAction (Component effect model action) = action
+instance ToView (Component effect model action a) where
+  type ToViewAction (Component effect model action a) = action
   toView (Component _ _ app) = toView app
 -----------------------------------------------------------------------------
-instance ToView (App effect model action) where
-  type ToViewAction (App effect model action) = action
+instance ToView (App effect model action a) where
+  type ToViewAction (App effect model action a) = action
   toView App {..} = toView (view model)
 -----------------------------------------------------------------------------
 -- | Namespace of DOM elements.


### PR DESCRIPTION
- `Effect` is now `effect model action a`
- `App`, `update` and `Effect` reflect identical param order
- Drop `()` in `App` (make `a`)
- Update examples & third-party examples to reflect
- Correct type variable naming where applicable