### PR TITLE
Update PointerEvent to use Double

### DIFF
--- a/examples/svg/Main.hs
+++ b/examples/svg/Main.hs
@@ -33,14 +33,14 @@ emptyModel = Model (0, 0)
 updateModel :: Action -> Effect Model Action ()
 updateModel (HandlePointer pointer) = modify update
   where
-    update m = m { mouseCoords = coords pointer }
+    update m = m { mouseCoords = client pointer }
 
 data Action
   = HandlePointer PointerEvent
 
 newtype Model
   = Model
-  { mouseCoords :: (Int, Int)
+  { mouseCoords :: (Double, Double)
   } deriving (Show, Eq)
 
 viewModel :: Model -> View Action

--- a/nix/haskell/packages/source.nix
+++ b/nix/haskell/packages/source.nix
@@ -51,8 +51,8 @@ in
   the2048 = fetchFromGitHub {
     owner = "dmjio";
     repo = "hs2048";
-    rev = "8a6c951e75bea7502287b809e66bfe8f1db77a7c";
-    sha256 = "sha256-O3AqxsyrwvUMb7Nnz3KDUgRYJtgJouunnONqR3SIgNQ=";
+    rev = "400ed27";
+    sha256 = "sha256-M1PpZvzDGz8okaHP3Chg9wY5t/LxaxV5CgtOv4q/lj4=";
   };
   snake = fetchFromGitHub {
     owner = "dmjio";

--- a/src/Miso/Event/Decoder.hs
+++ b/src/Miso/Event/Decoder.hs
@@ -120,7 +120,7 @@ pointerDecoder = Decoder {..}
         <$> o .: "pointerType"
         <*> o .: "pointerId"
         <*> o .: "isPrimary"
-        <*> pair o "x" "y"
+        <*> pair o "clientX" "clientY"
         <*> pair o "screenX" "screenY"
         <*> pair o "pageX" "pageY"
         <*> pair o "tiltX" "tiltY"

--- a/src/Miso/Event/Types.hs
+++ b/src/Miso/Event/Types.hs
@@ -36,12 +36,11 @@ module Miso.Event.Types
   , pointerEvents
   ) where
 -----------------------------------------------------------------------------
-import           Data.Aeson (FromJSON(..), withText, Value(String))
-import           Data.Aeson.Types (typeMismatch)
+import           Data.Aeson (FromJSON(..), withText)
 import qualified Data.Map.Strict as M
 import           GHC.Generics (Generic)
 import           GHCJS.Marshal (ToJSVal)
-import           Miso.String (MisoString)
+import           Miso.String (MisoString, ms)
 -----------------------------------------------------------------------------
 -- | Type useful for both KeyCode and additional key press information.
 data KeyInfo
@@ -67,13 +66,13 @@ data PointerEvent
   { pointerType :: PointerType
   , pointerId :: Int
   , isPrimary :: Bool
-  , coords :: (Int, Int)
-  -- ^ clientX (or x), clientY (or y)
-  , screen :: (Int,Int)
+  , client :: (Double, Double)
+  -- ^ clientX, clientY
+  , screen :: (Double, Double)
   -- ^ screenX, screenY
-  , page :: (Int,Int)
+  , page :: (Double,Double)
   -- ^ pageX, pageY
-  , tilt :: (Int,Int)
+  , tilt :: (Double,Double)
   -- ^ tiltX, tiltY
   , pressure :: Double
   } deriving (Show, Eq)
@@ -84,6 +83,7 @@ data PointerType
   = MousePointerType
   | PenPointerType
   | TouchPointerType
+  | UnknownPointerType MisoString
   deriving (Show, Eq)
 -----------------------------------------------------------------------------
 instance FromJSON PointerType where
@@ -91,7 +91,7 @@ instance FromJSON PointerType where
     "mouse" -> pure MousePointerType
     "touch" -> pure TouchPointerType
     "pen"   -> pure PenPointerType
-    p -> typeMismatch "PointerEvent" (String p)
+    x       -> pure (UnknownPointerType (ms x))
 -----------------------------------------------------------------------------
 -- | Options for handling event propagation.
 data Options


### PR DESCRIPTION
- `"x"` -> `"clientX"`
- `"y"` -> `"clientY"`
- Add `UnknownPointerType` (Spec says it can be unknown / empty string as well.)
- `coords` -> `client`, be spec. preserving