### PR TITLE
Try to pin our nixops.

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -60,7 +60,7 @@ in with pkgs.haskell.lib;
 
   #ci
   deploy = pkgs.deploy rev;
-  inherit (pkgs) haskell-miso-org-test;
+  inherit (pkgs) haskell-miso-org-test nixops;
 
   # ghciwatch
   inherit (pkgs) ghciwatch;

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -65,6 +65,14 @@ options: self: super: {
       };
     };
   };
+
+  nixops = super.nixops.overrideAttrs (drv: {
+    src = builtins.fetchTarball {
+      url = "https://nixos.org/releases/nixops/nixops-1.7/nixops-1.7.tar.bz2";
+      sha256 = "sha256:1iax9hz16ry1pm9yw2wab0np7140d7pv4rnk1bw63kq4gnxnr93c";
+    };
+  });
+
   deploy = rev: super.writeScript "deploy" ''
     export PATH=$PATH:${self.nixops}/bin
     export PATH=$PATH:${self.jq}/bin


### PR DESCRIPTION
- For use with nixpkgs upgrading.
- When we move to ghc9122, we'll need to keep around our old ops tools.