### PR TITLE
Drop document window param

### DIFF
--- a/js/miso.js
+++ b/js/miso.js
@@ -701,7 +701,9 @@ module["exports"] = (function () {
         .split("(")[1]
         .split(")")[0]
         .split(",")
-        .map((x) => {return +x});
+        .map((x) => {
+          return +x;
+        });
   };
 
   // dmj: Does deep equivalence check, spine and leaves of virtual DOM to DOM.

--- a/js/miso.js
+++ b/js/miso.js
@@ -4,31 +4,31 @@ module = typeof module === "undefined" ? {} : module;
 /* module export pattern */
 module["exports"] = (function () {
   /* virtual-dom diffing algorithm, applies patches as detected */
-  var diff = function (currentObj, newObj, parent, doc) {
+  var diff = function (currentObj, newObj, parent) {
     if (!currentObj && !newObj) return;
-    else if (!currentObj && newObj) create(newObj, parent, doc);
+    else if (!currentObj && newObj) create(newObj, parent);
     else if (!newObj) destroy(currentObj, parent);
     else {
       if (currentObj["type"] === newObj["type"]) {
-        diffNodes(currentObj, newObj, parent, doc);
+        diffNodes(currentObj, newObj, parent);
       } else {
-        replace(currentObj, newObj, parent, doc);
+        replace(currentObj, newObj, parent);
       }
     }
   };
 
   // replace everything function
-  var replace = function (c, n, parent, doc) {
+  var replace = function (c, n, parent) {
     // step1 : prepare to delete, unmount things
     callBeforeDestroyedRecursive(c);
     // ^ this will unmount sub components before we replace the child
     // and will recursively call hooks on nodes
     // step2 : create new things, replace old things with new things
     if (n["type"] === "vtext") {
-      n["domRef"] = doc.createTextNode(n["text"]);
+      n["domRef"] = document.createTextNode(n["text"]);
       parent.replaceChild(n["domRef"], c["domRef"]);
     } else {
-      createElement(n, doc, function (ref) {
+      createElement(n, function (ref) {
         parent.replaceChild(ref, c["domRef"]);
       });
     }
@@ -48,7 +48,7 @@ module["exports"] = (function () {
     callDestroyedRecursive(obj);
   };
 
-  var diffNodes = function (c, n, parent, doc) {
+  var diffNodes = function (c, n, parent) {
     // bail out on easy vtext case
     if (c["type"] === "vtext") {
       if (c["text"] !== n["text"]) c["domRef"].textContent = n["text"];
@@ -63,10 +63,10 @@ module["exports"] = (function () {
     ) {
       n["domRef"] = c["domRef"];
       // dmj: we will diff properties on 'vcomp' as well
-      populate(c, n, doc);
+      populate(c, n);
     } else {
       // dmj: we replace when things just don't line up during the diff
-      replace(c, n, parent, doc);
+      replace(c, n, parent);
     }
   };
 
@@ -94,12 +94,12 @@ module["exports"] = (function () {
     }
   };
   // ** </> recursive calls to hooks
-  var callCreated = function (obj, doc) {
+  var callCreated = function (obj) {
     if (obj["onCreated"]) obj["onCreated"]();
-    if (obj["type"] === "vcomp") mountComponent(obj, doc);
+    if (obj["type"] === "vcomp") mountComponent(obj);
   };
 
-  var populate = function (c, n, doc) {
+  var populate = function (c, n) {
     if (!c) {
       c = {
         props: null,
@@ -110,7 +110,7 @@ module["exports"] = (function () {
     diffProps(c["props"], n["props"], n["domRef"], n["ns"] === "svg");
     diffCss(c["css"], n["css"], n["domRef"]);
     if (n["type"] === "vcomp") return; // dmj: don't diff vcomp children
-    diffChildren(c["children"], n["children"], n["domRef"], doc);
+    diffChildren(c["children"], n["children"], n["domRef"]);
   };
 
   var diffProps = function (cProps, nProps, node, isSvg) {
@@ -193,46 +193,46 @@ module["exports"] = (function () {
     );
   };
 
-  var diffChildren = function (cs, ns, parent, doc) {
+  var diffChildren = function (cs, ns, parent) {
     var longest = ns.length > cs.length ? ns.length : cs.length;
     if (hasKeys(ns, cs)) {
-      syncChildren(cs, ns, parent, doc);
+      syncChildren(cs, ns, parent);
     } else {
       for (var i = 0; i < longest; i++) {
-        diff(cs[i], ns[i], parent, doc);
+        diff(cs[i], ns[i], parent);
       }
     }
   };
 
-  var populateDomRef = function (obj, doc) {
+  var populateDomRef = function (obj) {
     if (obj["ns"] === "svg") {
-      obj["domRef"] = doc.createElementNS(
+      obj["domRef"] = document.createElementNS(
         "http://www.w3.org/2000/svg",
         obj["tag"],
       );
     } else if (obj["ns"] === "mathml") {
-      obj["domRef"] = doc.createElementNS(
+      obj["domRef"] = document.createElementNS(
         "http://www.w3.org/1998/Math/MathML",
         obj["tag"],
       );
     } else {
-      obj["domRef"] = doc.createElement(obj["tag"]);
+      obj["domRef"] = document.createElement(obj["tag"]);
     }
   };
 
   // dmj: refactor this, the callback function feels meh
-  var createElement = function (obj, doc, cb) {
-    populateDomRef(obj, doc);
+  var createElement = function (obj, cb) {
+    populateDomRef(obj);
     cb(obj["domRef"]);
-    populate(null, obj, doc);
-    callCreated(obj, doc);
+    populate(null, obj);
+    callCreated(obj);
   };
 
   // mounts vcomp by calling into Haskell side.
   // unmount is handled with pre-destroy recursive hooks
-  var mountComponent = function (obj, doc) {
+  var mountComponent = function (obj) {
     var componentId = obj["data-component-id"],
-      nodeList = doc.querySelectorAll(
+      nodeList = document.querySelectorAll(
         "[data-component-id='" + componentId + "']",
       );
 
@@ -258,19 +258,19 @@ module["exports"] = (function () {
   };
 
   // creates nodes on virtual and dom (vtext, vcomp, vnode)
-  var create = function (obj, parent, doc) {
+  var create = function (obj, parent) {
     if (obj.type === "vtext") {
-      obj["domRef"] = doc.createTextNode(obj["text"]);
+      obj["domRef"] = document.createTextNode(obj["text"]);
       parent.appendChild(obj["domRef"]);
     } else {
-      createElement(obj, doc, function (ref) {
+      createElement(obj, function (ref) {
         parent.appendChild(ref);
       });
     }
   };
 
   /* Child reconciliation algorithm, inspired by kivi and Bobril */
-  var syncChildren = function (os, ns, parent, doc) {
+  var syncChildren = function (os, ns, parent) {
     var oldFirstIndex = 0,
       newFirstIndex = 0,
       oldLastIndex = os.length - 1,
@@ -301,7 +301,7 @@ module["exports"] = (function () {
          -> [ a b c ] <- new children
          */
       if (oldFirstIndex > oldLastIndex) {
-        diff(null, nFirst, parent, doc);
+        diff(null, nFirst, parent);
         /* insertBefore's semantics will append a node if the second argument provided is `null` or `undefined`.
            Otherwise, it will insert node['domRef'] before oLast['domRef']. */
         parent.insertBefore(nFirst["domRef"], oFirst ? oFirst["domRef"] : null);
@@ -322,9 +322,9 @@ module["exports"] = (function () {
          -> newFirstIndex -> [ a b c ] <- newLastIndex
          check if nFirst and oFirst align, if so, check nLast and oLast
          */ else if (oFirst["key"] === nFirst["key"]) {
-        diff(os[oldFirstIndex++], ns[newFirstIndex++], parent, doc);
+        diff(os[oldFirstIndex++], ns[newFirstIndex++], parent);
       } else if (oLast["key"] === nLast["key"]) {
-        diff(os[oldLastIndex--], ns[newLastIndex--], parent, doc);
+        diff(os[oldLastIndex--], ns[newLastIndex--], parent);
       } /* flip-flop case, nodes have been swapped, in some way or another
          both could have been swapped.
          -> [ a b c ] <- old children
@@ -335,8 +335,8 @@ module["exports"] = (function () {
       ) {
         swapDomRefs(node, oLast["domRef"], oFirst["domRef"], parent);
         swap(os, oldFirstIndex, oldLastIndex);
-        diff(os[oldFirstIndex++], ns[newFirstIndex++], parent, doc);
-        diff(os[oldLastIndex--], ns[newLastIndex--], parent, doc);
+        diff(os[oldFirstIndex++], ns[newFirstIndex++], parent);
+        diff(os[oldLastIndex--], ns[newLastIndex--], parent);
       } /* Or just one could be swapped (d's align here)
              This is top left and bottom right match case.
              We move d to end of list, mutate old vdom to reflect the change
@@ -352,7 +352,7 @@ module["exports"] = (function () {
         parent.insertBefore(oFirst["domRef"], oLast["domRef"].nextSibling);
         /* swap positions in old vdom */
         os.splice(oldLastIndex, 0, os.splice(oldFirstIndex, 1)[0]);
-        diff(os[oldLastIndex--], ns[newLastIndex--], parent, doc);
+        diff(os[oldLastIndex--], ns[newLastIndex--], parent);
       } /* This is top right and bottom lefts match case.
          We move d to end of list, mutate old vdom to reflect the change
          -> [ b a d ] <- old children
@@ -366,7 +366,7 @@ module["exports"] = (function () {
         parent.insertBefore(oLast["domRef"], oFirst["domRef"]);
         /* swap positions in old vdom */
         os.splice(oldFirstIndex, 0, os.splice(oldLastIndex, 1)[0]);
-        diff(os[oldFirstIndex++], nFirst, parent, doc);
+        diff(os[oldFirstIndex++], nFirst, parent);
         newFirstIndex++;
       } /* The 'you're screwed' case, nothing aligns, pull the ripcord, do something more fancy
          This can happen when the list is sorted, for example.
@@ -400,7 +400,7 @@ module["exports"] = (function () {
           /* Move item to correct position */
           os.splice(oldFirstIndex, 0, os.splice(tmp, 1)[0]);
           /* optionally perform `diff` here */
-          diff(os[oldFirstIndex++], nFirst, parent, doc);
+          diff(os[oldFirstIndex++], nFirst, parent);
           /* Swap DOM references */
           parent.insertBefore(node["domRef"], os[oldFirstIndex]["domRef"]);
           /* increment counters */
@@ -417,7 +417,7 @@ module["exports"] = (function () {
              -> [ b e a j   ] <- new children
                 ^
                 */ else {
-          createElement(nFirst, doc, function (ref) {
+          createElement(nFirst, function (ref) {
             parent.insertBefore(ref, oFirst["domRef"]);
           });
           os.splice(oldFirstIndex++, 0, nFirst);
@@ -631,18 +631,18 @@ module["exports"] = (function () {
     return adjusted;
   };
 
-  var copyDOMIntoVTree = function (logLevel, mountPoint, vtree, doc, window) {
+  var copyDOMIntoVTree = function (logLevel, mountPoint, vtree) {
     var mountChildIdx = 0,
       node;
     // If script tags are rendered first in body, skip them.
     if (!mountPoint) {
-      if (doc.body.childNodes.length > 0) {
-        node = doc.body.firstChild;
+      if (document.body.childNodes.length > 0) {
+        node = document.body.firstChild;
       } else {
-        node = doc.body.appendChild(doc.createElement("div"));
+        node = document.body.appendChild(document.createElement("div"));
       }
     } else if (mountPoint.childNodes.length === 0) {
-      node = mountPoint.appendChild(doc.createElement("div"));
+      node = mountPoint.appendChild(document.createElement("div"));
     } else {
       while (
         mountPoint.childNodes[mountChildIdx] &&
@@ -652,13 +652,13 @@ module["exports"] = (function () {
         mountChildIdx++;
       }
       if (!mountPoint.childNodes[mountChildIdx]) {
-        node = doc.body.appendChild(doc.createElement("div"));
+        node = document.body.appendChild(document.createElement("div"));
       } else {
         node = mountPoint.childNodes[mountChildIdx];
       }
     }
 
-    if (!walk(logLevel, vtree, node, doc)) {
+    if (!walk(logLevel, vtree, node)) {
       if (logLevel) {
         console.warn(
           "Could not copy DOM into virtual DOM, falling back to diff",
@@ -667,11 +667,11 @@ module["exports"] = (function () {
       // Remove all children before rebuilding DOM
       while (node.firstChild) node.removeChild(node.lastChild);
       vtree["domRef"] = node;
-      populate(null, vtree, doc);
+      populate(null, vtree);
       return false;
     } else {
       if (logLevel) {
-        var result = integrityCheck(true, vtree, window);
+        var result = integrityCheck(true, vtree);
         if (!result) {
           console.warn("Integrity check completed with errors");
         } else {
@@ -705,7 +705,7 @@ module["exports"] = (function () {
   };
 
   // dmj: Does deep equivalence check, spine and leaves of virtual DOM to DOM.
-  var integrityCheck = function (result, vtree, window) {
+  var integrityCheck = function (result, vtree) {
     // text nodes must be the same
     if (vtree["type"] == "vtext") {
       if (vtree["domRef"].nodeType !== 3) {
@@ -829,13 +829,13 @@ module["exports"] = (function () {
 
       // recursive call for `vnode` / `vcomp`
       for (i = 0; i < vtree.children.length; i++) {
-        result &= integrityCheck(result, vtree.children[i], window);
+        result &= integrityCheck(result, vtree.children[i]);
       }
     }
     return result;
   };
 
-  var walk = function (logLevel, vtree, node, doc) {
+  var walk = function (logLevel, vtree, node) {
     // This is slightly more complicated than one might expect since
     // browsers will collapse consecutive text nodes into a single text node.
     // There can thus be fewer DOM nodes than VDOM nodes.
@@ -844,7 +844,7 @@ module["exports"] = (function () {
     vtree["domRef"] = node;
 
     // Fire onCreated events as though the elements had just been created.
-    callCreated(vtree, doc);
+    callCreated(vtree);
 
     vtree.children = collapseSiblingTextNodes(vtree.children);
 
@@ -870,36 +870,36 @@ module["exports"] = (function () {
       } else if (vdomChild["type"] === "vcomp") {
         vdomChild["mount"](function (component) {
           vdomChild.children.push(component);
-          walk(logLevel, vdomChild, domChild, doc);
+          walk(logLevel, vdomChild, domChild);
         });
       } else {
         if (domChild.nodeType !== 1) return false;
         vdomChild["domRef"] = domChild;
-        walk(logLevel, vdomChild, domChild, doc);
+        walk(logLevel, vdomChild, domChild);
       }
     }
     return true;
   };
 
   /* various utilities */
-  var callFocus = function (id, doc, delay) {
+  var callFocus = function (id, delay) {
     var setFocus = function () {
-      var e = doc.getElementById(id);
+      var e = document.getElementById(id);
       if (e && e.focus) e.focus();
     };
     delay > 0 ? setTimeout(setFocus, delay) : setFocus();
   };
 
-  var callBlur = function (id, doc, delay) {
+  var callBlur = function (id, delay) {
     var setBlur = function () {
-      var e = doc.getElementById(id);
+      var e = document.getElementById(id);
       if (e && e.blur) e.blur();
     };
     delay > 0 ? setTimeout(setBlur, delay) : setBlur();
   };
 
-  var setBodyComponent = function (componentId, doc) {
-    doc.body.setAttribute("data-component-id", componentId);
+  var setBodyComponent = function (componentId) {
+    document.body.setAttribute("data-component-id", componentId);
   };
 
   /* dmj, keep quoted field names so closure-compiler doesn't rename */

--- a/js/miso.spec.js
+++ b/js/miso.spec.js
@@ -98,7 +98,7 @@ describe("miso.js tests", () => {
     const body = document.body;
     var c = null;
     var n = null;
-    miso.diff(c, n, body, document);
+    miso.diff(c, n, body);
     expect(body.childNodes.length).toBe(0);
   });
 
@@ -108,7 +108,7 @@ describe("miso.js tests", () => {
       type: "vtext",
       text: "foo",
     };
-    miso.diff(null, newNode, body, document);
+    miso.diff(null, newNode, body);
     expect(newNode.domRef.wholeText).toBe("foo");
   });
 
@@ -118,13 +118,13 @@ describe("miso.js tests", () => {
       type: "vtext",
       text: "foo",
     };
-    miso.diff(null, currentNode, body, document);
+    miso.diff(null, currentNode, body);
     expect(currentNode.domRef.wholeText).toBe("foo");
     var newNode = {
       type: "vtext",
       text: "foo",
     };
-    miso.diff(currentNode, newNode, body, document);
+    miso.diff(currentNode, newNode, body);
     expect("foo").toBe(newNode.domRef.wholeText);
   });
 
@@ -134,13 +134,13 @@ describe("miso.js tests", () => {
       type: "vtext",
       text: "foo",
     };
-    miso.diff(null, currentNode, body, document);
+    miso.diff(null, currentNode, body);
     expect(currentNode.domRef.wholeText).toBe("foo");
     var newNode = {
       type: "vtext",
       text: "bar",
     };
-    miso.diff(currentNode, newNode, body, document);
+    miso.diff(currentNode, newNode, body);
     expect(newNode.domRef.wholeText).toBe("bar");
   });
 
@@ -148,7 +148,7 @@ describe("miso.js tests", () => {
     var body = document.body;
     var currentNode = null;
     var newNode = vnode("div", []);
-    miso.diff(currentNode, newNode, body, document);
+    miso.diff(currentNode, newNode, body);
     expect(body.children[0]).toBe(newNode.domRef);
   });
 
@@ -162,7 +162,7 @@ describe("miso.js tests", () => {
       { "background-color": "red" },
       [],
     );
-    miso.diff(null, newComp1, body, document);
+    miso.diff(null, newComp1, body);
     var newComp2 = vcomp(
       () => {return mountCount++},
       null,
@@ -171,7 +171,7 @@ describe("miso.js tests", () => {
       [],
     );
     var newNode = vnode("div", [newComp2], {}, {}, "svg");
-    miso.diff(null, newNode, body, document);
+    miso.diff(null, newNode, body);
     expect(mountCount).toBe(1);
   });
 
@@ -182,7 +182,7 @@ describe("miso.js tests", () => {
     var mountFunc = function (cb) {
       mountCount++;
       var node = vnode("div", []);
-      miso.diff(null, node, body, document);
+      miso.diff(null, node, body);
       cb(node);
     };
     var newNode = vcomp(
@@ -194,13 +194,13 @@ describe("miso.js tests", () => {
       },
       [],
     );
-    miso.diff(null, newNode, body, document);
+    miso.diff(null, newNode, body);
     expect(mountCount).toBe(1);
     expect(newNode.children.length).toBe(1);
     expect(newNode.domRef.children.length).toBe(1);
     expect(newNode.domRef.id).toBe("vcomp-foo");
     expect(newNode.domRef.style["background-color"]).toBe("red");
-    miso.diff(newNode, null, body, document);
+    miso.diff(newNode, null, body);
     expect(unmountCount).toBe(1);
   });
 
@@ -208,7 +208,7 @@ describe("miso.js tests", () => {
     var body = document.body;
     var currentNode = null;
     var newNode = vnode("div", [], {}, {}, "svg");
-    miso.diff(currentNode, newNode, body, document);
+    miso.diff(currentNode, newNode, body);
     expect(body.children[0]).toBe(newNode.domRef);
   });
 
@@ -216,7 +216,7 @@ describe("miso.js tests", () => {
     var body = document.body;
     var currentNode = null;
     var newNode = vnode("math", [], {}, {}, "mathml");
-    miso.diff(currentNode, newNode, body, document);
+    miso.diff(currentNode, newNode, body);
     expect(body.children[0]).toBe(newNode.domRef);
   });
 
@@ -232,7 +232,7 @@ describe("miso.js tests", () => {
       {},
       "svg",
     );
-    miso.diff(currentNode, newNode, body, document);
+    miso.diff(currentNode, newNode, body);
     expect(
       body.children[0].getAttributeNS("http://www.w3.org/1999/xlink", "href"),
     ).toBe("https://google.com");
@@ -250,7 +250,7 @@ describe("miso.js tests", () => {
       {},
       "svg",
     );
-    miso.diff(currentNode, newNode, body, document);
+    miso.diff(currentNode, newNode, body);
     expect(
       body.children[0].getAttributeNS("http://www.w3.org/1999/xlink", "href"),
     ).toBe("https://google.com");
@@ -263,7 +263,7 @@ describe("miso.js tests", () => {
       {},
       "svg",
     );
-    miso.diff(newNode, newerNode, body, document);
+    miso.diff(newNode, newerNode, body);
     expect(
       body.children[0].getAttributeNS("http://www.w3.org/1999/xlink", "href"),
     ).toBe("https://yahoo.com");
@@ -281,7 +281,7 @@ describe("miso.js tests", () => {
       {},
       "svg",
     );
-    miso.diff(currentNode, newNode, body, document);
+    miso.diff(currentNode, newNode, body);
     expect(body.children[0].getAttribute("rx")).toBe("100");
   });
 
@@ -297,7 +297,7 @@ describe("miso.js tests", () => {
       {},
       "svg",
     );
-    miso.diff(currentNode, newNode, body, document);
+    miso.diff(currentNode, newNode, body);
     expect(body.children[0].getAttribute("rx")).toBe("100");
     var newerNode = vnode(
       "ellipse",
@@ -308,7 +308,7 @@ describe("miso.js tests", () => {
       {},
       "svg",
     );
-    miso.diff(newNode, newerNode, body, document);
+    miso.diff(newNode, newerNode, body);
     expect(body.children[0].getAttribute("rx")).toBe("200");
   });
 
@@ -317,14 +317,14 @@ describe("miso.js tests", () => {
 
     // populate DOM
     var node = vnode("div", []);
-    miso.diff(null, node, body, document);
+    miso.diff(null, node, body);
 
     // Test node was populated
     expect(body.children.length).toBe(1);
 
     // Replace node
     var newNode = vnode("a", []);
-    miso.diff(node, newNode, body, document);
+    miso.diff(node, newNode, body);
 
     // Test node is removed from DOM
     expect(body.children[0].tagName).toBe("A");
@@ -335,7 +335,7 @@ describe("miso.js tests", () => {
 
     // populate DOM
     var node = vnode("div", [vnode("div", [])]);
-    miso.diff(null, node, body, document);
+    miso.diff(null, node, body);
     expect(node.domRef.children.length).toBe(1);
   });
 
@@ -344,12 +344,12 @@ describe("miso.js tests", () => {
 
     // populate DOM
     var node = vnode("div", [vnode("div", [])]);
-    miso.diff(null, node, body, document);
+    miso.diff(null, node, body);
     expect(node.domRef.children.length).toBe(1);
 
     // populate DOM
     var newNode = vnode("div", []);
-    miso.diff(node, newNode, body, document);
+    miso.diff(node, newNode, body);
     expect(node.domRef.children.length).toBe(0);
   });
 
@@ -367,7 +367,7 @@ describe("miso.js tests", () => {
       { "background-color": "red" },
     );
 
-    miso.diff(null, compNode1, body, document);
+    miso.diff(null, compNode1, body);
     expect(mountCount).toBe(1);
 
     // Test node was populated
@@ -385,7 +385,7 @@ describe("miso.js tests", () => {
       { "background-color": "green" },
     );
 
-    miso.diff(compNode1, compNode2, body, document);
+    miso.diff(compNode1, compNode2, body);
     expect(body.childNodes[0].style["background-color"]).toBe("green");
   });
 
@@ -394,7 +394,7 @@ describe("miso.js tests", () => {
 
     // populate DOM
     var node = vnode("div", []);
-    miso.diff(null, node, body, document);
+    miso.diff(null, node, body);
 
     // Test node was populated
     expect(body.childNodes.length).toBe(1);
@@ -402,7 +402,7 @@ describe("miso.js tests", () => {
     // Replace node
     var mountCount = 0;
     var compNode = vcomp(() => {return mountCount++});
-    miso.diff(node, compNode, body, document);
+    miso.diff(node, compNode, body);
 
     // Node is removed from DOM, Component is on the DOM
     expect(body.childNodes[0].getAttribute("data-component-id")).toBe(
@@ -416,7 +416,7 @@ describe("miso.js tests", () => {
 
     // populate DOM
     var node = vtext("foo");
-    miso.diff(null, node, body, document);
+    miso.diff(null, node, body);
 
     // Test node was populated
     expect(node.domRef.wholeText).toBe("foo");
@@ -425,7 +425,7 @@ describe("miso.js tests", () => {
     // Replace node
     var mountCount = 0;
     var compNode = vcomp(() => {return mountCount++});
-    miso.diff(node, compNode, body, document);
+    miso.diff(node, compNode, body);
 
     // Node is removed from DOM, Component is on the DOM
     expect(body.childNodes[0].getAttribute("data-component-id")).toBe(
@@ -439,14 +439,14 @@ describe("miso.js tests", () => {
 
     // populate DOM
     var node = vnode("div", []);
-    miso.diff(null, node, body, document);
+    miso.diff(null, node, body);
 
     // Test node was populated
     expect(body.childNodes.length).toBe(1);
 
     // Replace node
     var textNode = vtext("fooo");
-    miso.diff(node, textNode, body, document);
+    miso.diff(node, textNode, body);
 
     // Test node is removed from DOM
     expect(body.childNodes[0].wholeText).toBe("fooo");
@@ -462,7 +462,7 @@ describe("miso.js tests", () => {
       () => {return mountCount++},
       () => {return unmountCount++},
     );
-    miso.diff(null, component, body, document);
+    miso.diff(null, component, body);
 
     // Test component was populated
     expect(body.childNodes.length).toBe(1);
@@ -471,7 +471,7 @@ describe("miso.js tests", () => {
 
     // Replace component
     var textNode = vtext("fooo");
-    miso.diff(component, textNode, body, document);
+    miso.diff(component, textNode, body);
 
     // Test node is removed from DOM
     expect(body.childNodes[0].wholeText).toBe("fooo");
@@ -488,7 +488,7 @@ describe("miso.js tests", () => {
       () => {return mountCount++},
       () => {return unmountCount++},
     );
-    miso.diff(null, component, body, document);
+    miso.diff(null, component, body);
 
     // Test component was populated
     expect(body.childNodes.length).toBe(1);
@@ -497,7 +497,7 @@ describe("miso.js tests", () => {
 
     // Replace component
     var node = vnode("div", []);
-    miso.diff(component, node, body, document);
+    miso.diff(component, node, body);
 
     // Test node is removed from DOM
     expect(body.children[0].tagName).toBe("DIV");
@@ -509,14 +509,14 @@ describe("miso.js tests", () => {
 
     // populate DOM
     var textNode = vtext("fooo");
-    miso.diff(null, textNode, body, document);
+    miso.diff(null, textNode, body);
 
     // Test node was populated
     expect(body.childNodes.length).toBe(1);
 
     // Replace node
     var node = vnode("div", []);
-    miso.diff(textNode, node, body, document);
+    miso.diff(textNode, node, body);
 
     // Test node is removed from DOM
     expect(body.children[0].tagName).toBe("DIV");
@@ -528,13 +528,13 @@ describe("miso.js tests", () => {
     // populate DOM
     var currentNode = null;
     var newNode = vnode("div", []);
-    miso.diff(currentNode, newNode, body, document);
+    miso.diff(currentNode, newNode, body);
 
     // Test node was populated
     expect(body.children.length).toBe(1);
 
     // Remove node
-    miso.diff(newNode, null, body, document);
+    miso.diff(newNode, null, body);
 
     // Test node is removed from DOM
     expect(body.children.length).toBe(0);
@@ -547,7 +547,7 @@ describe("miso.js tests", () => {
     var currentNode = vnode("div", [], {
       id: "a",
     });
-    miso.diff(null, currentNode, body, document);
+    miso.diff(null, currentNode, body);
     expect(currentNode.domRef["id"]).toBe("a");
   });
 
@@ -558,12 +558,12 @@ describe("miso.js tests", () => {
     var currentNode = vnode("div", [], {
       id: "a",
     });
-    miso.diff(null, currentNode, body, document);
+    miso.diff(null, currentNode, body);
 
     var newNode = vnode("div", [], {
       id: "a",
     });
-    miso.diff(currentNode, newNode, body, document);
+    miso.diff(currentNode, newNode, body);
     expect(currentNode.domRef).toBe(newNode.domRef);
   });
 
@@ -579,7 +579,7 @@ describe("miso.js tests", () => {
       },
       {},
     );
-    miso.diff(null, currentNode, body, document);
+    miso.diff(null, currentNode, body);
     expect(currentNode.domRef.getAttribute("lol")).toBe("lol");
   });
 
@@ -595,7 +595,7 @@ describe("miso.js tests", () => {
       },
       {},
     );
-    miso.diff(null, currentNode, body, document);
+    miso.diff(null, currentNode, body);
     expect(currentNode.domRef.getAttribute("lol")).toBe("lol");
 
     var newNode = vnode(
@@ -606,7 +606,7 @@ describe("miso.js tests", () => {
       },
       {},
     );
-    miso.diff(currentNode, newNode, body, document);
+    miso.diff(currentNode, newNode, body);
     expect(currentNode.domRef.getAttribute("lol")).toBe("lolz");
   });
 
@@ -617,12 +617,12 @@ describe("miso.js tests", () => {
     var currentNode = vnode("div", [], {
       lol: "lol",
     });
-    miso.diff(null, currentNode, body, document);
+    miso.diff(null, currentNode, body);
     expect(currentNode.domRef.getAttribute("lol")).toBe("lol");
 
     // test property change
     var newNode = vnode("div", [], {});
-    miso.diff(currentNode, newNode, body, document);
+    miso.diff(currentNode, newNode, body);
     expect(newNode.domRef.getAttribute("lol")).toBe(null);
   });
 
@@ -633,11 +633,11 @@ describe("miso.js tests", () => {
     var currentNode = vnode("div", [], {
       id: "someid",
     });
-    miso.diff(null, currentNode, body, document);
+    miso.diff(null, currentNode, body);
 
     // test property change
     var newNode = vnode("div", [], {});
-    miso.diff(currentNode, newNode, body, document);
+    miso.diff(currentNode, newNode, body);
     expect(newNode.domRef["id"]).toBe("");
   });
 
@@ -648,13 +648,13 @@ describe("miso.js tests", () => {
     var currentNode = vnode("div", [], {
       id: "someid",
     });
-    miso.diff(null, currentNode, body, document);
+    miso.diff(null, currentNode, body);
 
     // test property change
     var newNode = vnode("div", [], {
       id: "foo",
     });
-    miso.diff(currentNode, newNode, body, document);
+    miso.diff(currentNode, newNode, body);
     expect(newNode.domRef["id"]).toBe("foo");
   });
 
@@ -670,7 +670,7 @@ describe("miso.js tests", () => {
         color: "red",
       },
     );
-    miso.diff(null, newNode, body, document);
+    miso.diff(null, newNode, body);
     expect(newNode.domRef.style["color"]).toBe("red");
   });
 
@@ -686,11 +686,11 @@ describe("miso.js tests", () => {
         color: "red",
       },
     );
-    miso.diff(null, currentNode, body, document);
+    miso.diff(null, currentNode, body);
 
     // test css change
     var newNode = vnode("div", [], {}, {});
-    miso.diff(currentNode, newNode, body, document);
+    miso.diff(currentNode, newNode, body);
     expect(newNode.domRef.style["color"]).toBe("");
   });
 
@@ -706,7 +706,7 @@ describe("miso.js tests", () => {
         color: "red",
       },
     );
-    miso.diff(null, currentNode, body, document);
+    miso.diff(null, currentNode, body);
 
     // test css change
     var newNode = vnode(
@@ -717,7 +717,7 @@ describe("miso.js tests", () => {
         color: "blue",
       },
     );
-    miso.diff(currentNode, newNode, body, document);
+    miso.diff(currentNode, newNode, body);
     expect(newNode.domRef.style["color"]).toBe("blue");
   });
 
@@ -733,7 +733,7 @@ describe("miso.js tests", () => {
         color: "red",
       },
     );
-    miso.diff(null, currentNode, body, document);
+    miso.diff(null, currentNode, body);
 
     // test css no-op change
     var newNode = vnode(
@@ -744,7 +744,7 @@ describe("miso.js tests", () => {
         color: "red",
       },
     );
-    miso.diff(currentNode, newNode, body, document);
+    miso.diff(currentNode, newNode, body);
     expect(newNode.domRef.style["color"]).toBe("red");
   });
 
@@ -771,10 +771,10 @@ describe("miso.js tests", () => {
       "key",
     );
 
-    miso.diff(null, currentNode, body, document);
+    miso.diff(null, currentNode, body);
     expect(create).toBe(1);
 
-    miso.diff(currentNode, null, body, document);
+    miso.diff(currentNode, null, body);
     expect(destroy).toBe(1);
   });
 
@@ -801,10 +801,10 @@ describe("miso.js tests", () => {
       "key",
     );
 
-    miso.diff(null, currentNode, body, document);
+    miso.diff(null, currentNode, body);
     expect(create).toBe(1);
 
-    miso.diff(currentNode, null, body, document);
+    miso.diff(currentNode, null, body);
     expect(destroy).toBe(1);
   });
 
@@ -842,8 +842,8 @@ describe("miso.js tests", () => {
       null,
       "b",
     );
-    miso.diff(null, currentNode, body, document);
-    miso.diff(currentNode, null, body, document);
+    miso.diff(null, currentNode, body);
+    miso.diff(currentNode, null, body);
     expect(destroy).toBe(1);
     expect(childDestroy).toBe(1);
   });
@@ -882,8 +882,8 @@ describe("miso.js tests", () => {
       },
       "b",
     );
-    miso.diff(null, currentNode, body, document);
-    miso.diff(currentNode, null, body, document);
+    miso.diff(null, currentNode, body);
+    miso.diff(currentNode, null, body);
     expect(destroy).toBe(1);
     expect(childDestroy).toBe(1);
   });
@@ -905,7 +905,7 @@ describe("miso.js tests", () => {
       null,
       "key-1",
     );
-    miso.diff(null, currentNode, body, document);
+    miso.diff(null, currentNode, body);
     var newNode = vnode(
       "div",
       [],
@@ -920,9 +920,9 @@ describe("miso.js tests", () => {
       null,
       "key-1",
     );
-    miso.diff(null, currentNode, body, document);
+    miso.diff(null, currentNode, body);
     expect(destroy).toBe(0);
-    miso.diff(currentNode, newNode, body, document);
+    miso.diff(currentNode, newNode, body);
     var newKeyedNode = vnode(
       "div",
       [],
@@ -937,7 +937,7 @@ describe("miso.js tests", () => {
       null,
       "key-2",
     );
-    miso.diff(currentNode, newKeyedNode, body, document);
+    miso.diff(currentNode, newKeyedNode, body);
     expect(destroy).toBe(1);
   });
 
@@ -955,7 +955,7 @@ describe("miso.js tests", () => {
       null,
       "key-1",
     );
-    miso.diff(null, currentNode, body, document);
+    miso.diff(null, currentNode, body);
     var newNode = vnode(
       "div",
       [vnodeKeyed("div", "a"), vnodeKeyed("div", "b"), vnodeKeyed("div", "c")],
@@ -968,7 +968,7 @@ describe("miso.js tests", () => {
       null,
       "key-1",
     );
-    miso.diff(currentNode, newNode, body, document);
+    miso.diff(currentNode, newNode, body);
     expect(newNode.children.length).toBe(3);
     expect(newNode.children.length).toBe(currentNode.children.length);
     expect(currentNode.children).toEqual(newNode.children);
@@ -990,7 +990,7 @@ describe("miso.js tests", () => {
       null,
       "key-1",
     );
-    miso.diff(null, currentNode, body, document);
+    miso.diff(null, currentNode, body);
     var newNode = vnode(
       "div",
       [vnodeKeyed("div", "2"), vnodeKeyed("div", "1")],
@@ -1003,7 +1003,7 @@ describe("miso.js tests", () => {
       null,
       "key-1",
     );
-    miso.diff(currentNode, newNode, body, document);
+    miso.diff(currentNode, newNode, body);
     expect(newNode.children.length).toBe(2);
     expect(newNode.children.length).toBe(currentNode.children.length);
     expect(currentNode.children).toEqual(newNode.children);
@@ -1025,7 +1025,7 @@ describe("miso.js tests", () => {
       null,
       "key-1",
     );
-    miso.diff(null, currentNode, body, document);
+    miso.diff(null, currentNode, body);
     var newNode = vnode(
       "div",
       [vnodeKeyed("div", "z"), vnodeKeyed("div", "c")],
@@ -1038,7 +1038,7 @@ describe("miso.js tests", () => {
       null,
       "key-1",
     );
-    miso.diff(currentNode, newNode, body, document);
+    miso.diff(currentNode, newNode, body);
     expect(newNode.children.length).toBe(2);
     expect(newNode.children.length).toBe(currentNode.children.length);
     expect(currentNode.children).toEqual(newNode.children);
@@ -1060,7 +1060,7 @@ describe("miso.js tests", () => {
       null,
       "key-1",
     );
-    miso.diff(null, currentNode, body, document);
+    miso.diff(null, currentNode, body);
     var newNode = vnode(
       "div",
       [vnodeKeyed("div", "b"), vnodeKeyed("div", "a")],
@@ -1073,7 +1073,7 @@ describe("miso.js tests", () => {
       null,
       "key-1",
     );
-    miso.diff(currentNode, newNode, body, document);
+    miso.diff(currentNode, newNode, body);
     expect(newNode.children.length).toBe(2);
     expect(newNode.children.length).toBe(currentNode.children.length);
     expect(currentNode.children).toEqual(newNode.children);
@@ -1095,7 +1095,7 @@ describe("miso.js tests", () => {
       null,
       "key-1",
     );
-    miso.diff(null, currentNode, body, document);
+    miso.diff(null, currentNode, body);
     var newNode = vnode(
       "div",
       [vnodeKeyed("div", "c"), vnodeKeyed("div", "b"), vnodeKeyed("div", "a")],
@@ -1108,7 +1108,7 @@ describe("miso.js tests", () => {
       null,
       "key-1",
     );
-    miso.diff(currentNode, newNode, body, document);
+    miso.diff(currentNode, newNode, body);
     expect(newNode.children.length).toBe(3);
     expect(newNode.children.length).toBe(currentNode.children.length);
     expect(currentNode.children).toEqual(newNode.children);
@@ -1148,7 +1148,7 @@ describe("miso.js tests", () => {
         newKids.push(vnodeKeyed("div", i));
       }
     }
-    miso.diff(null, currentNode, body, document);
+    miso.diff(null, currentNode, body);
     var newNode = vnode(
       "div",
       newKids,
@@ -1161,7 +1161,7 @@ describe("miso.js tests", () => {
       null,
       "key-1",
     );
-    miso.diff(currentNode, newNode, body, document);
+    miso.diff(currentNode, newNode, body);
     expect(newNode.children.length).toBe(1000);
     expect(newNode.children.length).toBe(currentNode.children.length);
     expect(currentNode.children).toEqual(newNode.children);
@@ -1198,7 +1198,7 @@ describe("miso.js tests", () => {
       null,
       "key-1",
     );
-    miso.diff(null, currentNode, body, document);
+    miso.diff(null, currentNode, body);
     var newNode = vnode(
       "div",
       [
@@ -1217,7 +1217,7 @@ describe("miso.js tests", () => {
       null,
       "key-1",
     );
-    miso.diff(currentNode, newNode, body, document);
+    miso.diff(currentNode, newNode, body);
     expect(newNode.children.length).toBe(5);
     expect(newNode.children.length).toBe(currentNode.children.length);
     expect(currentNode.children).toEqual(newNode.children);
@@ -1245,7 +1245,7 @@ describe("miso.js tests", () => {
       null,
       "key-1",
     );
-    miso.diff(null, currentNode, body, document);
+    miso.diff(null, currentNode, body);
     var newNode = vnode(
       "div",
       [
@@ -1264,7 +1264,7 @@ describe("miso.js tests", () => {
       null,
       "key-1",
     );
-    miso.diff(currentNode, newNode, body, document);
+    miso.diff(currentNode, newNode, body);
     expect(newNode.children.length).toBe(5);
     expect(newNode.children.length).toBe(currentNode.children.length);
     expect(currentNode.children).toEqual(newNode.children);
@@ -1291,7 +1291,7 @@ describe("miso.js tests", () => {
       null,
       "key-1",
     );
-    miso.diff(null, currentNode, body, document);
+    miso.diff(null, currentNode, body);
     var newNode = vnode(
       "div",
       [
@@ -1309,7 +1309,7 @@ describe("miso.js tests", () => {
       null,
       "key-1",
     );
-    miso.diff(currentNode, newNode, body, document);
+    miso.diff(currentNode, newNode, body);
     expect(newNode.children.length).toBe(4);
     expect(newNode.children.length).toBe(currentNode.children.length);
     expect(currentNode.children).toEqual(newNode.children);
@@ -1331,7 +1331,7 @@ describe("miso.js tests", () => {
       null,
       "key-1",
     );
-    miso.diff(null, currentNode, body, document);
+    miso.diff(null, currentNode, body);
     var newNode = vnode(
       "div",
       [vnodeKeyed("div", "b"), vnodeKeyed("div", "z"), vnodeKeyed("div", "j")],
@@ -1344,7 +1344,7 @@ describe("miso.js tests", () => {
       null,
       "key-1",
     );
-    miso.diff(currentNode, newNode, body, document);
+    miso.diff(currentNode, newNode, body);
     expect(newNode.children.length).toBe(3);
     expect(newNode.children.length).toBe(currentNode.children.length);
     expect(currentNode.children).toEqual(newNode.children);
@@ -1371,7 +1371,7 @@ describe("miso.js tests", () => {
       null,
       "key-1",
     );
-    miso.diff(null, currentNode, body, document);
+    miso.diff(null, currentNode, body);
     var newNode = vnode(
       "div",
       [
@@ -1389,7 +1389,7 @@ describe("miso.js tests", () => {
       null,
       "key-1",
     );
-    miso.diff(currentNode, newNode, body, document);
+    miso.diff(currentNode, newNode, body);
     expect(newNode.children.length).toBe(5);
     expect(newNode.children.length).toBe(currentNode.children.length);
     expect(currentNode.children).toEqual(newNode.children);
@@ -1410,7 +1410,7 @@ describe("miso.js tests", () => {
       null,
       "key-1",
     );
-    miso.diff(null, currentNode, body, document);
+    miso.diff(null, currentNode, body);
     var newNode = vnode(
       "div",
       [vnodeKeyed("div", "a"), vnodeKeyed("div", "c"), vnodeKeyed("div", "k")],
@@ -1422,7 +1422,7 @@ describe("miso.js tests", () => {
       null,
       "key-1",
     );
-    miso.diff(currentNode, newNode, body, document);
+    miso.diff(currentNode, newNode, body);
     expect(newNode.children.length).toBe(3);
     expect(newNode.children.length).toBe(currentNode.children.length);
     expect(currentNode.children).toEqual(newNode.children);
@@ -1437,13 +1437,13 @@ describe("miso.js tests", () => {
       vtextKeyed("bar", 2),
       vtextKeyed("baz", 3),
     ]);
-    miso.diff(null, currentNode, body, document);
+    miso.diff(null, currentNode, body);
     var newNode = vnodeKids("div", [
       vtextKeyed("baz", 3),
       vtextKeyed("bar", 2),
       vtextKeyed("foo", 1),
     ]);
-    miso.diff(currentNode, newNode, body, document);
+    miso.diff(currentNode, newNode, body);
     expect(newNode.children.length).toBe(currentNode.children.length);
     expect(newNode.children).toEqual(currentNode.children);
   });
@@ -1457,7 +1457,7 @@ describe("miso.js tests", () => {
     var txt = document.createTextNode("foo");
     nestedDiv.appendChild(txt);
     var currentNode = vnodeKids("div", [vnodeKids("div", [vtext("foo")])]);
-    miso.copyDOMIntoVTree(true, body, currentNode, document);
+    miso.copyDOMIntoVTree(true, body, currentNode);
     expect(currentNode.children[0].children[0].text).toEqual("foo");
   });
 
@@ -1468,7 +1468,7 @@ describe("miso.js tests", () => {
     var nestedDiv = document.createElement("div");
     div.appendChild(nestedDiv);
     var currentNode = vnodeKids("div", [vtext("foo")]);
-    var res = miso.copyDOMIntoVTree(true, body, currentNode, document);
+    var res = miso.copyDOMIntoVTree(true, body, currentNode);
     expect(res).toEqual(false);
   });
 
@@ -1479,7 +1479,7 @@ describe("miso.js tests", () => {
     var txt = document.createTextNode("foo");
     div.appendChild(txt);
     var currentNode = vnodeKids("div", [vnode("div", [])]);
-    var res = miso.copyDOMIntoVTree(true, body, currentNode, document);
+    var res = miso.copyDOMIntoVTree(true, body, currentNode);
     expect(res).toEqual(false);
   });
 
@@ -1490,7 +1490,7 @@ describe("miso.js tests", () => {
     var txt = document.createTextNode("foo");
     div.appendChild(txt);
     var currentNode = vnodeKids("div", [vtext("bar")]);
-    var res = miso.copyDOMIntoVTree(true, body, currentNode, document);
+    var res = miso.copyDOMIntoVTree(true, body, currentNode);
     expect(res).toEqual(false);
   });
 
@@ -1501,7 +1501,7 @@ describe("miso.js tests", () => {
     var txt = document.createTextNode("foobar");
     div.appendChild(txt);
     var currentNode = vnodeKids("div", [vtext("foo")]);
-    var res = miso.copyDOMIntoVTree(true, body, currentNode, document);
+    var res = miso.copyDOMIntoVTree(true, body, currentNode);
     expect(res).toEqual(false);
   });
 
@@ -1516,7 +1516,7 @@ describe("miso.js tests", () => {
       vtext("bar"),
       vtext("baz"),
     ]);
-    miso.copyDOMIntoVTree(true, body, currentNode, document);
+    miso.copyDOMIntoVTree(true, body, currentNode);
     // Expect "foobarbaz" to be split up into three nodes in the DOM
     expect(div.childNodes[0].textContent).toEqual("foobarbaz");
   });
@@ -1536,7 +1536,7 @@ describe("miso.js tests", () => {
       vtext("bar"),
       vtext("baz"),
     ]);
-    miso.copyDOMIntoVTree(true, null, currentNode, document);
+    miso.copyDOMIntoVTree(true, null, currentNode);
     // Expect "foobarbaz" to be split up into three nodes in the DOM
     expect(div.childNodes[0].textContent).toEqual("foobarbaz");
     expect(div.childNodes[2].textContent).toEqual("foobarbaz");
@@ -1559,7 +1559,7 @@ describe("miso.js tests", () => {
     var txt = document.createTextNode("foo");
     nestedDiv2.appendChild(txt);
     var currentNode = vnodeKids("div", [vnodeKids("div", [vtext("foo")])]);
-    var succeeded = miso.copyDOMIntoVTree(true, misoDiv, currentNode, document);
+    var succeeded = miso.copyDOMIntoVTree(true, misoDiv, currentNode);
     expect(currentNode.children[0].children[0].domRef).toEqual(txt);
     expect(succeeded).toEqual(true);
   });
@@ -1581,7 +1581,7 @@ describe("miso.js tests", () => {
     var txt = document.createTextNode("foo");
     nestedDiv2.appendChild(txt);
     var currentNode = vnodeKids("div", [vnodeKids("div", [vtext("foo")])]);
-    var succeeded = miso.copyDOMIntoVTree(true, body, currentNode, document);
+    var succeeded = miso.copyDOMIntoVTree(true, body, currentNode);
     expect(currentNode.children[0].children[0].domRef).toEqual(txt);
     expect(succeeded).toEqual(false);
   });
@@ -1596,13 +1596,13 @@ describe("miso.js tests", () => {
   //   var misoTxt = document.createTextNode("foo");
   //   body.appendChild(misoTxt);
   //   var currentNode = vnodeKids('div', [ vnodeKids('div', [ vtext("foo") ]) ]);
-  //   var succeeded = miso.copyDOMIntoVTree(true, misoTxt, currentNode, document);
+  //   var succeeded = miso.copyDOMIntoVTree(true, misoTxt, currentNode);
   //   expect(succeeded).toEqual(false);
   // });
 
   test("Should mount on an empty body", () => {
     var currentNode = vnodeKids("div", [vnodeKids("div", [vtext("foo")])]);
-    var succeeded = miso.copyDOMIntoVTree(true, null, currentNode, document);
+    var succeeded = miso.copyDOMIntoVTree(true, null, currentNode);
     expect(succeeded).toEqual(false);
   });
 
@@ -1623,9 +1623,9 @@ describe("miso.js tests", () => {
       ns: "HTML",
       css: {},
     };
-    var result = miso.copyDOMIntoVTree(false, body, vtree, document);
+    var result = miso.copyDOMIntoVTree(false, body, vtree);
     expect(result).toEqual(true);
-    var check = miso.integrityCheck(true, vtree, window);
+    var check = miso.integrityCheck(true, vtree);
     expect(check).toBe(1);
   });
 
@@ -1646,12 +1646,12 @@ describe("miso.js tests", () => {
       ns: "HTML",
       css: {},
     };
-    var result = miso.copyDOMIntoVTree(false, body, vtree, document);
+    var result = miso.copyDOMIntoVTree(false, body, vtree);
     expect(result).toEqual(true);
-    var check = miso.integrityCheck(true, vtree, window);
+    var check = miso.integrityCheck(true, vtree);
     expect(check).toBe(1);
     vtree.tag = "lol";
-    check = miso.integrityCheck(true, vtree, window);
+    check = miso.integrityCheck(true, vtree);
     expect(check).toBe(0);
   });
 
@@ -1672,7 +1672,7 @@ describe("miso.js tests", () => {
       ns: "HTML",
       css: {},
     };
-    var result = miso.copyDOMIntoVTree(true, body, vtree, document);
+    var result = miso.copyDOMIntoVTree(true, body, vtree);
     expect(result).toEqual(false);
   });
 
@@ -1693,12 +1693,12 @@ describe("miso.js tests", () => {
       ns: "HTML",
       css: {},
     };
-    var result = miso.copyDOMIntoVTree(false, body, vtree, document);
+    var result = miso.copyDOMIntoVTree(false, body, vtree);
     expect(result).toEqual(true);
-    var check = miso.integrityCheck(true, vtree, window);
+    var check = miso.integrityCheck(true, vtree);
     expect(check).toBe(1);
     vtree.children[0].text = "oops";
-    check = miso.integrityCheck(true, vtree, window);
+    check = miso.integrityCheck(true, vtree);
     expect(check).toBe(0);
   });
 
@@ -1719,12 +1719,12 @@ describe("miso.js tests", () => {
       ns: "HTML",
       css: {},
     };
-    var result = miso.copyDOMIntoVTree(false, body, vtree, document);
+    var result = miso.copyDOMIntoVTree(false, body, vtree);
     expect(result).toEqual(true);
-    var check = miso.integrityCheck(true, vtree, window);
+    var check = miso.integrityCheck(true, vtree);
     expect(check).toBe(1);
     vtree.children = [];
-    check = miso.integrityCheck(true, vtree, window);
+    check = miso.integrityCheck(true, vtree);
     expect(check).toBe(false);
   });
 
@@ -1746,12 +1746,12 @@ describe("miso.js tests", () => {
       ns: "HTML",
       css: { "background-color": "red" },
     };
-    var result = miso.copyDOMIntoVTree(false, body, vtree, document);
+    var result = miso.copyDOMIntoVTree(false, body, vtree);
     expect(result).toEqual(true);
-    var check = miso.integrityCheck(true, vtree, window);
+    var check = miso.integrityCheck(true, vtree);
     expect(check).toBe(1);
     vtree.css["background-color"] = "green";
-    check = miso.integrityCheck(true, vtree, window);
+    check = miso.integrityCheck(true, vtree);
     expect(check).toBe(0);
   });
 
@@ -1774,12 +1774,12 @@ describe("miso.js tests", () => {
       ns: "HTML",
       css: { "background-color": "red", color: "#cccccc" },
     };
-    var result = miso.copyDOMIntoVTree(false, body, vtree, document);
+    var result = miso.copyDOMIntoVTree(false, body, vtree);
     expect(result).toEqual(true);
-    var check = miso.integrityCheck(true, vtree, window);
+    var check = miso.integrityCheck(true, vtree);
     expect(check).toBe(1);
     vtree.css["color"] = "#dddddd";
-    check = miso.integrityCheck(true, vtree, window);
+    check = miso.integrityCheck(true, vtree);
     expect(check).toBe(0);
   });
 
@@ -1802,12 +1802,12 @@ describe("miso.js tests", () => {
       ns: "HTML",
       css: { "background-color": "red" },
     };
-    var result = miso.copyDOMIntoVTree(false, body, vtree, document);
+    var result = miso.copyDOMIntoVTree(false, body, vtree);
     expect(result).toEqual(true);
-    var check = miso.integrityCheck(true, vtree, window);
+    var check = miso.integrityCheck(true, vtree);
     expect(check).toBe(1);
     vtree.props["class"] = "something-else";
-    check = miso.integrityCheck(true, vtree, window);
+    check = miso.integrityCheck(true, vtree);
     expect(check).toBe(0);
   });
 
@@ -1832,13 +1832,13 @@ describe("miso.js tests", () => {
       ns: "HTML",
       css: { "background-color": "red" },
     };
-    var result = miso.copyDOMIntoVTree(false, body, vtree, document);
+    var result = miso.copyDOMIntoVTree(false, body, vtree);
     expect(result).toEqual(true);
-    var check = miso.integrityCheck(true, vtree, window);
+    var check = miso.integrityCheck(true, vtree);
     expect(check).toBe(1);
     vtree.props["height"] = "200";
     vtree.props["width"] = "200";
-    check = miso.integrityCheck(true, vtree, window);
+    check = miso.integrityCheck(true, vtree);
     expect(check).toBe(0);
   });
 
@@ -1860,12 +1860,12 @@ describe("miso.js tests", () => {
       ns: "HTML",
       css: {},
     };
-    var result = miso.copyDOMIntoVTree(false, body, vtree, document);
+    var result = miso.copyDOMIntoVTree(false, body, vtree);
     expect(result).toEqual(true);
-    var check = miso.integrityCheck(true, vtree, window);
+    var check = miso.integrityCheck(true, vtree);
     expect(check).toBe(1);
     vtree.props["title"] = "woz";
-    check = miso.integrityCheck(true, vtree, window);
+    check = miso.integrityCheck(true, vtree);
     expect(check).toBe(0);
   });
 
@@ -1888,12 +1888,12 @@ describe("miso.js tests", () => {
       ns: "HTML",
       css: { "background-color": "red" },
     };
-    var result = miso.copyDOMIntoVTree(false, body, vtree, document);
+    var result = miso.copyDOMIntoVTree(false, body, vtree);
     expect(result).toEqual(true);
-    var check = miso.integrityCheck(true, vtree, window);
+    var check = miso.integrityCheck(true, vtree);
     expect(check).toBe(1);
     vtree.props["href"] = "notgoogle.com";
-    check = miso.integrityCheck(true, vtree, window);
+    check = miso.integrityCheck(true, vtree);
     expect(check).toBe(0);
   });
 
@@ -1916,12 +1916,12 @@ describe("miso.js tests", () => {
       ns: "HTML",
       css: { "background-color": "red" },
     };
-    var result = miso.copyDOMIntoVTree(false, body, vtree, document);
+    var result = miso.copyDOMIntoVTree(false, body, vtree);
     expect(result).toEqual(true);
-    var check = miso.integrityCheck(true, vtree, window);
+    var check = miso.integrityCheck(true, vtree);
     expect(check).toBe(1);
     vtree.children[0].domRef = document.createElement("div");
-    check = miso.integrityCheck(true, vtree, window);
+    check = miso.integrityCheck(true, vtree);
     expect(check).toBe(0);
   });
 
@@ -1942,15 +1942,15 @@ describe("miso.js tests", () => {
       ns: "HTML",
       css: {},
     };
-    var result = miso.copyDOMIntoVTree(false, body, vtree, document);
+    var result = miso.copyDOMIntoVTree(false, body, vtree);
     expect(result).toEqual(true);
-    var check = miso.integrityCheck(true, vtree, window);
+    var check = miso.integrityCheck(true, vtree);
     expect(check).toBe(0);
   });
 
   test("Should set body[data-component-id] via setBodyComponent()", () => {
     var document = window.document;
-    miso.setBodyComponent("component-one", document);
+    miso.setBodyComponent("component-one");
     expect(document.body.getAttribute("data-component-id")).toEqual(
       "component-one",
     );
@@ -2008,7 +2008,7 @@ describe("miso.js tests", () => {
     };
 
     /* initial page draw */
-    miso.diff(null, vtree, document.body, document);
+    miso.diff(null, vtree, document.body);
 
     /* ensure structures match */
     expect(vtree.domRef).toEqual(document.body.childNodes[0]);
@@ -2054,8 +2054,8 @@ describe("miso.js tests", () => {
     };
 
     var vtree = mkVComp("one", [mkVComp("two", [mkVComp("three", [])])]);
-    miso.diff(null, vtree, document.body, document);
-    miso.diff(vtree, null, document.body, document);
+    miso.diff(null, vtree, document.body);
+    miso.diff(vtree, null, document.body);
     expect(unmounts).toEqual(["one", "two", "three"]);
   });
 

--- a/js/miso.spec.js
+++ b/js/miso.spec.js
@@ -156,7 +156,9 @@ describe("miso.js tests", () => {
     var body = document.body;
     var mountCount = 0;
     var newComp1 = vcomp(
-      () => {return mountCount++},
+      () => {
+        return mountCount++;
+      },
       null,
       { "data-component-id": "vcomp-foo" },
       { "background-color": "red" },
@@ -164,7 +166,9 @@ describe("miso.js tests", () => {
     );
     miso.diff(null, newComp1, body);
     var newComp2 = vcomp(
-      () => {return mountCount++},
+      () => {
+        return mountCount++;
+      },
       null,
       { "data-component-id": "vcomp-foo" },
       { "background-color": "red" },
@@ -187,7 +191,9 @@ describe("miso.js tests", () => {
     };
     var newNode = vcomp(
       mountFunc,
-      () => {return unmountCount++},
+      () => {
+        return unmountCount++;
+      },
       { id: "vcomp-foo" },
       {
         "background-color": "red",
@@ -359,7 +365,9 @@ describe("miso.js tests", () => {
     // populate DOM
     var mountCount = 0;
     var compNode1 = vcomp(
-      () => {return mountCount++},
+      () => {
+        return mountCount++;
+      },
       null,
       {
         "data-component-id": "vcomp-foo",
@@ -377,7 +385,9 @@ describe("miso.js tests", () => {
     // Replace node
     mountCount = 0;
     var compNode2 = vcomp(
-      () => {return mountCount++},
+      () => {
+        return mountCount++;
+      },
       null,
       {
         "data-component-id": "vcomp-foo",
@@ -401,7 +411,9 @@ describe("miso.js tests", () => {
 
     // Replace node
     var mountCount = 0;
-    var compNode = vcomp(() => {return mountCount++});
+    var compNode = vcomp(() => {
+      return mountCount++;
+    });
     miso.diff(node, compNode, body);
 
     // Node is removed from DOM, Component is on the DOM
@@ -424,7 +436,9 @@ describe("miso.js tests", () => {
 
     // Replace node
     var mountCount = 0;
-    var compNode = vcomp(() => {return mountCount++});
+    var compNode = vcomp(() => {
+      return mountCount++;
+    });
     miso.diff(node, compNode, body);
 
     // Node is removed from DOM, Component is on the DOM
@@ -459,8 +473,12 @@ describe("miso.js tests", () => {
     var mountCount = 0,
       unmountCount = 0;
     var component = vcomp(
-      () => {return mountCount++},
-      () => {return unmountCount++},
+      () => {
+        return mountCount++;
+      },
+      () => {
+        return unmountCount++;
+      },
     );
     miso.diff(null, component, body);
 
@@ -485,8 +503,12 @@ describe("miso.js tests", () => {
     var mountCount = 0,
       unmountCount = 0;
     var component = vcomp(
-      () => {return mountCount++},
-      () => {return unmountCount++},
+      () => {
+        return mountCount++;
+      },
+      () => {
+        return unmountCount++;
+      },
     );
     miso.diff(null, component, body);
 

--- a/src/Miso/Diff.hs
+++ b/src/Miso/Diff.hs
@@ -24,16 +24,15 @@ import           Miso.String
 -----------------------------------------------------------------------------
 -- | diffing / patching a given element
 diff :: JSVal -> Maybe VTree -> Maybe VTree -> JSM ()
-diff mountEl current new = do
-  doc <- FFI.getDocument
+diff mountEl current new =
   case (current, new) of
     (Nothing, Nothing) -> pure ()
     (Just (VTree current'), Just (VTree new')) ->
-      FFI.diff current' new' mountEl doc
+      FFI.diff current' new' mountEl
     (Nothing, Just (VTree new')) -> do
-      FFI.diff (Object jsNull) new' mountEl doc
+      FFI.diff (Object jsNull) new' mountEl
     (Just (VTree current'), Nothing) ->
-      FFI.diff current' (Object jsNull) mountEl doc
+      FFI.diff current' (Object jsNull) mountEl
 -----------------------------------------------------------------------------
 -- | return the configured mountPoint element or the body
 mountElement :: MisoString -> JSM JSVal

--- a/src/Miso/FFI.hs
+++ b/src/Miso/FFI.hs
@@ -250,12 +250,6 @@ getBody = jsg "document" ! "body"
 getDocument :: JSM JSVal
 getDocument = jsg "document"
 -----------------------------------------------------------------------------
--- | Retrieves a reference to the window.
---
--- See <https://developer.mozilla.org/en-US/docs/Web/API/Window>
-getWindow :: JSM JSVal
-getWindow = jsg "window"
------------------------------------------------------------------------------
 -- | Returns an Element object representing the element whose id property matches
 -- the specified string.
 --
@@ -271,12 +265,10 @@ diff
   -- ^ new object
   -> JSVal
   -- ^ parent node
-  -> JSVal
-  -- ^ document
   -> JSM ()
-diff (Object a) (Object b) c d = do
+diff (Object a) (Object b) c = do
   moduleExports <- jsg "module" ! "exports"
-  void $ moduleExports # "diff" $ [a,b,c,d]
+  void $ moduleExports # "diff" $ [a,b,c]
 -----------------------------------------------------------------------------
 -- | Helper function for converting Integral types to JavaScript strings
 integralToJSString :: Integral a => a -> MisoString
@@ -327,11 +319,9 @@ undelegate mountPoint events debug callback = do
 -- entry point into isomorphic javascript
 copyDOMIntoVTree :: Bool -> JSVal -> JSVal -> JSM ()
 copyDOMIntoVTree logLevel mountPoint vtree = void $ do
-  window <- getWindow
-  doc <- getDocument
   ll <- toJSVal logLevel
   moduleExports <- jsg "module" ! "exports"
-  void $ moduleExports # "copyDOMIntoVTree" $ [ll, mountPoint, vtree, doc, window]
+  void $ moduleExports # "copyDOMIntoVTree" $ [ll, mountPoint, vtree]
 -----------------------------------------------------------------------------
 -- | Fails silently if the element is not found.
 --
@@ -339,10 +329,9 @@ copyDOMIntoVTree logLevel mountPoint vtree = void $ do
 focus :: MisoString -> JSM ()
 focus x = do
   moduleExports <- jsg "module" ! "exports"
-  doc <- getDocument
   el <- toJSVal x
   delay <- toJSVal (50 :: Int)
-  void $ moduleExports # "callFocus" $ [el,doc,delay]
+  void $ moduleExports # "callFocus" $ [el,delay]
 -----------------------------------------------------------------------------
 -- | Fails silently if the element is not found.
 --
@@ -350,10 +339,9 @@ focus x = do
 blur :: MisoString -> JSM ()
 blur x = do
   moduleExports <- jsg "module" ! "exports"
-  doc <- getDocument
   el <- toJSVal x
   delay <- toJSVal (50 :: Int)
-  void $ moduleExports # "callBlur" $ [el,doc,delay]
+  void $ moduleExports # "callBlur" $ [el,delay]
 -----------------------------------------------------------------------------
 -- | Calls @document.getElementById(id).scrollIntoView()@
 scrollIntoView :: MisoString -> JSM ()
@@ -373,8 +361,7 @@ reload = void $ jsg "location" # "reload" $ ([] :: [MisoString])
 -- | Sets the body with data-component-id
 setBodyComponent :: MisoString -> JSM ()
 setBodyComponent name = do
-  doc <- getDocument
   component <- toJSVal name
   moduleExports <- jsg "module" ! "exports"
-  void $ moduleExports # "setBodyComponent" $ [component, doc]
+  void $ moduleExports # "setBodyComponent" $ [component]
 -----------------------------------------------------------------------------


### PR DESCRIPTION
Now that `jest-jsdom-environment` sets this up implicitly we no longer need to explicitly pass (`window`, `document`) to `diff`, etc. This simplifies the FFI statements in Haskell and the test code in `miso.spec.js`