### PR TITLE
Preserve quoted field names during miso.js export

### DIFF
--- a/js/miso.js
+++ b/js/miso.js
@@ -1,15 +1,15 @@
 /* account for node.js running tests, or a browser / wasm environment */
-module = typeof module === "undefined" ? {} : module;
+module = typeof module === 'undefined' ? {} : module;
 
 /* module export pattern */
-module["exports"] = (function () {
+module['exports'] = (function () {
   /* virtual-dom diffing algorithm, applies patches as detected */
   var diff = function (currentObj, newObj, parent) {
     if (!currentObj && !newObj) return;
     else if (!currentObj && newObj) create(newObj, parent);
     else if (!newObj) destroy(currentObj, parent);
     else {
-      if (currentObj["type"] === newObj["type"]) {
+      if (currentObj['type'] === newObj['type']) {
         diffNodes(currentObj, newObj, parent);
       } else {
         replace(currentObj, newObj, parent);
@@ -24,12 +24,12 @@ module["exports"] = (function () {
     // ^ this will unmount sub components before we replace the child
     // and will recursively call hooks on nodes
     // step2 : create new things, replace old things with new things
-    if (n["type"] === "vtext") {
-      n["domRef"] = document.createTextNode(n["text"]);
-      parent.replaceChild(n["domRef"], c["domRef"]);
+    if (n['type'] === 'vtext') {
+      n['domRef'] = document.createTextNode(n['text']);
+      parent.replaceChild(n['domRef'], c['domRef']);
     } else {
       createElement(n, function (ref) {
-        parent.replaceChild(ref, c["domRef"]);
+        parent.replaceChild(ref, c['domRef']);
       });
     }
     // step 3: call destroyed hooks, call created hooks
@@ -42,7 +42,7 @@ module["exports"] = (function () {
     callBeforeDestroyedRecursive(obj);
 
     // step 2: destroy
-    parent.removeChild(obj["domRef"]);
+    parent.removeChild(obj['domRef']);
 
     // step 3: invoke post-hooks for vnode and vcomp
     callDestroyedRecursive(obj);
@@ -50,18 +50,18 @@ module["exports"] = (function () {
 
   var diffNodes = function (c, n, parent) {
     // bail out on easy vtext case
-    if (c["type"] === "vtext") {
-      if (c["text"] !== n["text"]) c["domRef"].textContent = n["text"];
-      n["domRef"] = c["domRef"];
+    if (c['type'] === 'vtext') {
+      if (c['text'] !== n['text']) c['domRef'].textContent = n['text'];
+      n['domRef'] = c['domRef'];
       return;
     }
     // check children
     if (
-      c["tag"] === n["tag"] &&
-      n["key"] === c["key"] &&
-      n["data-component-id"] === c["data-component-id"]
+      c['tag'] === n['tag'] &&
+      n['key'] === c['key'] &&
+      n['data-component-id'] === c['data-component-id']
     ) {
-      n["domRef"] = c["domRef"];
+      n['domRef'] = c['domRef'];
       // dmj: we will diff properties on 'vcomp' as well
       populate(c, n);
     } else {
@@ -79,12 +79,12 @@ module["exports"] = (function () {
   };
 
   var callDestroyed = function (obj) {
-    if (obj["onDestroyed"]) obj["onDestroyed"]();
+    if (obj['onDestroyed']) obj['onDestroyed']();
   };
 
   var callBeforeDestroyed = function (obj) {
-    if (obj["onBeforeDestroyed"]) obj["onBeforeDestroyed"]();
-    if (obj["type"] === "vcomp") obj["unmount"](obj["domRef"]);
+    if (obj['onBeforeDestroyed']) obj['onBeforeDestroyed']();
+    if (obj['type'] === 'vcomp') obj['unmount'](obj['domRef']);
   };
 
   var callBeforeDestroyedRecursive = function (obj) {
@@ -95,8 +95,8 @@ module["exports"] = (function () {
   };
   // ** </> recursive calls to hooks
   var callCreated = function (obj) {
-    if (obj["onCreated"]) obj["onCreated"]();
-    if (obj["type"] === "vcomp") mountComponent(obj);
+    if (obj['onCreated']) obj['onCreated']();
+    if (obj['type'] === 'vcomp') mountComponent(obj);
   };
 
   var populate = function (c, n) {
@@ -107,10 +107,10 @@ module["exports"] = (function () {
         children: [],
       };
     }
-    diffProps(c["props"], n["props"], n["domRef"], n["ns"] === "svg");
-    diffCss(c["css"], n["css"], n["domRef"]);
-    if (n["type"] === "vcomp") return; // dmj: don't diff vcomp children
-    diffChildren(c["children"], n["children"], n["domRef"]);
+    diffProps(c['props'], n['props'], n['domRef'], n['ns'] === 'svg');
+    diffCss(c['css'], n['css'], n['domRef']);
+    if (n['type'] === 'vcomp') return; // dmj: don't diff vcomp children
+    diffChildren(c['children'], n['children'], n['domRef']);
   };
 
   var diffProps = function (cProps, nProps, node, isSvg) {
@@ -124,22 +124,22 @@ module["exports"] = (function () {
         if (isSvg || !(c in node)) {
           node.removeAttribute(c, cProps[c]);
         } else {
-          node[c] = "";
+          node[c] = '';
         }
       } else {
         /* Already on DOM from previous diff, continue */
-        if (newProp === cProps[c] && c !== "checked" && c !== "value") continue;
+        if (newProp === cProps[c] && c !== 'checked' && c !== 'value') continue;
         if (isSvg) {
-          if (c === "href") {
+          if (c === 'href') {
             node.setAttributeNS(
-              "http://www.w3.org/1999/xlink",
-              "href",
+              'http://www.w3.org/1999/xlink',
+              'href',
               newProp,
             );
           } else {
             node.setAttribute(c, newProp);
           }
-        } else if (c in node && !(c === "list" || c === "form")) {
+        } else if (c in node && !(c === 'list' || c === 'form')) {
           node[c] = newProp;
         } else {
           node.setAttribute(c, newProp);
@@ -152,12 +152,12 @@ module["exports"] = (function () {
       newProp = nProps[n];
       /* Only add new properties, skip (continue) if they already exist in current property map */
       if (isSvg) {
-        if (n === "href") {
-          node.setAttributeNS("http://www.w3.org/1999/xlink", "href", newProp);
+        if (n === 'href') {
+          node.setAttributeNS('http://www.w3.org/1999/xlink', 'href', newProp);
         } else {
           node.setAttribute(n, newProp);
         }
-      } else if (n in node && !(n === "list" || n === "form")) {
+      } else if (n in node && !(n === 'list' || n === 'form')) {
         node[n] = nProps[n];
       } else {
         node.setAttribute(n, newProp);
@@ -188,8 +188,8 @@ module["exports"] = (function () {
     return (
       ns.length > 0 &&
       cs.length > 0 &&
-      ns[0]["key"] != null &&
-      cs[0]["key"] != null
+      ns[0]['key'] != null &&
+      cs[0]['key'] != null
     );
   };
 
@@ -205,25 +205,25 @@ module["exports"] = (function () {
   };
 
   var populateDomRef = function (obj) {
-    if (obj["ns"] === "svg") {
-      obj["domRef"] = document.createElementNS(
-        "http://www.w3.org/2000/svg",
-        obj["tag"],
+    if (obj['ns'] === 'svg') {
+      obj['domRef'] = document.createElementNS(
+        'http://www.w3.org/2000/svg',
+        obj['tag'],
       );
-    } else if (obj["ns"] === "mathml") {
-      obj["domRef"] = document.createElementNS(
-        "http://www.w3.org/1998/Math/MathML",
-        obj["tag"],
+    } else if (obj['ns'] === 'mathml') {
+      obj['domRef'] = document.createElementNS(
+        'http://www.w3.org/1998/Math/MathML',
+        obj['tag'],
       );
     } else {
-      obj["domRef"] = document.createElement(obj["tag"]);
+      obj['domRef'] = document.createElement(obj['tag']);
     }
   };
 
   // dmj: refactor this, the callback function feels meh
   var createElement = function (obj, cb) {
     populateDomRef(obj);
-    cb(obj["domRef"]);
+    cb(obj['domRef']);
     populate(null, obj);
     callCreated(obj);
   };
@@ -231,7 +231,7 @@ module["exports"] = (function () {
   // mounts vcomp by calling into Haskell side.
   // unmount is handled with pre-destroy recursive hooks
   var mountComponent = function (obj) {
-    var componentId = obj["data-component-id"],
+    var componentId = obj['data-component-id'],
       nodeList = document.querySelectorAll(
         "[data-component-id='" + componentId + "']",
       );
@@ -247,21 +247,21 @@ module["exports"] = (function () {
     }
     // dmj, the component placeholder div[id=name] is already on the dom and vdom
     // Now we gen the component and append it to the vdom and real dom
-    obj["domRef"].setAttribute("data-component-id", componentId);
+    obj['domRef'].setAttribute('data-component-id', componentId);
     // ^ we have to set this before 'mount()' is called, since `diff` requires it.
-    obj["mount"](function (component) {
+    obj['mount'](function (component) {
       // mount() gives us the VTree from the Haskell side, so we just attach it here
       // to tie the knot (attach to both vdom and real dom).
       obj.children.push(component);
-      obj["domRef"].appendChild(component["domRef"]);
+      obj['domRef'].appendChild(component['domRef']);
     });
   };
 
   // creates nodes on virtual and dom (vtext, vcomp, vnode)
   var create = function (obj, parent) {
-    if (obj.type === "vtext") {
-      obj["domRef"] = document.createTextNode(obj["text"]);
-      parent.appendChild(obj["domRef"]);
+    if (obj.type === 'vtext') {
+      obj['domRef'] = document.createTextNode(obj['text']);
+      parent.appendChild(obj['domRef']);
     } else {
       createElement(obj, function (ref) {
         parent.appendChild(ref);
@@ -304,7 +304,7 @@ module["exports"] = (function () {
         diff(null, nFirst, parent);
         /* insertBefore's semantics will append a node if the second argument provided is `null` or `undefined`.
            Otherwise, it will insert node['domRef'] before oLast['domRef']. */
-        parent.insertBefore(nFirst["domRef"], oFirst ? oFirst["domRef"] : null);
+        parent.insertBefore(nFirst['domRef'], oFirst ? oFirst['domRef'] : null);
         os.splice(newFirstIndex, 0, nFirst);
         newFirstIndex++;
       } /* No more new nodes, delete all remaining nodes in old list
@@ -313,7 +313,7 @@ module["exports"] = (function () {
          */ else if (newFirstIndex > newLastIndex) {
         tmp = oldLastIndex;
         while (oldLastIndex >= oldFirstIndex) {
-          parent.removeChild(os[oldLastIndex--]["domRef"]);
+          parent.removeChild(os[oldLastIndex--]['domRef']);
         }
         os.splice(oldFirstIndex, tmp - oldFirstIndex + 1);
         break;
@@ -321,19 +321,19 @@ module["exports"] = (function () {
          -> oldFirstIndex -> [ a b c ] <- oldLastIndex
          -> newFirstIndex -> [ a b c ] <- newLastIndex
          check if nFirst and oFirst align, if so, check nLast and oLast
-         */ else if (oFirst["key"] === nFirst["key"]) {
+         */ else if (oFirst['key'] === nFirst['key']) {
         diff(os[oldFirstIndex++], ns[newFirstIndex++], parent);
-      } else if (oLast["key"] === nLast["key"]) {
+      } else if (oLast['key'] === nLast['key']) {
         diff(os[oldLastIndex--], ns[newLastIndex--], parent);
       } /* flip-flop case, nodes have been swapped, in some way or another
          both could have been swapped.
          -> [ a b c ] <- old children
          -> [ c b a ] <- new children
          */ else if (
-        oFirst["key"] === nLast["key"] &&
-        nFirst["key"] === oLast["key"]
+        oFirst['key'] === nLast['key'] &&
+        nFirst['key'] === oLast['key']
       ) {
-        swapDomRefs(node, oLast["domRef"], oFirst["domRef"], parent);
+        swapDomRefs(node, oLast['domRef'], oFirst['domRef'], parent);
         swap(os, oldFirstIndex, oldLastIndex);
         diff(os[oldFirstIndex++], ns[newFirstIndex++], parent);
         diff(os[oldLastIndex--], ns[newLastIndex--], parent);
@@ -347,9 +347,9 @@ module["exports"] = (function () {
              -> [ a b d ] <- old children
              -> [ a b d ] <- new children
              and now we happy path
-             */ else if (oFirst["key"] === nLast["key"]) {
+             */ else if (oFirst['key'] === nLast['key']) {
         /* insertAfter */
-        parent.insertBefore(oFirst["domRef"], oLast["domRef"].nextSibling);
+        parent.insertBefore(oFirst['domRef'], oLast['domRef'].nextSibling);
         /* swap positions in old vdom */
         os.splice(oldLastIndex, 0, os.splice(oldFirstIndex, 1)[0]);
         diff(os[oldLastIndex--], ns[newLastIndex--], parent);
@@ -361,9 +361,9 @@ module["exports"] = (function () {
          -> [ d b a ] <- old children
          -> [ d b a ] <- new children
          and now we happy path
-         */ else if (oLast["key"] === nFirst["key"]) {
+         */ else if (oLast['key'] === nFirst['key']) {
         /* insertAfter */
-        parent.insertBefore(oLast["domRef"], oFirst["domRef"]);
+        parent.insertBefore(oLast['domRef'], oFirst['domRef']);
         /* swap positions in old vdom */
         os.splice(oldFirstIndex, 0, os.splice(oldLastIndex, 1)[0]);
         diff(os[oldFirstIndex++], nFirst, parent);
@@ -377,7 +377,7 @@ module["exports"] = (function () {
         found = false;
         tmp = oldFirstIndex;
         while (tmp <= oldLastIndex) {
-          if (os[tmp]["key"] === nFirst["key"]) {
+          if (os[tmp]['key'] === nFirst['key']) {
             found = true;
             node = os[tmp];
             break;
@@ -402,7 +402,7 @@ module["exports"] = (function () {
           /* optionally perform `diff` here */
           diff(os[oldFirstIndex++], nFirst, parent);
           /* Swap DOM references */
-          parent.insertBefore(node["domRef"], os[oldFirstIndex]["domRef"]);
+          parent.insertBefore(node['domRef'], os[oldFirstIndex]['domRef']);
           /* increment counters */
           newFirstIndex++;
         } /* If new key was *not* found in the old map this means it must now be created, example below
@@ -418,7 +418,7 @@ module["exports"] = (function () {
                 ^
                 */ else {
           createElement(nFirst, function (ref) {
-            parent.insertBefore(ref, oFirst["domRef"]);
+            parent.insertBefore(ref, oFirst['domRef']);
           });
           os.splice(oldFirstIndex++, 0, nFirst);
           newFirstIndex++;
@@ -494,8 +494,8 @@ module["exports"] = (function () {
     } /* stack not length 1, recurse */ else if (stack.length > 1) {
       parentStack.unshift(obj);
       for (var o = 0; o < obj.children.length; o++) {
-        if (obj["type"] === "vcomp") continue;
-        if (obj.children[o]["domRef"] === stack[1]) {
+        if (obj['type'] === 'vcomp') continue;
+        if (obj.children[o]['domRef'] === stack[1]) {
           delegateEvent(
             event,
             obj.children[o],
@@ -507,14 +507,14 @@ module["exports"] = (function () {
         }
       }
     } /* stack.length == 1 */ else {
-      var eventObj = obj["events"][event.type];
+      var eventObj = obj['events'][event.type];
       if (eventObj) {
-        var options = eventObj["options"];
-        if (options["preventDefault"]) {
+        var options = eventObj['options'];
+        if (options['preventDefault']) {
           event.preventDefault();
         }
-        eventObj["runEvent"](event);
-        if (!options["stopPropagation"]) {
+        eventObj['runEvent'](event);
+        if (!options['stopPropagation']) {
           propagateWhileAble(parentStack, event);
         }
       } else {
@@ -537,12 +537,12 @@ module["exports"] = (function () {
   /* Propagate the event up the chain, invoking other event handlers as encountered */
   var propagateWhileAble = function (parentStack, event) {
     for (var i = 0; i < parentStack.length; i++) {
-      if (parentStack[i]["events"][event.type]) {
-        var eventObj = parentStack[i]["events"][event.type],
-          options = eventObj["options"];
-        if (options["preventDefault"]) event.preventDefault();
-        eventObj["runEvent"](event);
-        if (options["stopPropagation"]) {
+      if (parentStack[i]['events'][event.type]) {
+        var eventObj = parentStack[i]['events'][event.type],
+          options = eventObj['options'];
+        if (options['preventDefault']) event.preventDefault();
+        eventObj['runEvent'](event);
+        if (options['stopPropagation']) {
           event.stopPropagation();
           break;
         }
@@ -556,7 +556,7 @@ module["exports"] = (function () {
   */
   var eventJSON = function (at, obj) {
     /* If at is of type [[MisoString]] */
-    if (typeof at[0] == "object") {
+    if (typeof at[0] == 'object') {
       var ret = [];
       for (var i = 0; i < at.length; i++) {
         ret.push(eventJSON(at[i], obj));
@@ -570,7 +570,7 @@ module["exports"] = (function () {
     var newObj;
     if (
       obj instanceof Array ||
-      ("length" in obj && obj["localName"] !== "select")
+      ('length' in obj && obj['localName'] !== 'select')
     ) {
       newObj = [];
       for (i = 0; i < obj.length; i++) {
@@ -586,17 +586,17 @@ module["exports"] = (function () {
       /* https://stackoverflow.com/a/25569117/453261 */
       /* https://html.spec.whatwg.org/multipage/input.html#do-not-apply */
       if (
-        obj["localName"] === "input" &&
-        (i === "selectionDirection" ||
-          i === "selectionStart" ||
-          i === "selectionEnd")
+        obj['localName'] === 'input' &&
+        (i === 'selectionDirection' ||
+          i === 'selectionStart' ||
+          i === 'selectionEnd')
       ) {
         continue;
       }
       if (
-        typeof obj[i] == "string" ||
-        typeof obj[i] == "number" ||
-        typeof obj[i] == "boolean"
+        typeof obj[i] == 'string' ||
+        typeof obj[i] == 'number' ||
+        typeof obj[i] == 'boolean'
       ) {
         newObj[i] = obj[i];
       }
@@ -622,8 +622,8 @@ module["exports"] = (function () {
     var ax = 0,
       adjusted = vs.length > 0 ? [vs[0]] : [];
     for (var ix = 1; ix < vs.length; ix++) {
-      if (adjusted[ax]["type"] === "vtext" && vs[ix]["type"] === "vtext") {
-        adjusted[ax]["text"] += vs[ix]["text"];
+      if (adjusted[ax]['type'] === 'vtext' && vs[ix]['type'] === 'vtext') {
+        adjusted[ax]['text'] += vs[ix]['text'];
         continue;
       }
       adjusted[++ax] = vs[ix];
@@ -639,20 +639,20 @@ module["exports"] = (function () {
       if (document.body.childNodes.length > 0) {
         node = document.body.firstChild;
       } else {
-        node = document.body.appendChild(document.createElement("div"));
+        node = document.body.appendChild(document.createElement('div'));
       }
     } else if (mountPoint.childNodes.length === 0) {
-      node = mountPoint.appendChild(document.createElement("div"));
+      node = mountPoint.appendChild(document.createElement('div'));
     } else {
       while (
         mountPoint.childNodes[mountChildIdx] &&
         (mountPoint.childNodes[mountChildIdx].nodeType === 3 ||
-          mountPoint.childNodes[mountChildIdx].localName === "script")
+          mountPoint.childNodes[mountChildIdx].localName === 'script')
       ) {
         mountChildIdx++;
       }
       if (!mountPoint.childNodes[mountChildIdx]) {
-        node = document.body.appendChild(document.createElement("div"));
+        node = document.body.appendChild(document.createElement('div'));
       } else {
         node = mountPoint.childNodes[mountChildIdx];
       }
@@ -661,21 +661,21 @@ module["exports"] = (function () {
     if (!walk(logLevel, vtree, node)) {
       if (logLevel) {
         console.warn(
-          "Could not copy DOM into virtual DOM, falling back to diff",
+          'Could not copy DOM into virtual DOM, falling back to diff',
         );
       }
       // Remove all children before rebuilding DOM
       while (node.firstChild) node.removeChild(node.lastChild);
-      vtree["domRef"] = node;
+      vtree['domRef'] = node;
       populate(null, vtree);
       return false;
     } else {
       if (logLevel) {
         var result = integrityCheck(true, vtree);
         if (!result) {
-          console.warn("Integrity check completed with errors");
+          console.warn('Integrity check completed with errors');
         } else {
-          console.info("Successfully prerendered page");
+          console.info('Successfully prerendered page');
         }
       }
     }
@@ -683,12 +683,12 @@ module["exports"] = (function () {
   };
 
   var diagnoseError = function (logLevel, vtree, node) {
-    if (logLevel) console.warn("VTree differed from node", vtree, node);
+    if (logLevel) console.warn('VTree differed from node', vtree, node);
   };
 
   // https://stackoverflow.com/questions/11068240/what-is-the-most-efficient-way-to-parse-a-css-color-in-javascript
   var parseColor = function (input) {
-    if (input.substr(0, 1) == "#") {
+    if (input.substr(0, 1) == '#') {
       var collen = (input.length - 1) / 3;
       var fact = [17, 1, 0.062272][collen - 1];
       return [
@@ -698,9 +698,9 @@ module["exports"] = (function () {
       ];
     } else
       return input
-        .split("(")[1]
-        .split(")")[0]
-        .split(",")
+        .split('(')[1]
+        .split(')')[0]
+        .split(',')
         .map((x) => {
           return +x;
         });
@@ -709,121 +709,121 @@ module["exports"] = (function () {
   // dmj: Does deep equivalence check, spine and leaves of virtual DOM to DOM.
   var integrityCheck = function (result, vtree) {
     // text nodes must be the same
-    if (vtree["type"] == "vtext") {
-      if (vtree["domRef"].nodeType !== 3) {
-        console.warn("VText domRef not a TEXT_NODE", vtree);
+    if (vtree['type'] == 'vtext') {
+      if (vtree['domRef'].nodeType !== 3) {
+        console.warn('VText domRef not a TEXT_NODE', vtree);
         result = false;
-      } else if (vtree["text"] !== vtree["domRef"].textContent) {
-        console.warn("VText node content differs", vtree);
+      } else if (vtree['text'] !== vtree['domRef'].textContent) {
+        console.warn('VText node content differs', vtree);
         result = false;
       }
     } // if vnode / vcomp, must be the same
     else {
       // tags must be identical
-      if (vtree["tag"].toUpperCase() !== vtree["domRef"].tagName) {
+      if (vtree['tag'].toUpperCase() !== vtree['domRef'].tagName) {
         console.warn(
-          "Integrity check failed, tags differ",
-          vtree["tag"].toUpperCase(),
-          vtree["domRef"].tagName,
+          'Integrity check failed, tags differ',
+          vtree['tag'].toUpperCase(),
+          vtree['domRef'].tagName,
         );
         result = false;
       }
       // Child lengths must be identical
       if (
-        "children" in vtree &&
-        vtree["children"].length !== vtree["domRef"].childNodes.length
+        'children' in vtree &&
+        vtree['children'].length !== vtree['domRef'].childNodes.length
       ) {
         console.warn(
-          "Integrity check failed, children lengths differ",
+          'Integrity check failed, children lengths differ',
           vtree,
           vtree.children,
-          vtree["domRef"].childNodes,
+          vtree['domRef'].childNodes,
         );
         result = false;
       }
 
       // properties must be identical
-      var keyLength = Object.keys(vtree["props"]).length,
+      var keyLength = Object.keys(vtree['props']).length,
         key = null;
       for (var i = 0; i < keyLength; i++) {
-        key = Object.keys(vtree["props"])[i];
-        if (key === "href") {
-          var absolute = window.location.origin + "/" + vtree["props"][key],
-            url = vtree["domRef"][key],
-            relative = vtree["props"][key];
+        key = Object.keys(vtree['props'])[i];
+        if (key === 'href') {
+          var absolute = window.location.origin + '/' + vtree['props'][key],
+            url = vtree['domRef'][key],
+            relative = vtree['props'][key];
           if (
             absolute !== url &&
             relative !== url &&
-            relative + "/" !== url &&
-            absolute + "/" !== url
+            relative + '/' !== url &&
+            absolute + '/' !== url
           ) {
             console.warn(
-              "Property " + key + " differs",
-              vtree["props"][key],
-              vtree["domRef"][key],
+              'Property ' + key + ' differs',
+              vtree['props'][key],
+              vtree['domRef'][key],
             );
             result = false;
           }
-        } else if (key === "height" || key === "width") {
+        } else if (key === 'height' || key === 'width') {
           if (
-            parseFloat(vtree["props"][key]) !== parseFloat(vtree["domRef"][key])
+            parseFloat(vtree['props'][key]) !== parseFloat(vtree['domRef'][key])
           ) {
             console.warn(
-              "Property " + key + " differs",
-              vtree["props"][key],
-              vtree["domRef"][key],
+              'Property ' + key + ' differs',
+              vtree['props'][key],
+              vtree['domRef'][key],
             );
             result = false;
           }
-        } else if (key === "class" || key === "className") {
-          if (vtree["props"][key] !== vtree["domRef"].className) {
+        } else if (key === 'class' || key === 'className') {
+          if (vtree['props'][key] !== vtree['domRef'].className) {
             console.warn(
-              "Property class differs",
-              vtree["props"][key],
-              vtree["domRef"].className,
+              'Property class differs',
+              vtree['props'][key],
+              vtree['domRef'].className,
             );
             result = false;
           }
-        } else if (!vtree["domRef"][key]) {
-          if (vtree["props"][key] !== vtree["domRef"].getAttribute(key)) {
+        } else if (!vtree['domRef'][key]) {
+          if (vtree['props'][key] !== vtree['domRef'].getAttribute(key)) {
             console.warn(
-              "Property " + key + " differs",
-              vtree["props"][key],
-              vtree["domRef"].getAttribute(key),
+              'Property ' + key + ' differs',
+              vtree['props'][key],
+              vtree['domRef'].getAttribute(key),
             );
             result = false;
           }
-        } else if (vtree["props"][key] !== vtree["domRef"][key]) {
+        } else if (vtree['props'][key] !== vtree['domRef'][key]) {
           console.warn(
-            "Property " + key + " differs",
-            vtree["props"][key],
-            vtree["domRef"][key],
+            'Property ' + key + ' differs',
+            vtree['props'][key],
+            vtree['domRef'][key],
           );
           result = false;
         }
       }
 
       // styles must be identical
-      keyLength = Object.keys(vtree["css"]).length;
+      keyLength = Object.keys(vtree['css']).length;
       for (i = 0; i < keyLength; i++) {
-        key = Object.keys(vtree["css"])[i];
-        if (key === "color") {
+        key = Object.keys(vtree['css'])[i];
+        if (key === 'color') {
           if (
-            parseColor(vtree["domRef"].style[key]).toString() !==
-            parseColor(vtree["css"][key]).toString()
+            parseColor(vtree['domRef'].style[key]).toString() !==
+            parseColor(vtree['css'][key]).toString()
           ) {
             console.warn(
-              "Style " + key + " differs",
-              vtree["css"][key],
-              vtree["domRef"].style[key],
+              'Style ' + key + ' differs',
+              vtree['css'][key],
+              vtree['domRef'].style[key],
             );
             result = false;
           }
-        } else if (vtree["css"][key] !== vtree["domRef"].style[key]) {
+        } else if (vtree['css'][key] !== vtree['domRef'].style[key]) {
           console.warn(
-            "Style " + key + " differs",
-            vtree["css"][key],
-            vtree["domRef"].style[key],
+            'Style ' + key + ' differs',
+            vtree['css'][key],
+            vtree['domRef'].style[key],
           );
           result = false;
         }
@@ -843,7 +843,7 @@ module["exports"] = (function () {
     // There can thus be fewer DOM nodes than VDOM nodes.
     // We handle this in collapseSiblingTextNodes
     var vdomChild, domChild;
-    vtree["domRef"] = node;
+    vtree['domRef'] = node;
 
     // Fire onCreated events as though the elements had just been created.
     callCreated(vtree);
@@ -851,32 +851,32 @@ module["exports"] = (function () {
     vtree.children = collapseSiblingTextNodes(vtree.children);
 
     for (var i = 0; i < vtree.children.length; i++) {
-      vdomChild = vtree["children"][i];
+      vdomChild = vtree['children'][i];
       domChild = node.childNodes[i];
       if (!domChild) {
         diagnoseError(logLevel, vdomChild, domChild);
         return false;
       }
-      if (vdomChild.type === "vtext") {
+      if (vdomChild.type === 'vtext') {
         if (domChild.nodeType !== 3) {
           diagnoseError(logLevel, vdomChild, domChild);
           return false;
         }
 
-        if (vdomChild["text"] === domChild.textContent) {
-          vdomChild["domRef"] = domChild;
+        if (vdomChild['text'] === domChild.textContent) {
+          vdomChild['domRef'] = domChild;
         } else {
           diagnoseError(logLevel, vdomChild, domChild);
           return false;
         }
-      } else if (vdomChild["type"] === "vcomp") {
-        vdomChild["mount"](function (component) {
+      } else if (vdomChild['type'] === 'vcomp') {
+        vdomChild['mount'](function (component) {
           vdomChild.children.push(component);
           walk(logLevel, vdomChild, domChild);
         });
       } else {
         if (domChild.nodeType !== 1) return false;
-        vdomChild["domRef"] = domChild;
+        vdomChild['domRef'] = domChild;
         walk(logLevel, vdomChild, domChild);
       }
     }
@@ -901,7 +901,7 @@ module["exports"] = (function () {
   };
 
   var setBodyComponent = function (componentId) {
-    document.body.setAttribute("data-component-id", componentId);
+    document.body.setAttribute('data-component-id', componentId);
   };
 
   /* dmj, keep quoted field names so closure-compiler doesn't rename */
@@ -922,6 +922,6 @@ module["exports"] = (function () {
     /* isomorphic */
     'hydrate': hydrate,
     /* version */
-    'version': "1.9.0.0",
+    'version': '1.9.0.0',
   };
 })();

--- a/js/miso.spec.js
+++ b/js/miso.spec.js
@@ -3,18 +3,18 @@
  */
 
 /* custom js imports */
-const miso = require("./miso");
+const miso = require('./miso');
 
 /* smart constructors */
 function vcomp(mount, unmount, props, css, children, ref, oc, od, bd, key) {
   return {
-    type: "vcomp",
-    tag: "div",
+    type: 'vcomp',
+    tag: 'div',
     children: [],
     props: props,
-    "data-component-id": "vcomp-id",
+    'data-component-id': 'vcomp-id',
     css: css,
-    ns: "HTML",
+    ns: 'HTML',
     domRef: ref,
     onCreated: oc,
     onDestroyed: od,
@@ -27,7 +27,7 @@ function vcomp(mount, unmount, props, css, children, ref, oc, od, bd, key) {
 
 function vnode(tag, children, props, css, ns, ref, oc, od, bd, key) {
   return {
-    type: "vnode",
+    type: 'vnode',
     tag: tag,
     children: children,
     props: props,
@@ -43,12 +43,12 @@ function vnode(tag, children, props, css, ns, ref, oc, od, bd, key) {
 
 function vnodeKeyed(tag, key) {
   return {
-    type: "vnode",
+    type: 'vnode',
     tag: tag,
     children: [vtext(key)],
     props: {},
     css: {},
-    ns: "HTML",
+    ns: 'HTML',
     domRef: null,
     onCreated: null,
     onDestroyed: null,
@@ -59,12 +59,12 @@ function vnodeKeyed(tag, key) {
 
 function vnodeKids(tag, kids) {
   return {
-    type: "vnode",
+    type: 'vnode',
     tag: tag,
     children: kids,
     props: {},
     css: {},
-    ns: "HTML",
+    ns: 'HTML',
     domRef: null,
     onCreated: null,
     onDestroyed: null,
@@ -74,26 +74,26 @@ function vnodeKids(tag, kids) {
 
 function vtext(txt) {
   return {
-    type: "vtext",
+    type: 'vtext',
     text: txt,
   };
 }
 
 function vtextKeyed(txt, key) {
   return {
-    type: "vtext",
+    type: 'vtext',
     text: txt,
     key: key,
   };
 }
 
-describe("miso.js tests", () => {
+describe('miso.js tests', () => {
   /* Reset DOM before each test */
   beforeEach(() => {
-    document.body.innerHTML = "";
+    document.body.innerHTML = '';
   });
 
-  test("Should be null when miso.diffing two null virtual DOMs", () => {
+  test('Should be null when miso.diffing two null virtual DOMs', () => {
     var document = window.document;
     const body = document.body;
     var c = null;
@@ -102,57 +102,57 @@ describe("miso.js tests", () => {
     expect(body.childNodes.length).toBe(0);
   });
 
-  test("Should create a new text node", () => {
+  test('Should create a new text node', () => {
     const body = document.body;
     var newNode = {
-      type: "vtext",
-      text: "foo",
+      type: 'vtext',
+      text: 'foo',
     };
     miso.diff(null, newNode, body);
-    expect(newNode.domRef.wholeText).toBe("foo");
+    expect(newNode.domRef.wholeText).toBe('foo');
   });
 
-  test("Should window miso.diff two identical text nodes", () => {
+  test('Should window miso.diff two identical text nodes', () => {
     const body = document.body;
     var currentNode = {
-      type: "vtext",
-      text: "foo",
+      type: 'vtext',
+      text: 'foo',
     };
     miso.diff(null, currentNode, body);
-    expect(currentNode.domRef.wholeText).toBe("foo");
+    expect(currentNode.domRef.wholeText).toBe('foo');
     var newNode = {
-      type: "vtext",
-      text: "foo",
+      type: 'vtext',
+      text: 'foo',
     };
     miso.diff(currentNode, newNode, body);
-    expect("foo").toBe(newNode.domRef.wholeText);
+    expect('foo').toBe(newNode.domRef.wholeText);
   });
 
-  test("Should window miso.diff two window miso.different text nodes", () => {
+  test('Should window miso.diff two window miso.different text nodes', () => {
     const body = document.body;
     var currentNode = {
-      type: "vtext",
-      text: "foo",
+      type: 'vtext',
+      text: 'foo',
     };
     miso.diff(null, currentNode, body);
-    expect(currentNode.domRef.wholeText).toBe("foo");
+    expect(currentNode.domRef.wholeText).toBe('foo');
     var newNode = {
-      type: "vtext",
-      text: "bar",
+      type: 'vtext',
+      text: 'bar',
     };
     miso.diff(currentNode, newNode, body);
-    expect(newNode.domRef.wholeText).toBe("bar");
+    expect(newNode.domRef.wholeText).toBe('bar');
   });
 
-  test("Should create a new DOM node", () => {
+  test('Should create a new DOM node', () => {
     var body = document.body;
     var currentNode = null;
-    var newNode = vnode("div", []);
+    var newNode = vnode('div', []);
     miso.diff(currentNode, newNode, body);
     expect(body.children[0]).toBe(newNode.domRef);
   });
 
-  test("Should detect duplicate component mounting", () => {
+  test('Should detect duplicate component mounting', () => {
     var body = document.body;
     var mountCount = 0;
     var newComp1 = vcomp(
@@ -160,8 +160,8 @@ describe("miso.js tests", () => {
         return mountCount++;
       },
       null,
-      { "data-component-id": "vcomp-foo" },
-      { "background-color": "red" },
+      { 'data-component-id': 'vcomp-foo' },
+      { 'background-color': 'red' },
       [],
     );
     miso.diff(null, newComp1, body);
@@ -170,22 +170,22 @@ describe("miso.js tests", () => {
         return mountCount++;
       },
       null,
-      { "data-component-id": "vcomp-foo" },
-      { "background-color": "red" },
+      { 'data-component-id': 'vcomp-foo' },
+      { 'background-color': 'red' },
       [],
     );
-    var newNode = vnode("div", [newComp2], {}, {}, "svg");
+    var newNode = vnode('div', [newComp2], {}, {}, 'svg');
     miso.diff(null, newNode, body);
     expect(mountCount).toBe(1);
   });
 
-  test("Should mount and unmount a component", () => {
+  test('Should mount and unmount a component', () => {
     var body = document.body;
     var mountCount = 0;
     var unmountCount = 0;
     var mountFunc = function (cb) {
       mountCount++;
-      var node = vnode("div", []);
+      var node = vnode('div', []);
       miso.diff(null, node, body);
       cb(node);
     };
@@ -194,9 +194,9 @@ describe("miso.js tests", () => {
       () => {
         return unmountCount++;
       },
-      { id: "vcomp-foo" },
+      { id: 'vcomp-foo' },
       {
-        "background-color": "red",
+        'background-color': 'red',
       },
       [],
     );
@@ -204,162 +204,162 @@ describe("miso.js tests", () => {
     expect(mountCount).toBe(1);
     expect(newNode.children.length).toBe(1);
     expect(newNode.domRef.children.length).toBe(1);
-    expect(newNode.domRef.id).toBe("vcomp-foo");
-    expect(newNode.domRef.style["background-color"]).toBe("red");
+    expect(newNode.domRef.id).toBe('vcomp-foo');
+    expect(newNode.domRef.style['background-color']).toBe('red');
     miso.diff(newNode, null, body);
     expect(unmountCount).toBe(1);
   });
 
-  test("Should create an SVG DOM node", () => {
+  test('Should create an SVG DOM node', () => {
     var body = document.body;
     var currentNode = null;
-    var newNode = vnode("div", [], {}, {}, "svg");
+    var newNode = vnode('div', [], {}, {}, 'svg');
     miso.diff(currentNode, newNode, body);
     expect(body.children[0]).toBe(newNode.domRef);
   });
 
-  test("Should create a MathML DOM node", () => {
+  test('Should create a MathML DOM node', () => {
     var body = document.body;
     var currentNode = null;
-    var newNode = vnode("math", [], {}, {}, "mathml");
+    var newNode = vnode('math', [], {}, {}, 'mathml');
     miso.diff(currentNode, newNode, body);
     expect(body.children[0]).toBe(newNode.domRef);
   });
 
-  test("Should create an SVG DOM node, with href attribute", () => {
+  test('Should create an SVG DOM node, with href attribute', () => {
     var body = document.body;
     var currentNode = null;
     var newNode = vnode(
-      "ellipse",
+      'ellipse',
       [],
       {
-        href: "https://google.com",
+        href: 'https://google.com',
       },
       {},
-      "svg",
+      'svg',
     );
     miso.diff(currentNode, newNode, body);
     expect(
-      body.children[0].getAttributeNS("http://www.w3.org/1999/xlink", "href"),
-    ).toBe("https://google.com");
+      body.children[0].getAttributeNS('http://www.w3.org/1999/xlink', 'href'),
+    ).toBe('https://google.com');
   });
 
-  test("Should create an SVG DOM node, with href attribute, and change it", () => {
+  test('Should create an SVG DOM node, with href attribute, and change it', () => {
     var body = document.body;
     var currentNode = null;
     var newNode = vnode(
-      "ellipse",
+      'ellipse',
       [],
       {
-        href: "https://google.com",
+        href: 'https://google.com',
       },
       {},
-      "svg",
+      'svg',
     );
     miso.diff(currentNode, newNode, body);
     expect(
-      body.children[0].getAttributeNS("http://www.w3.org/1999/xlink", "href"),
-    ).toBe("https://google.com");
+      body.children[0].getAttributeNS('http://www.w3.org/1999/xlink', 'href'),
+    ).toBe('https://google.com');
     var newerNode = vnode(
-      "ellipse",
+      'ellipse',
       [],
       {
-        href: "https://yahoo.com",
+        href: 'https://yahoo.com',
       },
       {},
-      "svg",
+      'svg',
     );
     miso.diff(newNode, newerNode, body);
     expect(
-      body.children[0].getAttributeNS("http://www.w3.org/1999/xlink", "href"),
-    ).toBe("https://yahoo.com");
+      body.children[0].getAttributeNS('http://www.w3.org/1999/xlink', 'href'),
+    ).toBe('https://yahoo.com');
   });
 
-  test("Should create an SVG DOM node, with regular attribute", () => {
+  test('Should create an SVG DOM node, with regular attribute', () => {
     var body = document.body;
     var currentNode = null;
     var newNode = vnode(
-      "ellipse",
+      'ellipse',
       [],
       {
-        rx: "100",
+        rx: '100',
       },
       {},
-      "svg",
+      'svg',
     );
     miso.diff(currentNode, newNode, body);
-    expect(body.children[0].getAttribute("rx")).toBe("100");
+    expect(body.children[0].getAttribute('rx')).toBe('100');
   });
 
-  test("Should create an SVG DOM node, with regular attribute, and change it", () => {
+  test('Should create an SVG DOM node, with regular attribute, and change it', () => {
     var body = document.body;
     var currentNode = null;
     var newNode = vnode(
-      "ellipse",
+      'ellipse',
       [],
       {
-        rx: "100",
+        rx: '100',
       },
       {},
-      "svg",
+      'svg',
     );
     miso.diff(currentNode, newNode, body);
-    expect(body.children[0].getAttribute("rx")).toBe("100");
+    expect(body.children[0].getAttribute('rx')).toBe('100');
     var newerNode = vnode(
-      "ellipse",
+      'ellipse',
       [],
       {
-        rx: "200",
+        rx: '200',
       },
       {},
-      "svg",
+      'svg',
     );
     miso.diff(newNode, newerNode, body);
-    expect(body.children[0].getAttribute("rx")).toBe("200");
+    expect(body.children[0].getAttribute('rx')).toBe('200');
   });
 
-  test("Should replace a Node with a new Node of a window miso.different tag", () => {
+  test('Should replace a Node with a new Node of a window miso.different tag', () => {
     var body = document.body;
 
     // populate DOM
-    var node = vnode("div", []);
+    var node = vnode('div', []);
     miso.diff(null, node, body);
 
     // Test node was populated
     expect(body.children.length).toBe(1);
 
     // Replace node
-    var newNode = vnode("a", []);
+    var newNode = vnode('a', []);
     miso.diff(node, newNode, body);
 
     // Test node is removed from DOM
-    expect(body.children[0].tagName).toBe("A");
+    expect(body.children[0].tagName).toBe('A');
   });
 
-  test("Should create children", () => {
+  test('Should create children', () => {
     var body = document.body;
 
     // populate DOM
-    var node = vnode("div", [vnode("div", [])]);
+    var node = vnode('div', [vnode('div', [])]);
     miso.diff(null, node, body);
     expect(node.domRef.children.length).toBe(1);
   });
 
-  test("Should remove a child", () => {
+  test('Should remove a child', () => {
     var body = document.body;
 
     // populate DOM
-    var node = vnode("div", [vnode("div", [])]);
+    var node = vnode('div', [vnode('div', [])]);
     miso.diff(null, node, body);
     expect(node.domRef.children.length).toBe(1);
 
     // populate DOM
-    var newNode = vnode("div", []);
+    var newNode = vnode('div', []);
     miso.diff(node, newNode, body);
     expect(node.domRef.children.length).toBe(0);
   });
 
-  test("Should Miso.Diff attrs of two Components", () => {
+  test('Should Miso.Diff attrs of two Components', () => {
     var body = document.body;
 
     // populate DOM
@@ -370,9 +370,9 @@ describe("miso.js tests", () => {
       },
       null,
       {
-        "data-component-id": "vcomp-foo",
+        'data-component-id': 'vcomp-foo',
       },
-      { "background-color": "red" },
+      { 'background-color': 'red' },
     );
 
     miso.diff(null, compNode1, body);
@@ -380,7 +380,7 @@ describe("miso.js tests", () => {
 
     // Test node was populated
     expect(body.childNodes.length).toBe(1);
-    expect(body.childNodes[0].style["background-color"]).toBe("red");
+    expect(body.childNodes[0].style['background-color']).toBe('red');
 
     // Replace node
     mountCount = 0;
@@ -390,20 +390,20 @@ describe("miso.js tests", () => {
       },
       null,
       {
-        "data-component-id": "vcomp-foo",
+        'data-component-id': 'vcomp-foo',
       },
-      { "background-color": "green" },
+      { 'background-color': 'green' },
     );
 
     miso.diff(compNode1, compNode2, body);
-    expect(body.childNodes[0].style["background-color"]).toBe("green");
+    expect(body.childNodes[0].style['background-color']).toBe('green');
   });
 
-  test("Should replace Node with Component", () => {
+  test('Should replace Node with Component', () => {
     var body = document.body;
 
     // populate DOM
-    var node = vnode("div", []);
+    var node = vnode('div', []);
     miso.diff(null, node, body);
 
     // Test node was populated
@@ -417,21 +417,21 @@ describe("miso.js tests", () => {
     miso.diff(node, compNode, body);
 
     // Node is removed from DOM, Component is on the DOM
-    expect(body.childNodes[0].getAttribute("data-component-id")).toBe(
-      "vcomp-id",
+    expect(body.childNodes[0].getAttribute('data-component-id')).toBe(
+      'vcomp-id',
     );
     expect(mountCount).toBe(1);
   });
 
-  test("Should replace Text with Component", () => {
+  test('Should replace Text with Component', () => {
     var body = document.body;
 
     // populate DOM
-    var node = vtext("foo");
+    var node = vtext('foo');
     miso.diff(null, node, body);
 
     // Test node was populated
-    expect(node.domRef.wholeText).toBe("foo");
+    expect(node.domRef.wholeText).toBe('foo');
     expect(body.childNodes.length).toBe(1);
 
     // Replace node
@@ -442,31 +442,31 @@ describe("miso.js tests", () => {
     miso.diff(node, compNode, body);
 
     // Node is removed from DOM, Component is on the DOM
-    expect(body.childNodes[0].getAttribute("data-component-id")).toBe(
-      "vcomp-id",
+    expect(body.childNodes[0].getAttribute('data-component-id')).toBe(
+      'vcomp-id',
     );
     expect(mountCount).toBe(1);
   });
 
-  test("Should replace Node with TextNode", () => {
+  test('Should replace Node with TextNode', () => {
     var body = document.body;
 
     // populate DOM
-    var node = vnode("div", []);
+    var node = vnode('div', []);
     miso.diff(null, node, body);
 
     // Test node was populated
     expect(body.childNodes.length).toBe(1);
 
     // Replace node
-    var textNode = vtext("fooo");
+    var textNode = vtext('fooo');
     miso.diff(node, textNode, body);
 
     // Test node is removed from DOM
-    expect(body.childNodes[0].wholeText).toBe("fooo");
+    expect(body.childNodes[0].wholeText).toBe('fooo');
   });
 
-  test("Should replace Component with TextNode", () => {
+  test('Should replace Component with TextNode', () => {
     var body = document.body;
 
     // populate DOM
@@ -488,15 +488,15 @@ describe("miso.js tests", () => {
     expect(unmountCount).toBe(0);
 
     // Replace component
-    var textNode = vtext("fooo");
+    var textNode = vtext('fooo');
     miso.diff(component, textNode, body);
 
     // Test node is removed from DOM
-    expect(body.childNodes[0].wholeText).toBe("fooo");
+    expect(body.childNodes[0].wholeText).toBe('fooo');
     expect(unmountCount).toBe(1);
   });
 
-  test("Should replace Component with Node", () => {
+  test('Should replace Component with Node', () => {
     var body = document.body;
 
     // populate DOM
@@ -518,38 +518,38 @@ describe("miso.js tests", () => {
     expect(unmountCount).toBe(0);
 
     // Replace component
-    var node = vnode("div", []);
+    var node = vnode('div', []);
     miso.diff(component, node, body);
 
     // Test node is removed from DOM
-    expect(body.children[0].tagName).toBe("DIV");
+    expect(body.children[0].tagName).toBe('DIV');
     expect(unmountCount).toBe(1);
   });
 
-  test("Should replace TextNode with Node", () => {
+  test('Should replace TextNode with Node', () => {
     var body = document.body;
 
     // populate DOM
-    var textNode = vtext("fooo");
+    var textNode = vtext('fooo');
     miso.diff(null, textNode, body);
 
     // Test node was populated
     expect(body.childNodes.length).toBe(1);
 
     // Replace node
-    var node = vnode("div", []);
+    var node = vnode('div', []);
     miso.diff(textNode, node, body);
 
     // Test node is removed from DOM
-    expect(body.children[0].tagName).toBe("DIV");
+    expect(body.children[0].tagName).toBe('DIV');
   });
 
-  test("Should remove a DOM node", () => {
+  test('Should remove a DOM node', () => {
     var body = document.body;
 
     // populate DOM
     var currentNode = null;
-    var newNode = vnode("div", []);
+    var newNode = vnode('div', []);
     miso.diff(currentNode, newNode, body);
 
     // Test node was populated
@@ -562,226 +562,226 @@ describe("miso.js tests", () => {
     expect(body.children.length).toBe(0);
   });
 
-  test("Should create a new property on a DOM node", () => {
+  test('Should create a new property on a DOM node', () => {
     var body = document.body;
 
     // populate DOM
-    var currentNode = vnode("div", [], {
-      id: "a",
+    var currentNode = vnode('div', [], {
+      id: 'a',
     });
     miso.diff(null, currentNode, body);
-    expect(currentNode.domRef["id"]).toBe("a");
+    expect(currentNode.domRef['id']).toBe('a');
   });
 
-  test("Should skip if window miso.diffing identical properties", () => {
+  test('Should skip if window miso.diffing identical properties', () => {
     var body = document.body;
 
     // populate DOM
-    var currentNode = vnode("div", [], {
-      id: "a",
+    var currentNode = vnode('div', [], {
+      id: 'a',
     });
     miso.diff(null, currentNode, body);
 
-    var newNode = vnode("div", [], {
-      id: "a",
+    var newNode = vnode('div', [], {
+      id: 'a',
     });
     miso.diff(currentNode, newNode, body);
     expect(currentNode.domRef).toBe(newNode.domRef);
   });
 
-  test("Should create a custom attribute on a DOM node", () => {
+  test('Should create a custom attribute on a DOM node', () => {
     var body = document.body;
 
     // populate DOM
     var currentNode = vnode(
-      "div",
+      'div',
       [],
       {
-        lol: "lol",
+        lol: 'lol',
       },
       {},
     );
     miso.diff(null, currentNode, body);
-    expect(currentNode.domRef.getAttribute("lol")).toBe("lol");
+    expect(currentNode.domRef.getAttribute('lol')).toBe('lol');
   });
 
-  test("Should change a custom attribute on a DOM node", () => {
+  test('Should change a custom attribute on a DOM node', () => {
     var body = document.body;
 
     // populate DOM
     var currentNode = vnode(
-      "div",
+      'div',
       [],
       {
-        lol: "lol",
+        lol: 'lol',
       },
       {},
     );
     miso.diff(null, currentNode, body);
-    expect(currentNode.domRef.getAttribute("lol")).toBe("lol");
+    expect(currentNode.domRef.getAttribute('lol')).toBe('lol');
 
     var newNode = vnode(
-      "div",
+      'div',
       [],
       {
-        lol: "lolz",
+        lol: 'lolz',
       },
       {},
     );
     miso.diff(currentNode, newNode, body);
-    expect(currentNode.domRef.getAttribute("lol")).toBe("lolz");
+    expect(currentNode.domRef.getAttribute('lol')).toBe('lolz');
   });
 
-  test("Should remove a custom attribute from a DOM node", () => {
+  test('Should remove a custom attribute from a DOM node', () => {
     var body = document.body;
 
     // populate DOM
-    var currentNode = vnode("div", [], {
-      lol: "lol",
+    var currentNode = vnode('div', [], {
+      lol: 'lol',
     });
     miso.diff(null, currentNode, body);
-    expect(currentNode.domRef.getAttribute("lol")).toBe("lol");
+    expect(currentNode.domRef.getAttribute('lol')).toBe('lol');
 
     // test property change
-    var newNode = vnode("div", [], {});
+    var newNode = vnode('div', [], {});
     miso.diff(currentNode, newNode, body);
-    expect(newNode.domRef.getAttribute("lol")).toBe(null);
+    expect(newNode.domRef.getAttribute('lol')).toBe(null);
   });
 
-  test("Should remove a property from DOM node", () => {
+  test('Should remove a property from DOM node', () => {
     var body = document.body;
 
     // populate DOM
-    var currentNode = vnode("div", [], {
-      id: "someid",
-    });
-    miso.diff(null, currentNode, body);
-
-    // test property change
-    var newNode = vnode("div", [], {});
-    miso.diff(currentNode, newNode, body);
-    expect(newNode.domRef["id"]).toBe("");
-  });
-
-  test("Should change a property from DOM node", () => {
-    var body = document.body;
-
-    // populate DOM
-    var currentNode = vnode("div", [], {
-      id: "someid",
+    var currentNode = vnode('div', [], {
+      id: 'someid',
     });
     miso.diff(null, currentNode, body);
 
     // test property change
-    var newNode = vnode("div", [], {
-      id: "foo",
-    });
+    var newNode = vnode('div', [], {});
     miso.diff(currentNode, newNode, body);
-    expect(newNode.domRef["id"]).toBe("foo");
+    expect(newNode.domRef['id']).toBe('');
   });
 
-  test("Should create css on a DOM node", () => {
+  test('Should change a property from DOM node', () => {
+    var body = document.body;
+
+    // populate DOM
+    var currentNode = vnode('div', [], {
+      id: 'someid',
+    });
+    miso.diff(null, currentNode, body);
+
+    // test property change
+    var newNode = vnode('div', [], {
+      id: 'foo',
+    });
+    miso.diff(currentNode, newNode, body);
+    expect(newNode.domRef['id']).toBe('foo');
+  });
+
+  test('Should create css on a DOM node', () => {
     var body = document.body;
 
     // populate DOM
     var newNode = vnode(
-      "div",
+      'div',
       [],
       {},
       {
-        color: "red",
+        color: 'red',
       },
     );
     miso.diff(null, newNode, body);
-    expect(newNode.domRef.style["color"]).toBe("red");
+    expect(newNode.domRef.style['color']).toBe('red');
   });
 
-  test("Should remove css from DOM node", () => {
+  test('Should remove css from DOM node', () => {
     var body = document.body;
 
     // populate DOM
     var currentNode = vnode(
-      "div",
+      'div',
       [],
       {},
       {
-        color: "red",
+        color: 'red',
       },
     );
     miso.diff(null, currentNode, body);
 
     // test css change
-    var newNode = vnode("div", [], {}, {});
+    var newNode = vnode('div', [], {}, {});
     miso.diff(currentNode, newNode, body);
-    expect(newNode.domRef.style["color"]).toBe("");
+    expect(newNode.domRef.style['color']).toBe('');
   });
 
-  test("Should change css on a DOM node", () => {
+  test('Should change css on a DOM node', () => {
     var body = document.body;
 
     // populate DOM
     var currentNode = vnode(
-      "div",
+      'div',
       [],
       {},
       {
-        color: "red",
+        color: 'red',
       },
     );
     miso.diff(null, currentNode, body);
 
     // test css change
     var newNode = vnode(
-      "div",
+      'div',
       [],
       {},
       {
-        color: "blue",
+        color: 'blue',
       },
     );
     miso.diff(currentNode, newNode, body);
-    expect(newNode.domRef.style["color"]).toBe("blue");
+    expect(newNode.domRef.style['color']).toBe('blue');
   });
 
-  test("Should no-op change to css on a DOM node", () => {
+  test('Should no-op change to css on a DOM node', () => {
     var body = document.body;
 
     // populate DOM
     var currentNode = vnode(
-      "div",
+      'div',
       [],
       {},
       {
-        color: "red",
+        color: 'red',
       },
     );
     miso.diff(null, currentNode, body);
 
     // test css no-op change
     var newNode = vnode(
-      "div",
+      'div',
       [],
       {},
       {
-        color: "red",
+        color: 'red',
       },
     );
     miso.diff(currentNode, newNode, body);
-    expect(newNode.domRef.style["color"]).toBe("red");
+    expect(newNode.domRef.style['color']).toBe('red');
   });
 
-  test("Should call onCreated and onDestroyed", () => {
+  test('Should call onCreated and onDestroyed', () => {
     var body = document.body;
 
     // populate DOM
     var create = 0,
       destroy = 0;
     var currentNode = vnode(
-      "div",
+      'div',
       [],
       {},
       {},
-      "html",
+      'html',
       null,
       function () {
         create++;
@@ -790,7 +790,7 @@ describe("miso.js tests", () => {
         destroy++;
       },
       null,
-      "key",
+      'key',
     );
 
     miso.diff(null, currentNode, body);
@@ -800,18 +800,18 @@ describe("miso.js tests", () => {
     expect(destroy).toBe(1);
   });
 
-  test("Should call onCreated and onBeforeDestroyed", () => {
+  test('Should call onCreated and onBeforeDestroyed', () => {
     var body = document.body;
 
     // populate DOM
     var create = 0,
       destroy = 0;
     var currentNode = vnode(
-      "div",
+      'div',
       [],
       {},
       {},
-      "html",
+      'html',
       null,
       function () {
         create++;
@@ -820,7 +820,7 @@ describe("miso.js tests", () => {
       function () {
         destroy++;
       },
-      "key",
+      'key',
     );
 
     miso.diff(null, currentNode, body);
@@ -830,39 +830,39 @@ describe("miso.js tests", () => {
     expect(destroy).toBe(1);
   });
 
-  test("Should call onDestroyed recursively", () => {
+  test('Should call onDestroyed recursively', () => {
     var body = document.body;
     // populate DOM
     var destroy = 0,
       childDestroy = 0;
     var currentNode = vnode(
-      "div",
+      'div',
       [
         vnode(
-          "div",
+          'div',
           [],
           {},
           {},
-          "html",
+          'html',
           null,
           null,
           function () {
             childDestroy++;
           },
           null,
-          "a",
+          'a',
         ),
       ],
       {},
       {},
-      "html",
+      'html',
       null,
       null,
       function () {
         destroy++;
       },
       null,
-      "b",
+      'b',
     );
     miso.diff(null, currentNode, body);
     miso.diff(currentNode, null, body);
@@ -870,39 +870,39 @@ describe("miso.js tests", () => {
     expect(childDestroy).toBe(1);
   });
 
-  test("Should call onBeforeDestroyed recursively", () => {
+  test('Should call onBeforeDestroyed recursively', () => {
     var body = document.body;
     // populate DOM
     var destroy = 0;
     var childDestroy = 0;
     var currentNode = vnode(
-      "div",
+      'div',
       [
         vnode(
-          "div",
+          'div',
           [],
           {},
           {},
-          "html",
+          'html',
           null,
           null,
           null,
           function () {
             childDestroy++;
           },
-          "a",
+          'a',
         ),
       ],
       {},
       {},
-      "html",
+      'html',
       null,
       null,
       null,
       function () {
         destroy++;
       },
-      "b",
+      'b',
     );
     miso.diff(null, currentNode, body);
     miso.diff(currentNode, null, body);
@@ -910,85 +910,85 @@ describe("miso.js tests", () => {
     expect(childDestroy).toBe(1);
   });
 
-  test("Should recreate a DOM node when tags are the same but keys are window miso.different", () => {
+  test('Should recreate a DOM node when tags are the same but keys are window miso.different', () => {
     var body = document.body;
     var destroy = 0;
     var currentNode = vnode(
-      "div",
+      'div',
       [],
       {},
       {},
-      "html",
+      'html',
       null,
       null,
       function () {
         destroy++;
       },
       null,
-      "key-1",
+      'key-1',
     );
     miso.diff(null, currentNode, body);
     var newNode = vnode(
-      "div",
+      'div',
       [],
       {},
       {},
-      "html",
+      'html',
       null,
       null,
       function () {
         destroy++;
       },
       null,
-      "key-1",
+      'key-1',
     );
     miso.diff(null, currentNode, body);
     expect(destroy).toBe(0);
     miso.diff(currentNode, newNode, body);
     var newKeyedNode = vnode(
-      "div",
+      'div',
       [],
       {},
       {},
-      "html",
+      'html',
       null,
       null,
       function () {
         destroy++;
       },
       null,
-      "key-2",
+      'key-2',
     );
     miso.diff(currentNode, newKeyedNode, body);
     expect(destroy).toBe(1);
   });
 
-  test("Should execute left-hand side happy path key-window miso.diffing case", () => {
+  test('Should execute left-hand side happy path key-window miso.diffing case', () => {
     var body = document.body;
     var currentNode = vnode(
-      "div",
-      [vnodeKeyed("div", "a"), vnodeKeyed("div", "b"), vnodeKeyed("div", "c")],
+      'div',
+      [vnodeKeyed('div', 'a'), vnodeKeyed('div', 'b'), vnodeKeyed('div', 'c')],
       {},
       {},
-      "html",
+      'html',
       null,
       null,
       null,
       null,
-      "key-1",
+      'key-1',
     );
     miso.diff(null, currentNode, body);
     var newNode = vnode(
-      "div",
-      [vnodeKeyed("div", "a"), vnodeKeyed("div", "b"), vnodeKeyed("div", "c")],
+      'div',
+      [vnodeKeyed('div', 'a'), vnodeKeyed('div', 'b'), vnodeKeyed('div', 'c')],
       {},
       {},
-      "html",
+      'html',
       null,
       null,
       null,
       null,
-      "key-1",
+      'key-1',
     );
     miso.diff(currentNode, newNode, body);
     expect(newNode.children.length).toBe(3);
@@ -998,32 +998,32 @@ describe("miso.js tests", () => {
     expect(currentNode.domRef.childNodes).toEqual(newNode.domRef.childNodes);
   });
 
-  test("Should miso.diff keys properly when keys are prepended", () => {
+  test('Should miso.diff keys properly when keys are prepended', () => {
     var body = document.body;
     var currentNode = vnode(
-      "div",
-      [vnodeKeyed("div", "1")],
+      'div',
+      [vnodeKeyed('div', '1')],
       {},
       {},
-      "html",
+      'html',
       null,
       null,
       null,
       null,
-      "key-1",
+      'key-1',
     );
     miso.diff(null, currentNode, body);
     var newNode = vnode(
-      "div",
-      [vnodeKeyed("div", "2"), vnodeKeyed("div", "1")],
+      'div',
+      [vnodeKeyed('div', '2'), vnodeKeyed('div', '1')],
       {},
       {},
-      "html",
+      'html',
       null,
       null,
       null,
       null,
-      "key-1",
+      'key-1',
     );
     miso.diff(currentNode, newNode, body);
     expect(newNode.children.length).toBe(2);
@@ -1033,32 +1033,32 @@ describe("miso.js tests", () => {
     expect(currentNode.domRef.childNodes).toEqual(newNode.domRef.childNodes);
   });
 
-  test("Should execute right-hand side happy path key-window miso.diffing case", () => {
+  test('Should execute right-hand side happy path key-window miso.diffing case', () => {
     var body = document.body;
     var currentNode = vnode(
-      "div",
-      [vnodeKeyed("div", "a"), vnodeKeyed("div", "c")],
+      'div',
+      [vnodeKeyed('div', 'a'), vnodeKeyed('div', 'c')],
       {},
       {},
-      "html",
+      'html',
       null,
       null,
       null,
       null,
-      "key-1",
+      'key-1',
     );
     miso.diff(null, currentNode, body);
     var newNode = vnode(
-      "div",
-      [vnodeKeyed("div", "z"), vnodeKeyed("div", "c")],
+      'div',
+      [vnodeKeyed('div', 'z'), vnodeKeyed('div', 'c')],
       {},
       {},
-      "html",
+      'html',
       null,
       null,
       null,
       null,
-      "key-1",
+      'key-1',
     );
     miso.diff(currentNode, newNode, body);
     expect(newNode.children.length).toBe(2);
@@ -1068,32 +1068,32 @@ describe("miso.js tests", () => {
     expect(currentNode.domRef.childNodes).toEqual(newNode.domRef.childNodes);
   });
 
-  test("Should swap nodes", () => {
+  test('Should swap nodes', () => {
     var body = document.body;
     var currentNode = vnode(
-      "div",
-      [vnodeKeyed("div", "a"), vnodeKeyed("div", "b")],
+      'div',
+      [vnodeKeyed('div', 'a'), vnodeKeyed('div', 'b')],
       {},
       {},
-      "html",
+      'html',
       null,
       null,
       null,
       null,
-      "key-1",
+      'key-1',
     );
     miso.diff(null, currentNode, body);
     var newNode = vnode(
-      "div",
-      [vnodeKeyed("div", "b"), vnodeKeyed("div", "a")],
+      'div',
+      [vnodeKeyed('div', 'b'), vnodeKeyed('div', 'a')],
       {},
       {},
-      "html",
+      'html',
       null,
       null,
       null,
       null,
-      "key-1",
+      'key-1',
     );
     miso.diff(currentNode, newNode, body);
     expect(newNode.children.length).toBe(2);
@@ -1103,32 +1103,32 @@ describe("miso.js tests", () => {
     expect(currentNode.domRef.childNodes).toEqual(newNode.domRef.childNodes);
   });
 
-  test("Should execute flip-flop case", () => {
+  test('Should execute flip-flop case', () => {
     var body = document.body;
     var currentNode = vnode(
-      "div",
-      [vnodeKeyed("div", "a"), vnodeKeyed("div", "b"), vnodeKeyed("div", "c")],
+      'div',
+      [vnodeKeyed('div', 'a'), vnodeKeyed('div', 'b'), vnodeKeyed('div', 'c')],
       {},
       {},
-      "html",
+      'html',
       null,
       null,
       null,
       null,
-      "key-1",
+      'key-1',
     );
     miso.diff(null, currentNode, body);
     var newNode = vnode(
-      "div",
-      [vnodeKeyed("div", "c"), vnodeKeyed("div", "b"), vnodeKeyed("div", "a")],
+      'div',
+      [vnodeKeyed('div', 'c'), vnodeKeyed('div', 'b'), vnodeKeyed('div', 'a')],
       {},
       {},
-      "html",
+      'html',
       null,
       null,
       null,
       null,
-      "key-1",
+      'key-1',
     );
     miso.diff(currentNode, newNode, body);
     expect(newNode.children.length).toBe(3);
@@ -1142,46 +1142,46 @@ describe("miso.js tests", () => {
     }
   });
 
-  test("Should execute swapped case on 1k nodes", () => {
+  test('Should execute swapped case on 1k nodes', () => {
     var body = document.body;
     var kids = [];
-    for (var i = 1; i < 1001; i++) kids.push(vnodeKeyed("div", i));
+    for (var i = 1; i < 1001; i++) kids.push(vnodeKeyed('div', i));
 
     var currentNode = vnode(
-      "div",
+      'div',
       kids,
       {},
       {},
-      "html",
+      'html',
       null,
       null,
       null,
       null,
-      "key-1",
+      'key-1',
     );
 
     var newKids = [];
     for (i = 1; i < 1001; i++) {
       if (i == 3) {
-        newKids.push(vnodeKeyed("div", 999));
+        newKids.push(vnodeKeyed('div', 999));
       } else if (i == 999) {
-        newKids.push(vnodeKeyed("div", 3));
+        newKids.push(vnodeKeyed('div', 3));
       } else {
-        newKids.push(vnodeKeyed("div", i));
+        newKids.push(vnodeKeyed('div', i));
       }
     }
     miso.diff(null, currentNode, body);
     var newNode = vnode(
-      "div",
+      'div',
       newKids,
       {},
       {},
-      "html",
+      'html',
       null,
       null,
       null,
       null,
-      "key-1",
+      'key-1',
     );
     miso.diff(currentNode, newNode, body);
     expect(newNode.children.length).toBe(1000);
@@ -1200,44 +1200,44 @@ describe("miso.js tests", () => {
     }
   });
 
-  test("Should execute top-left and bottom-right match case", () => {
+  test('Should execute top-left and bottom-right match case', () => {
     var body = document.body;
     var currentNode = vnode(
-      "div",
+      'div',
       [
-        vnodeKeyed("div", "d"),
-        vnodeKeyed("div", "a"),
-        vnodeKeyed("div", "k"),
-        vnodeKeyed("div", "r"),
-        vnodeKeyed("div", "b"),
+        vnodeKeyed('div', 'd'),
+        vnodeKeyed('div', 'a'),
+        vnodeKeyed('div', 'k'),
+        vnodeKeyed('div', 'r'),
+        vnodeKeyed('div', 'b'),
       ],
       {},
       {},
-      "html",
+      'html',
       null,
       null,
       null,
       null,
-      "key-1",
+      'key-1',
     );
     miso.diff(null, currentNode, body);
     var newNode = vnode(
-      "div",
+      'div',
       [
-        vnodeKeyed("div", "a"),
-        vnodeKeyed("div", "b"),
-        vnodeKeyed("div", "r"),
-        vnodeKeyed("div", "k"),
-        vnodeKeyed("div", "d"),
+        vnodeKeyed('div', 'a'),
+        vnodeKeyed('div', 'b'),
+        vnodeKeyed('div', 'r'),
+        vnodeKeyed('div', 'k'),
+        vnodeKeyed('div', 'd'),
       ],
       {},
       {},
-      "html",
+      'html',
       null,
       null,
       null,
       null,
-      "key-1",
+      'key-1',
     );
     miso.diff(currentNode, newNode, body);
     expect(newNode.children.length).toBe(5);
@@ -1247,44 +1247,44 @@ describe("miso.js tests", () => {
     expect(currentNode.domRef.childNodes).toEqual(newNode.domRef.childNodes);
   });
 
-  test("Should handle duplicate keys case", () => {
+  test('Should handle duplicate keys case', () => {
     var body = document.body;
     var currentNode = vnode(
-      "div",
+      'div',
       [
-        vnodeKeyed("div", "a"),
-        vnodeKeyed("div", "a"),
-        vnodeKeyed("div", "a"),
-        vnodeKeyed("div", "b"),
-        vnodeKeyed("div", "b"),
+        vnodeKeyed('div', 'a'),
+        vnodeKeyed('div', 'a'),
+        vnodeKeyed('div', 'a'),
+        vnodeKeyed('div', 'b'),
+        vnodeKeyed('div', 'b'),
       ],
       {},
       {},
-      "html",
+      'html',
       null,
       null,
       null,
       null,
-      "key-1",
+      'key-1',
     );
     miso.diff(null, currentNode, body);
     var newNode = vnode(
-      "div",
+      'div',
       [
-        vnodeKeyed("div", "b"),
-        vnodeKeyed("div", "b"),
-        vnodeKeyed("div", "b"),
-        vnodeKeyed("div", "a"),
-        vnodeKeyed("div", "a"),
+        vnodeKeyed('div', 'b'),
+        vnodeKeyed('div', 'b'),
+        vnodeKeyed('div', 'b'),
+        vnodeKeyed('div', 'a'),
+        vnodeKeyed('div', 'a'),
       ],
       {},
       {},
-      "html",
+      'html',
       null,
       null,
       null,
       null,
-      "key-1",
+      'key-1',
     );
     miso.diff(currentNode, newNode, body);
     expect(newNode.children.length).toBe(5);
@@ -1294,42 +1294,42 @@ describe("miso.js tests", () => {
     expect(currentNode.domRef.childNodes).toEqual(newNode.domRef.childNodes);
   });
 
-  test("Should execute top-right and bottom-left match case", () => {
+  test('Should execute top-right and bottom-left match case', () => {
     var body = document.body;
     var currentNode = vnode(
-      "div",
+      'div',
       [
-        vnodeKeyed("div", "d"),
-        vnodeKeyed("div", "a"),
-        vnodeKeyed("div", "g"),
-        vnodeKeyed("div", "b"),
+        vnodeKeyed('div', 'd'),
+        vnodeKeyed('div', 'a'),
+        vnodeKeyed('div', 'g'),
+        vnodeKeyed('div', 'b'),
       ],
       {},
       {},
-      "html",
+      'html',
       null,
       null,
       null,
       null,
-      "key-1",
+      'key-1',
     );
     miso.diff(null, currentNode, body);
     var newNode = vnode(
-      "div",
+      'div',
       [
-        vnodeKeyed("div", "b"),
-        vnodeKeyed("div", "g"),
-        vnodeKeyed("div", "d"),
-        vnodeKeyed("div", "a"),
+        vnodeKeyed('div', 'b'),
+        vnodeKeyed('div', 'g'),
+        vnodeKeyed('div', 'd'),
+        vnodeKeyed('div', 'a'),
       ],
       {},
       {},
-      "html",
+      'html',
       null,
       null,
       null,
       null,
-      "key-1",
+      'key-1',
     );
     miso.diff(currentNode, newNode, body);
     expect(newNode.children.length).toBe(4);
@@ -1339,32 +1339,32 @@ describe("miso.js tests", () => {
     expect(currentNode.domRef.childNodes).toEqual(newNode.domRef.childNodes);
   });
 
-  test("Nothing matches case", () => {
+  test('Nothing matches case', () => {
     var body = document.body;
     var currentNode = vnode(
-      "div",
-      [vnodeKeyed("div", "e"), vnodeKeyed("div", "k"), vnodeKeyed("div", "l")],
+      'div',
+      [vnodeKeyed('div', 'e'), vnodeKeyed('div', 'k'), vnodeKeyed('div', 'l')],
       {},
       {},
-      "html",
+      'html',
       null,
       null,
       null,
       null,
-      "key-1",
+      'key-1',
     );
     miso.diff(null, currentNode, body);
     var newNode = vnode(
-      "div",
-      [vnodeKeyed("div", "b"), vnodeKeyed("div", "z"), vnodeKeyed("div", "j")],
+      'div',
+      [vnodeKeyed('div', 'b'), vnodeKeyed('div', 'z'), vnodeKeyed('div', 'j')],
       {},
       {},
-      "html",
+      'html',
       null,
       null,
       null,
       null,
-      "key-1",
+      'key-1',
     );
     miso.diff(currentNode, newNode, body);
     expect(newNode.children.length).toBe(3);
@@ -1374,42 +1374,42 @@ describe("miso.js tests", () => {
     expect(currentNode.domRef.childNodes).toEqual(newNode.domRef.childNodes);
   });
 
-  test("Should handle nothing matches case where new key is found in old map", () => {
+  test('Should handle nothing matches case where new key is found in old map', () => {
     var body = document.body;
     var currentNode = vnode(
-      "div",
+      'div',
       [
-        vnodeKeyed("div", "a"),
-        vnodeKeyed("div", "k"),
-        vnodeKeyed("div", "l"),
-        vnodeKeyed("div", "c"),
-        vnodeKeyed("div", "g"),
+        vnodeKeyed('div', 'a'),
+        vnodeKeyed('div', 'k'),
+        vnodeKeyed('div', 'l'),
+        vnodeKeyed('div', 'c'),
+        vnodeKeyed('div', 'g'),
       ],
       {},
       {},
-      "html",
+      'html',
       null,
       null,
       null,
-      "key-1",
+      'key-1',
     );
     miso.diff(null, currentNode, body);
     var newNode = vnode(
-      "div",
+      'div',
       [
-        vnodeKeyed("div", "b"),
-        vnodeKeyed("div", "c"),
-        vnodeKeyed("div", "l"),
-        vnodeKeyed("div", "r"),
-        vnodeKeyed("div", "k"),
+        vnodeKeyed('div', 'b'),
+        vnodeKeyed('div', 'c'),
+        vnodeKeyed('div', 'l'),
+        vnodeKeyed('div', 'r'),
+        vnodeKeyed('div', 'k'),
       ],
       {},
       {},
-      "html",
+      'html',
       null,
       null,
       null,
-      "key-1",
+      'key-1',
     );
     miso.diff(currentNode, newNode, body);
     expect(newNode.children.length).toBe(5);
@@ -1419,30 +1419,30 @@ describe("miso.js tests", () => {
     expect(currentNode.domRef.childNodes).toEqual(newNode.domRef.childNodes);
   });
 
-  test("Should append new nodes in keys patch", () => {
+  test('Should append new nodes in keys patch', () => {
     var body = document.body;
     var currentNode = vnode(
-      "div",
-      [vnodeKeyed("div", "a")],
+      'div',
+      [vnodeKeyed('div', 'a')],
       {},
       {},
-      "html",
+      'html',
       null,
       null,
       null,
-      "key-1",
+      'key-1',
     );
     miso.diff(null, currentNode, body);
     var newNode = vnode(
-      "div",
-      [vnodeKeyed("div", "a"), vnodeKeyed("div", "c"), vnodeKeyed("div", "k")],
+      'div',
+      [vnodeKeyed('div', 'a'), vnodeKeyed('div', 'c'), vnodeKeyed('div', 'k')],
       {},
       {},
-      "html",
+      'html',
       null,
       null,
       null,
-      "key-1",
+      'key-1',
     );
     miso.diff(currentNode, newNode, body);
     expect(newNode.children.length).toBe(3);
@@ -1452,157 +1452,157 @@ describe("miso.js tests", () => {
     expect(currentNode.domRef.childNodes).toEqual(newNode.domRef.childNodes);
   });
 
-  test("Should window miso.diff keyed text nodes", () => {
+  test('Should window miso.diff keyed text nodes', () => {
     var body = document.body;
-    var currentNode = vnodeKids("div", [
-      vtextKeyed("foo", 1),
-      vtextKeyed("bar", 2),
-      vtextKeyed("baz", 3),
+    var currentNode = vnodeKids('div', [
+      vtextKeyed('foo', 1),
+      vtextKeyed('bar', 2),
+      vtextKeyed('baz', 3),
     ]);
     miso.diff(null, currentNode, body);
-    var newNode = vnodeKids("div", [
-      vtextKeyed("baz", 3),
-      vtextKeyed("bar", 2),
-      vtextKeyed("foo", 1),
+    var newNode = vnodeKids('div', [
+      vtextKeyed('baz', 3),
+      vtextKeyed('bar', 2),
+      vtextKeyed('foo', 1),
     ]);
     miso.diff(currentNode, newNode, body);
     expect(newNode.children.length).toBe(currentNode.children.length);
     expect(newNode.children).toEqual(currentNode.children);
   });
 
-  test("Should copy simple nested DOM into VTree", () => {
+  test('Should copy simple nested DOM into VTree', () => {
     var body = document.body;
-    var div = document.createElement("div");
+    var div = document.createElement('div');
     body.appendChild(div);
-    var nestedDiv = document.createElement("div");
+    var nestedDiv = document.createElement('div');
     div.appendChild(nestedDiv);
-    var txt = document.createTextNode("foo");
+    var txt = document.createTextNode('foo');
     nestedDiv.appendChild(txt);
-    var currentNode = vnodeKids("div", [vnodeKids("div", [vtext("foo")])]);
+    var currentNode = vnodeKids('div', [vnodeKids('div', [vtext('foo')])]);
     miso.hydrate(true, body, currentNode);
-    expect(currentNode.children[0].children[0].text).toEqual("foo");
+    expect(currentNode.children[0].children[0].text).toEqual('foo');
   });
 
-  test("Should fail because of expecting text node", () => {
+  test('Should fail because of expecting text node', () => {
     var body = document.body;
-    var div = document.createElement("div");
+    var div = document.createElement('div');
     body.appendChild(div);
-    var nestedDiv = document.createElement("div");
+    var nestedDiv = document.createElement('div');
     div.appendChild(nestedDiv);
-    var currentNode = vnodeKids("div", [vtext("foo")]);
+    var currentNode = vnodeKids('div', [vtext('foo')]);
     var res = miso.hydrate(true, body, currentNode);
     expect(res).toEqual(false);
   });
 
-  test("Should fail because of expecting element", () => {
+  test('Should fail because of expecting element', () => {
     var body = document.body;
-    var div = document.createElement("div");
+    var div = document.createElement('div');
     body.appendChild(div);
-    var txt = document.createTextNode("foo");
+    var txt = document.createTextNode('foo');
     div.appendChild(txt);
-    var currentNode = vnodeKids("div", [vnode("div", [])]);
+    var currentNode = vnodeKids('div', [vnode('div', [])]);
     var res = miso.hydrate(true, body, currentNode);
     expect(res).toEqual(false);
   });
 
-  test("Should fail because of non-matching text", () => {
+  test('Should fail because of non-matching text', () => {
     var body = document.body;
-    var div = document.createElement("div");
+    var div = document.createElement('div');
     body.appendChild(div);
-    var txt = document.createTextNode("foo");
+    var txt = document.createTextNode('foo');
     div.appendChild(txt);
-    var currentNode = vnodeKids("div", [vtext("bar")]);
+    var currentNode = vnodeKids('div', [vtext('bar')]);
     var res = miso.hydrate(true, body, currentNode);
     expect(res).toEqual(false);
   });
 
-  test("Should fail because of non-matching DOM and VDOM", () => {
+  test('Should fail because of non-matching DOM and VDOM', () => {
     var body = document.body;
-    var div = document.createElement("div");
+    var div = document.createElement('div');
     body.appendChild(div);
-    var txt = document.createTextNode("foobar");
+    var txt = document.createTextNode('foobar');
     div.appendChild(txt);
-    var currentNode = vnodeKids("div", [vtext("foo")]);
+    var currentNode = vnodeKids('div', [vtext('foo')]);
     var res = miso.hydrate(true, body, currentNode);
     expect(res).toEqual(false);
   });
 
-  test("Should copy DOM into VTree with multiple consecutive text nodes and collapse them", () => {
+  test('Should copy DOM into VTree with multiple consecutive text nodes and collapse them', () => {
     var body = document.body;
-    var div = document.createElement("div");
+    var div = document.createElement('div');
     body.appendChild(div);
-    var txt = document.createTextNode("foobarbaz");
+    var txt = document.createTextNode('foobarbaz');
     div.appendChild(txt);
-    var currentNode = vnodeKids("div", [
-      vtext("foo"),
-      vtext("bar"),
-      vtext("baz"),
+    var currentNode = vnodeKids('div', [
+      vtext('foo'),
+      vtext('bar'),
+      vtext('baz'),
     ]);
     miso.hydrate(true, body, currentNode);
     // Expect "foobarbaz" to be split up into three nodes in the DOM
-    expect(div.childNodes[0].textContent).toEqual("foobarbaz");
+    expect(div.childNodes[0].textContent).toEqual('foobarbaz');
   });
 
-  test("Should copy DOM into VTree with multiple consecutive text nodes and collapse them without mount point", () => {
+  test('Should copy DOM into VTree with multiple consecutive text nodes and collapse them without mount point', () => {
     var body = document.body;
-    var div = document.createElement("div");
+    var div = document.createElement('div');
     body.appendChild(div);
-    var txt = document.createTextNode("foobarbaz");
+    var txt = document.createTextNode('foobarbaz');
     div.appendChild(txt);
-    var currentNode = vnodeKids("div", [
-      vtext("foo"),
-      vtext("bar"),
-      vtext("baz"),
-      vnodeKids("div", []),
-      vtext("foo"),
-      vtext("bar"),
-      vtext("baz"),
+    var currentNode = vnodeKids('div', [
+      vtext('foo'),
+      vtext('bar'),
+      vtext('baz'),
+      vnodeKids('div', []),
+      vtext('foo'),
+      vtext('bar'),
+      vtext('baz'),
     ]);
     miso.hydrate(true, null, currentNode);
     // Expect "foobarbaz" to be split up into three nodes in the DOM
-    expect(div.childNodes[0].textContent).toEqual("foobarbaz");
-    expect(div.childNodes[2].textContent).toEqual("foobarbaz");
+    expect(div.childNodes[0].textContent).toEqual('foobarbaz');
+    expect(div.childNodes[2].textContent).toEqual('foobarbaz');
   });
 
-  test("Should copy DOM into VTree at mountPoint", () => {
+  test('Should copy DOM into VTree at mountPoint', () => {
     var body = document.body;
-    var unrelatedDiv = document.createElement("div");
-    body.appendChild(document.createElement("script"));
-    body.appendChild(document.createTextNode("test"));
+    var unrelatedDiv = document.createElement('div');
+    body.appendChild(document.createElement('script'));
+    body.appendChild(document.createTextNode('test'));
     body.appendChild(unrelatedDiv);
-    var unrelatedTxt = document.createTextNode("Not part of Miso app");
+    var unrelatedTxt = document.createTextNode('Not part of Miso app');
     unrelatedDiv.appendChild(unrelatedTxt);
-    var misoDiv = document.createElement("div");
+    var misoDiv = document.createElement('div');
     body.appendChild(misoDiv);
-    var nestedDiv1 = document.createElement("div");
+    var nestedDiv1 = document.createElement('div');
     misoDiv.appendChild(nestedDiv1);
-    var nestedDiv2 = document.createElement("div");
+    var nestedDiv2 = document.createElement('div');
     nestedDiv1.appendChild(nestedDiv2);
-    var txt = document.createTextNode("foo");
+    var txt = document.createTextNode('foo');
     nestedDiv2.appendChild(txt);
-    var currentNode = vnodeKids("div", [vnodeKids("div", [vtext("foo")])]);
+    var currentNode = vnodeKids('div', [vnodeKids('div', [vtext('foo')])]);
     var succeeded = miso.hydrate(true, misoDiv, currentNode);
     expect(currentNode.children[0].children[0].domRef).toEqual(txt);
     expect(succeeded).toEqual(true);
   });
 
-  test("Should copy DOM into VTree at body w/ script / text siblings", () => {
+  test('Should copy DOM into VTree at body w/ script / text siblings', () => {
     var body = document.body;
-    var unrelatedDiv = document.createElement("div");
-    body.appendChild(document.createElement("script"));
-    body.appendChild(document.createTextNode("test"));
+    var unrelatedDiv = document.createElement('div');
+    body.appendChild(document.createElement('script'));
+    body.appendChild(document.createTextNode('test'));
     body.appendChild(unrelatedDiv);
-    var unrelatedTxt = document.createTextNode("Not part of Miso app");
+    var unrelatedTxt = document.createTextNode('Not part of Miso app');
     unrelatedDiv.appendChild(unrelatedTxt);
-    var misoDiv = document.createElement("div");
+    var misoDiv = document.createElement('div');
     body.appendChild(misoDiv);
-    var nestedDiv1 = document.createElement("div");
+    var nestedDiv1 = document.createElement('div');
     misoDiv.appendChild(nestedDiv1);
-    var nestedDiv2 = document.createElement("div");
+    var nestedDiv2 = document.createElement('div');
     nestedDiv1.appendChild(nestedDiv2);
-    var txt = document.createTextNode("foo");
+    var txt = document.createTextNode('foo');
     nestedDiv2.appendChild(txt);
-    var currentNode = vnodeKids("div", [vnodeKids("div", [vtext("foo")])]);
+    var currentNode = vnodeKids('div', [vnodeKids('div', [vtext('foo')])]);
     var succeeded = miso.hydrate(true, body, currentNode);
     expect(currentNode.children[0].children[0].domRef).toEqual(txt);
     expect(succeeded).toEqual(false);
@@ -1622,27 +1622,27 @@ describe("miso.js tests", () => {
   //   expect(succeeded).toEqual(false);
   // });
 
-  test("Should mount on an empty body", () => {
-    var currentNode = vnodeKids("div", [vnodeKids("div", [vtext("foo")])]);
+  test('Should mount on an empty body', () => {
+    var currentNode = vnodeKids('div', [vnodeKids('div', [vtext('foo')])]);
     var succeeded = miso.hydrate(true, null, currentNode);
     expect(succeeded).toEqual(false);
   });
 
-  test("Should pass integrity check", () => {
+  test('Should pass integrity check', () => {
     var document = window.document;
     var body = document.body;
-    var child = document.createElement("div");
-    var misoTxt = document.createTextNode("foo");
+    var child = document.createElement('div');
+    var misoTxt = document.createTextNode('foo');
     body.appendChild(child);
     child.appendChild(misoTxt);
     var vtree = {
-      type: "vnode",
+      type: 'vnode',
       domRef: null,
-      tag: "div",
+      tag: 'div',
       props: {},
-      children: [{ type: "vtext", text: "foo" }],
+      children: [{ type: 'vtext', text: 'foo' }],
       key: null,
-      ns: "HTML",
+      ns: 'HTML',
       css: {},
     };
     var result = miso.hydrate(false, body, vtree);
@@ -1651,94 +1651,94 @@ describe("miso.js tests", () => {
     expect(check).toBe(1);
   });
 
-  test("Should fail integrity check on bad tag", () => {
+  test('Should fail integrity check on bad tag', () => {
     var document = window.document;
     var body = document.body;
-    var child = document.createElement("div");
-    var misoTxt = document.createTextNode("foo");
+    var child = document.createElement('div');
+    var misoTxt = document.createTextNode('foo');
     body.appendChild(child);
     child.appendChild(misoTxt);
     var vtree = {
-      type: "vnode",
+      type: 'vnode',
       domRef: null,
-      tag: "div",
+      tag: 'div',
       props: {},
-      children: [{ type: "vtext", text: "foo" }],
+      children: [{ type: 'vtext', text: 'foo' }],
       key: null,
-      ns: "HTML",
+      ns: 'HTML',
       css: {},
     };
     var result = miso.hydrate(false, body, vtree);
     expect(result).toEqual(true);
     var check = miso.integrityCheck(true, vtree);
     expect(check).toBe(1);
-    vtree.tag = "lol";
+    vtree.tag = 'lol';
     check = miso.integrityCheck(true, vtree);
     expect(check).toBe(0);
   });
 
-  test("Should fail integrity check on bad tag in hydrate w/ logging enabled", () => {
+  test('Should fail integrity check on bad tag in hydrate w/ logging enabled', () => {
     var document = window.document;
     var body = document.body;
-    var child = document.createElement("div");
-    var misoTxt = document.createTextNode("foo");
+    var child = document.createElement('div');
+    var misoTxt = document.createTextNode('foo');
     body.appendChild(child);
     child.appendChild(misoTxt);
     var vtree = {
-      type: "vnode",
+      type: 'vnode',
       domRef: null,
-      tag: "lol",
+      tag: 'lol',
       props: {},
-      children: [{ type: "vtext", text: "fool?" }],
+      children: [{ type: 'vtext', text: 'fool?' }],
       key: null,
-      ns: "HTML",
+      ns: 'HTML',
       css: {},
     };
     var result = miso.hydrate(true, body, vtree);
     expect(result).toEqual(false);
   });
 
-  test("Should fail integrity check on miso.differing vtext", () => {
+  test('Should fail integrity check on miso.differing vtext', () => {
     var document = window.document;
     var body = document.body;
-    var child = document.createElement("div");
-    var misoTxt = document.createTextNode("foo");
+    var child = document.createElement('div');
+    var misoTxt = document.createTextNode('foo');
     body.appendChild(child);
     child.appendChild(misoTxt);
     var vtree = {
-      type: "vnode",
+      type: 'vnode',
       domRef: null,
-      tag: "div",
+      tag: 'div',
       props: {},
-      children: [{ type: "vtext", text: "foo" }],
+      children: [{ type: 'vtext', text: 'foo' }],
       key: null,
-      ns: "HTML",
+      ns: 'HTML',
       css: {},
     };
     var result = miso.hydrate(false, body, vtree);
     expect(result).toEqual(true);
     var check = miso.integrityCheck(true, vtree);
     expect(check).toBe(1);
-    vtree.children[0].text = "oops";
+    vtree.children[0].text = 'oops';
     check = miso.integrityCheck(true, vtree);
     expect(check).toBe(0);
   });
 
-  test("Should fail integrity check on miso.differing child lengths", () => {
+  test('Should fail integrity check on miso.differing child lengths', () => {
     var document = window.document;
     var body = document.body;
-    var child = document.createElement("div");
-    var misoTxt = document.createTextNode("foo");
+    var child = document.createElement('div');
+    var misoTxt = document.createTextNode('foo');
     body.appendChild(child);
     child.appendChild(misoTxt);
     var vtree = {
-      type: "vnode",
+      type: 'vnode',
       domRef: null,
-      tag: "div",
+      tag: 'div',
       props: {},
-      children: [{ type: "vtext", text: "foo" }],
+      children: [{ type: 'vtext', text: 'foo' }],
       key: null,
-      ns: "HTML",
+      ns: 'HTML',
       css: {},
     };
     var result = miso.hydrate(false, body, vtree);
@@ -1750,218 +1750,218 @@ describe("miso.js tests", () => {
     expect(check).toBe(false);
   });
 
-  test("Should fail integrity check on miso.differing styles", () => {
+  test('Should fail integrity check on miso.differing styles', () => {
     var document = window.document;
     var body = document.body;
-    var child = document.createElement("div");
-    var misoTxt = document.createTextNode("foo");
-    child.style["background-color"] = "red";
+    var child = document.createElement('div');
+    var misoTxt = document.createTextNode('foo');
+    child.style['background-color'] = 'red';
     body.appendChild(child);
     child.appendChild(misoTxt);
     var vtree = {
-      type: "vnode",
+      type: 'vnode',
       domRef: null,
-      tag: "div",
+      tag: 'div',
       props: {},
-      children: [{ type: "vtext", text: "foo" }],
+      children: [{ type: 'vtext', text: 'foo' }],
       key: null,
-      ns: "HTML",
-      css: { "background-color": "red" },
+      ns: 'HTML',
+      css: { 'background-color': 'red' },
     };
     var result = miso.hydrate(false, body, vtree);
     expect(result).toEqual(true);
     var check = miso.integrityCheck(true, vtree);
     expect(check).toBe(1);
-    vtree.css["background-color"] = "green";
+    vtree.css['background-color'] = 'green';
     check = miso.integrityCheck(true, vtree);
     expect(check).toBe(0);
   });
 
-  test("Should fail integrity check on miso.differing styles, for color", () => {
+  test('Should fail integrity check on miso.differing styles, for color', () => {
     var document = window.document;
     var body = document.body;
-    var child = document.createElement("div");
-    var misoTxt = document.createTextNode("foo");
-    child.style["background-color"] = "red";
-    child.style["color"] = "#cccccc";
+    var child = document.createElement('div');
+    var misoTxt = document.createTextNode('foo');
+    child.style['background-color'] = 'red';
+    child.style['color'] = '#cccccc';
     body.appendChild(child);
     child.appendChild(misoTxt);
     var vtree = {
-      type: "vnode",
+      type: 'vnode',
       domRef: null,
-      tag: "div",
+      tag: 'div',
       props: {},
-      children: [{ type: "vtext", text: "foo" }],
+      children: [{ type: 'vtext', text: 'foo' }],
       key: null,
-      ns: "HTML",
-      css: { "background-color": "red", color: "#cccccc" },
+      ns: 'HTML',
+      css: { 'background-color': 'red', color: '#cccccc' },
     };
     var result = miso.hydrate(false, body, vtree);
     expect(result).toEqual(true);
     var check = miso.integrityCheck(true, vtree);
     expect(check).toBe(1);
-    vtree.css["color"] = "#dddddd";
+    vtree.css['color'] = '#dddddd';
     check = miso.integrityCheck(true, vtree);
     expect(check).toBe(0);
   });
 
-  test("Should fail integrity check on miso.differing props", () => {
+  test('Should fail integrity check on miso.differing props', () => {
     var document = window.document;
     var body = document.body;
-    var child = document.createElement("div");
-    var misoTxt = document.createTextNode("foo");
-    child.style["background-color"] = "red";
-    child.className = "something";
+    var child = document.createElement('div');
+    var misoTxt = document.createTextNode('foo');
+    child.style['background-color'] = 'red';
+    child.className = 'something';
     body.appendChild(child);
     child.appendChild(misoTxt);
     var vtree = {
-      type: "vnode",
+      type: 'vnode',
       domRef: null,
-      tag: "div",
-      props: { class: "something" },
-      children: [{ type: "vtext", text: "foo" }],
+      tag: 'div',
+      props: { class: 'something' },
+      children: [{ type: 'vtext', text: 'foo' }],
       key: null,
-      ns: "HTML",
-      css: { "background-color": "red" },
+      ns: 'HTML',
+      css: { 'background-color': 'red' },
     };
     var result = miso.hydrate(false, body, vtree);
     expect(result).toEqual(true);
     var check = miso.integrityCheck(true, vtree);
     expect(check).toBe(1);
-    vtree.props["class"] = "something-else";
+    vtree.props['class'] = 'something-else';
     check = miso.integrityCheck(true, vtree);
     expect(check).toBe(0);
   });
 
-  test("Should fail integrity check on differing height / width", () => {
+  test('Should fail integrity check on differing height / width', () => {
     var document = window.document;
     var body = document.body;
-    var child = document.createElement("div");
-    var misoTxt = document.createTextNode("foo");
-    child.style["background-color"] = "red";
-    child.className = "something";
-    child.height = "100";
-    child.width = "100";
+    var child = document.createElement('div');
+    var misoTxt = document.createTextNode('foo');
+    child.style['background-color'] = 'red';
+    child.className = 'something';
+    child.height = '100';
+    child.width = '100';
     body.appendChild(child);
     child.appendChild(misoTxt);
     var vtree = {
-      type: "vnode",
+      type: 'vnode',
       domRef: null,
-      tag: "div",
-      props: { class: "something", height: "100", width: "100" },
-      children: [{ type: "vtext", text: "foo" }],
+      tag: 'div',
+      props: { class: 'something', height: '100', width: '100' },
+      children: [{ type: 'vtext', text: 'foo' }],
       key: null,
-      ns: "HTML",
-      css: { "background-color": "red" },
+      ns: 'HTML',
+      css: { 'background-color': 'red' },
     };
     var result = miso.hydrate(false, body, vtree);
     expect(result).toEqual(true);
     var check = miso.integrityCheck(true, vtree);
     expect(check).toBe(1);
-    vtree.props["height"] = "200";
-    vtree.props["width"] = "200";
+    vtree.props['height'] = '200';
+    vtree.props['width'] = '200';
     check = miso.integrityCheck(true, vtree);
     expect(check).toBe(0);
   });
 
-  test("Should fail integrity check on random property (title)", () => {
+  test('Should fail integrity check on random property (title)', () => {
     var document = window.document;
     var body = document.body;
-    var child = document.createElement("div");
-    var misoTxt = document.createTextNode("foo");
-    child["title"] = "bar";
+    var child = document.createElement('div');
+    var misoTxt = document.createTextNode('foo');
+    child['title'] = 'bar';
     body.appendChild(child);
     child.appendChild(misoTxt);
     var vtree = {
-      type: "vnode",
+      type: 'vnode',
       domRef: null,
-      tag: "div",
-      props: { title: "bar" },
-      children: [{ type: "vtext", text: "foo" }],
+      tag: 'div',
+      props: { title: 'bar' },
+      children: [{ type: 'vtext', text: 'foo' }],
       key: null,
-      ns: "HTML",
+      ns: 'HTML',
       css: {},
     };
     var result = miso.hydrate(false, body, vtree);
     expect(result).toEqual(true);
     var check = miso.integrityCheck(true, vtree);
     expect(check).toBe(1);
-    vtree.props["title"] = "woz";
+    vtree.props['title'] = 'woz';
     check = miso.integrityCheck(true, vtree);
     expect(check).toBe(0);
   });
 
-  test("Should fail integrity check on href", () => {
+  test('Should fail integrity check on href', () => {
     var document = window.document;
     var body = document.body;
-    var child = document.createElement("div");
-    var misoTxt = document.createTextNode("foo");
-    child.style["background-color"] = "red";
-    child.href = "google.com";
+    var child = document.createElement('div');
+    var misoTxt = document.createTextNode('foo');
+    child.style['background-color'] = 'red';
+    child.href = 'google.com';
     body.appendChild(child);
     child.appendChild(misoTxt);
     var vtree = {
-      type: "vnode",
+      type: 'vnode',
       domRef: null,
-      tag: "div",
-      props: { href: "google.com" },
-      children: [{ type: "vtext", text: "foo" }],
+      tag: 'div',
+      props: { href: 'google.com' },
+      children: [{ type: 'vtext', text: 'foo' }],
       key: null,
-      ns: "HTML",
-      css: { "background-color": "red" },
+      ns: 'HTML',
+      css: { 'background-color': 'red' },
     };
     var result = miso.hydrate(false, body, vtree);
     expect(result).toEqual(true);
     var check = miso.integrityCheck(true, vtree);
     expect(check).toBe(1);
-    vtree.props["href"] = "notgoogle.com";
+    vtree.props['href'] = 'notgoogle.com';
     check = miso.integrityCheck(true, vtree);
     expect(check).toBe(0);
   });
 
-  test("Should fail integrity check on vtext domRef", () => {
+  test('Should fail integrity check on vtext domRef', () => {
     var document = window.document;
     var body = document.body;
-    var child = document.createElement("div");
-    var misoTxt = document.createTextNode("foo");
-    child.style["background-color"] = "red";
-    child.href = "google.com";
+    var child = document.createElement('div');
+    var misoTxt = document.createTextNode('foo');
+    child.style['background-color'] = 'red';
+    child.href = 'google.com';
     body.appendChild(child);
     child.appendChild(misoTxt);
     var vtree = {
-      type: "vnode",
+      type: 'vnode',
       domRef: null,
-      tag: "div",
-      props: { href: "google.com" },
-      children: [{ type: "vtext", text: "foo" }],
+      tag: 'div',
+      props: { href: 'google.com' },
+      children: [{ type: 'vtext', text: 'foo' }],
       key: null,
-      ns: "HTML",
-      css: { "background-color": "red" },
+      ns: 'HTML',
+      css: { 'background-color': 'red' },
     };
     var result = miso.hydrate(false, body, vtree);
     expect(result).toEqual(true);
     var check = miso.integrityCheck(true, vtree);
     expect(check).toBe(1);
-    vtree.children[0].domRef = document.createElement("div");
+    vtree.children[0].domRef = document.createElement('div');
     check = miso.integrityCheck(true, vtree);
     expect(check).toBe(0);
   });
 
-  test("Should fail integrity check on unknown property test", () => {
+  test('Should fail integrity check on unknown property test', () => {
     var document = window.document;
     var body = document.body;
-    var child = document.createElement("div");
-    var misoTxt = document.createTextNode("foo");
+    var child = document.createElement('div');
+    var misoTxt = document.createTextNode('foo');
     body.appendChild(child);
     child.appendChild(misoTxt);
     var vtree = {
-      type: "vnode",
+      type: 'vnode',
       domRef: null,
-      tag: "div",
-      props: { foobah: "lol" },
-      children: [{ type: "vtext", text: "foo" }],
+      tag: 'div',
+      props: { foobah: 'lol' },
+      children: [{ type: 'vtext', text: 'foo' }],
       key: null,
-      ns: "HTML",
+      ns: 'HTML',
       css: {},
     };
     var result = miso.hydrate(false, body, vtree);
@@ -1970,30 +1970,30 @@ describe("miso.js tests", () => {
     expect(check).toBe(0);
   });
 
-  test("Should set body[data-component-id] via setBodyComponent()", () => {
+  test('Should set body[data-component-id] via setBodyComponent()', () => {
     var document = window.document;
-    miso.setBodyComponent("component-one");
-    expect(document.body.getAttribute("data-component-id")).toEqual(
-      "component-one",
+    miso.setBodyComponent('component-one');
+    expect(document.body.getAttribute('data-component-id')).toEqual(
+      'component-one',
     );
   });
 
-  test("Should call callFocus() and callBlur()", () => {
+  test('Should call callFocus() and callBlur()', () => {
     var document = window.document;
-    var child = document.createElement("input");
-    child["id"] = "foo";
+    var child = document.createElement('input');
+    child['id'] = 'foo';
     document.body.appendChild(child);
-    miso.callFocus("blah", document, 0); /* missing case */
-    miso.callFocus("foo", document, 0); /* found case */
-    miso.callFocus("foo", document, 1); /* found case */
+    miso.callFocus('blah', document, 0); /* missing case */
+    miso.callFocus('foo', document, 0); /* found case */
+    miso.callFocus('foo', document, 1); /* found case */
     expect(document.activeElement).toEqual(child);
-    miso.callBlur("blah", document, 0); /* missing case */
-    miso.callBlur("foo", document, 0); /* found case */
-    miso.callBlur("foo", document, 1); /* found case */
+    miso.callBlur('blah', document, 0); /* missing case */
+    miso.callBlur('foo', document, 0); /* found case */
+    miso.callBlur('foo', document, 1); /* found case */
     expect(document.activeElement).toEqual(document.body);
   });
 
-  test("Should delegate and undelegate button click", () => {
+  test('Should delegate and undelegate button click', () => {
     var document = window.document;
     var body = document.body;
     var count = 0;
@@ -2011,18 +2011,18 @@ describe("miso.js tests", () => {
       },
     };
     var vtreeChild = {
-      type: "vnode",
-      tag: "button",
-      ns: "HTML",
+      type: 'vnode',
+      tag: 'button',
+      ns: 'HTML',
       props: {},
       children: [],
       css: {},
       events: events,
     };
     var vtree = {
-      type: "vnode",
-      tag: "div",
-      ns: "HTML",
+      type: 'vnode',
+      tag: 'div',
+      ns: 'HTML',
       props: {},
       children: [vtreeChild],
       css: {},
@@ -2039,7 +2039,7 @@ describe("miso.js tests", () => {
     );
 
     /* setup event delegation */
-    events = { click: ["click", true] };
+    events = { click: ['click', true] };
     var getVTree = function (cb) {
       cb(vtree);
     };
@@ -2056,18 +2056,18 @@ describe("miso.js tests", () => {
     miso.undelegate(document.body, events, getVTree, true);
   });
 
-  test("Should unmount recursively in order", () => {
+  test('Should unmount recursively in order', () => {
     var document = window.document;
     var unmounts = [];
     var mkVComp = function (name, children) {
       return {
-        type: "vcomp",
-        tag: "div",
+        type: 'vcomp',
+        tag: 'div',
         props: {},
         children: children,
-        "data-component-id": name,
+        'data-component-id': name,
         css: {},
-        ns: "HTML",
+        ns: 'HTML',
         mount: function () {},
         unmount: function () {
           unmounts.push(name);
@@ -2075,13 +2075,13 @@ describe("miso.js tests", () => {
       };
     };
 
-    var vtree = mkVComp("one", [mkVComp("two", [mkVComp("three", [])])]);
+    var vtree = mkVComp('one', [mkVComp('two', [mkVComp('three', [])])]);
     miso.diff(null, vtree, document.body);
     miso.diff(vtree, null, document.body);
-    expect(unmounts).toEqual(["one", "two", "three"]);
+    expect(unmounts).toEqual(['one', 'two', 'three']);
   });
 
-  test("Should be latest version", () => {
-    expect(miso.version).toEqual("1.9.0.0");
+  test('Should be latest version', () => {
+    expect(miso.version).toEqual('1.9.0.0');
   });
 });

--- a/package.json
+++ b/package.json
@@ -27,6 +27,10 @@
   "jest": {
     "verbose": true
   },
+  "prettier": {
+    "singleQuote": true,
+    "quoteProps": "preserve"
+  },
   "homepage": "https://haskell-miso.org",
   "devDependencies": {
     "@eslint/js": "^9.23.0",


### PR DESCRIPTION
- Prettier by default will strip quoted field names, `{"quoteProps": "preserve"}` changes this default behavior. This is necessary to get around closure compilation attempting to rename field names to the smallest possible names.

- Standardizes on single-quotes

- This PR introduced the feature we need to ensure sound closure compilation https://github.com/prettier/prettier/pull/5934