### PR TITLE
Adds discriminated union for VTree (VComp | VNode | VText)

### DIFF
--- a/src/Miso/Internal.hs
+++ b/src/Miso/Internal.hs
@@ -284,6 +284,7 @@ runView prerender (Node ns tag key attrs kids) snk logLevel events = do
 runView _ (Text t) _ _ _ = do
   vtree <- create
   FFI.set "type" ("vtext" :: JSString) vtree
+  FFI.set "ns" ("text" :: JSString) vtree
   FFI.set "text" t vtree
   pure $ VTree vtree
 runView prerender (TextRaw str) snk logLevel events =

--- a/ts/miso.ts
+++ b/ts/miso.ts
@@ -2,7 +2,7 @@ import { diff } from './miso/dom';
 import { delegate, undelegate, eventJSON } from './miso/event';
 import { hydrate, integrityCheck } from './miso/hydrate';
 import { version, callFocus, callBlur, setBodyComponent } from './miso/util';
-import { VTree, Props, CSS, Events, EventCapture, EventObject, Options } from './miso/types';
+import { VTree, VNode, VText, VComp, Props, CSS, Events, NS, DOMRef, EventCapture, EventObject, Options } from './miso/types';
 import { vtree, vtext } from './miso/smart';
 
 /* top level re-export */
@@ -20,12 +20,16 @@ export {
   setBodyComponent,
   /* Types */
   VTree,
+  VComp,
+  VText,
+  VNode,
   EventCapture,
   EventObject,
   Options,
   CSS,
   Props,
   Events,
+  NS,
   /* Smart constructors */
   vtree,
   vtext,

--- a/ts/miso.ts
+++ b/ts/miso.ts
@@ -3,7 +3,7 @@ import { delegate, undelegate, eventJSON } from './miso/event';
 import { hydrate, integrityCheck } from './miso/hydrate';
 import { version, callFocus, callBlur, setBodyComponent } from './miso/util';
 import { VTree, VNode, VText, VComp, Props, CSS, Events, NS, DOMRef, EventCapture, EventObject, Options } from './miso/types';
-import { vtree, vtext } from './miso/smart';
+import { vcomp, vtree, vtext } from './miso/smart';
 
 /* top level re-export */
 export {
@@ -30,7 +30,9 @@ export {
   Props,
   Events,
   NS,
+  DOMRef,
   /* Smart constructors */
   vtree,
   vtext,
+  vcomp,
 };

--- a/ts/miso/dom.ts
+++ b/ts/miso/dom.ts
@@ -108,7 +108,7 @@ export function populate(c: VTree, n: VTree): void {
 function diffProps(cProps: Props, nProps: Props, node: Element, isSvg: boolean): void {
   var newProp;
   /* Is current prop in new prop list? */
-  for (var c in cProps) {
+  for (const c in cProps) {
     newProp = nProps[c];
     /* If current property no longer exists, remove it */
     if (newProp === undefined) {
@@ -135,7 +135,7 @@ function diffProps(cProps: Props, nProps: Props, node: Element, isSvg: boolean):
     }
   }
   /* add remaining */
-  for (var n in nProps) {
+  for (const n in nProps) {
     if (cProps && cProps[n]) continue;
     newProp = nProps[n];
     /* Only add new properties, skip (continue) if they already exist in current property map */
@@ -154,9 +154,9 @@ function diffProps(cProps: Props, nProps: Props, node: Element, isSvg: boolean):
 }
 
 function diffCss(cCss: CSS, nCss: CSS, node: DOMRef): void {
-  var result;
+  var result: string;
   /* is current attribute in new attribute list? */
-  for (var c in cCss) {
+  for (const c in cCss) {
     result = nCss[c];
     if (!result) {
       /* current key is not in node */
@@ -166,7 +166,7 @@ function diffCss(cCss: CSS, nCss: CSS, node: DOMRef): void {
     }
   }
   /* add remaining */
-  for (var n in nCss) {
+  for (const n in nCss) {
     if (cCss && cCss[n]) continue;
     node.style[n] = nCss[n];
   }
@@ -177,7 +177,7 @@ function hasKeys(ns: Array<VTree>, cs: Array<VTree>): boolean {
 }
 
 function diffChildren(cs: Array<VTree>, ns: Array<VTree>, parent: Element): void {
-  var longest: number = ns.length > cs.length ? ns.length : cs.length;
+  const longest: number = ns.length > cs.length ? ns.length : cs.length;
   if (hasKeys(ns, cs)) {
     syncChildren(cs, ns, parent);
   } else {
@@ -206,7 +206,7 @@ function createElement(obj: VTree, cb: (e: Node) => void): void {
 // mounts vcomp by calling into Haskell side.
 // unmount is handled with pre-destroy recursive hooks
 function mountComponent(obj: VTree): void {
-  var componentId = obj['data-component-id'],
+  const componentId = obj['data-component-id'],
     nodeList = document.querySelectorAll("[data-component-id='" + componentId + "']");
   // dmj: bail out if duplicate mounting detected
   if (nodeList.length > 0) {

--- a/ts/miso/event.ts
+++ b/ts/miso/event.ts
@@ -81,9 +81,9 @@ function delegateEvent(
       }
     }
   } /* stack.length == 1 */ else {
-    var eventObj: EventObject = obj['events'][event.type];
+    const eventObj: EventObject = obj['events'][event.type];
     if (eventObj) {
-      var options: Options = eventObj['options'];
+      const options: Options = eventObj['options'];
       if (options['preventDefault']) {
         event.preventDefault();
       }
@@ -101,7 +101,7 @@ function delegateEvent(
 function propagateWhileAble(parentStack: Array<VTree>, event: Event): void {
   for (const vtree of parentStack) {
     if (vtree['events'][event.type]) {
-      var eventObj = vtree['events'][event.type],
+      const eventObj = vtree['events'][event.type],
         options = eventObj['options'];
       if (options['preventDefault']) event.preventDefault();
       eventObj['runEvent'](event);

--- a/ts/miso/hydrate.ts
+++ b/ts/miso/hydrate.ts
@@ -16,7 +16,7 @@ function collapseSiblingTextNodes(vs: Array<VTree>): Array<VTree> {
 
 /* function to determine if <script> tags are present in `body` top-level
    if so we work around them */
-function preamble(logLevel: boolean, mountPoint: DOMRef | Text, vtree: VTree): Node {
+function preamble(mountPoint: DOMRef | Text): Node {
   var mountChildIdx = 0,
     node: ChildNode;
   if (!mountPoint) {
@@ -46,7 +46,7 @@ function preamble(logLevel: boolean, mountPoint: DOMRef | Text, vtree: VTree): N
 
 export function hydrate(logLevel: boolean, mountPoint: DOMRef | Text, vtree: VTree): boolean {
   // If script tags are rendered first in body, skip them.
-  var node: Node = preamble(logLevel, mountPoint, vtree);
+  const node: Node = preamble(mountPoint);
 
   // begin walking the DOM, report the result
   if (!walk(logLevel, vtree, node)) {
@@ -82,8 +82,8 @@ function diagnoseError(logLevel: boolean, vtree: VTree, node: Node): void {
 // https://stackoverflow.com/questions/11068240/what-is-the-most-efficient-way-to-parse-a-css-color-in-javascript
 function parseColor(input: string): number[] {
   if (input.substr(0, 1) == '#') {
-    var collen = (input.length - 1) / 3;
-    var fact = [17, 1, 0.062272][collen - 1];
+    const collen = (input.length - 1) / 3;
+    const fact = [17, 1, 0.062272][collen - 1];
     return [
       Math.round(parseInt(input.substr(1, collen), 16) * fact),
       Math.round(parseInt(input.substr(1 + collen, collen), 16) * fact),
@@ -137,7 +137,7 @@ function check(result: boolean, vtree: VTree): boolean {
     // properties must be identical
     for (const key in vtree['props']) {
       if (key === 'href') {
-        var absolute = window.location.origin + '/' + vtree['props'][key],
+        const absolute = window.location.origin + '/' + vtree['props'][key],
           url = vtree['domRef'][key],
           relative = vtree['props'][key];
         if (
@@ -213,8 +213,8 @@ function walk(logLevel: boolean, vtree: VTree, node: Node): boolean {
       callCreated(vtree);
 
       for (var i = 0; i < vtree['children'].length; i++) {
-        var vdomChild = vtree['children'][i];
-        var domChild = node.childNodes[i];
+        const vdomChild = vtree['children'][i];
+        const domChild = node.childNodes[i];
         if (!domChild) {
           diagnoseError(logLevel, vdomChild, domChild);
           return false;

--- a/ts/miso/smart.ts
+++ b/ts/miso/smart.ts
@@ -1,5 +1,5 @@
 /* smart constructors for VTree */
-import { VTree } from './types';
+import { VTree, VNode, VComp } from './types';
 
 /* vtext factory */
 export function vtext(input: string) {
@@ -11,8 +11,12 @@ export function vtextKeyed(input: string, k: string) {
 }
 
 /* vtree factory */
-export function vtree(props: any): VTree {
+export function vtree(props: any): VNode {
   return !props ? mkVTree() : union(mkVTree(), props);
+}
+
+export function vcomp(props: any): VComp {
+  return !props ? mkVComp() : union(mkVComp(), props);
 }
 
 /* set union */
@@ -39,7 +43,7 @@ export function vnodeKids(tag:string, kids:Array<VTree>): VTree {
 }
 
 /* "smart" helper for constructing an empty virtual DOM */
-export function mkVTree(): VTree {
+export function mkVTree(): VNode {
   return {
     props: {},
     css: {},
@@ -49,9 +53,25 @@ export function mkVTree(): VTree {
     domRef: null,
     tag: 'div',
     key: null,
-    text: '',
     events: {},
-    'data-component-id': null,
+    onDestroyed: () => {},
+    onBeforeDestroyed: () => {},
+    onCreated: () => {},
+  };
+}
+
+export function mkVComp(): VComp {
+  return {
+    props: {},
+    css: {},
+    children: [],
+    ns: 'html',
+    type: 'vcomp',
+    domRef: null,
+    tag: 'div',
+    key: null,
+    events: {},
+    'data-component-id': '',
     onDestroyed: () => {},
     onBeforeDestroyed: () => {},
     mount: () => {},

--- a/ts/miso/types.ts
+++ b/ts/miso/types.ts
@@ -3,12 +3,16 @@ type Props = Record<string, string>;
 type CSS = Record<string, string>;
 type Events = Record<string, EventObject>;
 
-type VTree = {
-  type: 'vtext' | 'vnode' | 'vcomp';
-  ns: 'html' | 'svg' | 'mathml';
-  domRef: any;
-  text: string;
-  tag: string;
+/* element name spacing */
+type NS = 'html' | 'svg' | 'mathml';
+
+type DOMRef = HTMLElement | SVGElement | MathMLElement;
+
+type VComp = {
+  type: 'vcomp';
+  domRef: HTMLElement;
+  ns: 'html';
+  tag: 'div';
   key: string;
   props: Props;
   css: CSS;
@@ -21,6 +25,30 @@ type VTree = {
   mount: (f: (component: VTree) => void) => void;
   unmount: (e: Element) => void;
 };
+
+type VNode = {
+  type: 'vnode';
+  ns: NS;
+  domRef: DOMRef;
+  tag: string;
+  key: string;
+  props: Props;
+  css: CSS;
+  events: Events;
+  children: Array<VTree>;
+  onDestroyed: () => void;
+  onCreated: () => void;
+  onBeforeDestroyed: () => void;
+};
+
+type VText = {
+  type: 'vtext';
+  text: string;
+  domRef: Text;
+  ns: NS;
+};
+
+type VTree = VComp | VNode | VText;
 
 type EventObject = {
   options: Options;
@@ -37,4 +65,17 @@ type EventCapture = {
   capture: boolean;
 };
 
-export { VTree, EventCapture, EventObject, Options, Props, CSS, Events };
+export {
+  VTree,
+  VComp,
+  VNode,
+  VText,
+  EventCapture,
+  EventObject,
+  Options,
+  Props,
+  CSS,
+  Events,
+  NS,
+  DOMRef,
+};

--- a/ts/spec/component.spec.ts
+++ b/ts/spec/component.spec.ts
@@ -1,6 +1,6 @@
 /* imports */
 import { diff } from '../miso/dom';
-import { mkVTree, vtree, vtext } from '../miso/smart';
+import { mkVTree, mkVComp, vtree, vcomp, vtext } from '../miso/smart';
 import { VTree } from '../miso/types';
 import { test, expect, describe, afterEach, beforeAll } from 'bun:test';
 
@@ -21,9 +21,8 @@ afterEach(() => {
 describe ('Component tests', () => {
   test('Should unmount recursively in order', () => {
     var unmounts = [];
-    var mkVComp = (name, children) => {
-        return vtree ({
-          type: 'vcomp',
+    var build = (name, children) => {
+        return vcomp ({
           children: children,
           'data-component-id': name,
           unmount: () => {
@@ -32,7 +31,7 @@ describe ('Component tests', () => {
       });
     };
 
-    var tree: VTree = mkVComp('one', [mkVComp('two', [mkVComp('three', [])])]);
+    var tree: VTree = build('one', [build('two', [build('three', [])])]);
     diff(null, tree, document.body);
     diff(tree, null, document.body);
     expect(unmounts).toEqual(['one', 'two', 'three']);
@@ -66,7 +65,7 @@ describe ('Component tests', () => {
       type: 'vcomp',
       mount: (cb) => {
         mountCount++;
-        var node = mkVTree();
+        var node = mkVComp();
         diff(null, node, document.body);
         cb(node);
       },
@@ -121,7 +120,7 @@ describe ('Component tests', () => {
 
   test('Should replace Node with Component', () => {
     // populate DOM
-    var node = mkVTree();
+    var node = mkVComp();
     diff(null, node, document.body);
 
     // Test node was populated
@@ -218,7 +217,7 @@ describe ('Component tests', () => {
     expect(unmountCount).toBe(0);
 
     // Replace component
-    diff(component, mkVTree(), document.body);
+    diff(component, mkVComp(), document.body);
 
     // Test node is removed from DOM
     expect(document.body.children[0].tagName).toBe('DIV');

--- a/ts/spec/component.spec.ts
+++ b/ts/spec/component.spec.ts
@@ -1,6 +1,6 @@
 /* imports */
 import { diff } from '../miso/dom';
-import { mkVTree, mkVComp, vtree, vcomp, vtext } from '../miso/smart';
+import { mkVComp, vtree, vcomp, vtext } from '../miso/smart';
 import { VTree } from '../miso/types';
 import { test, expect, describe, afterEach, beforeAll } from 'bun:test';
 


### PR DESCRIPTION
- Refines`VTree` to `VComp | VNode | VText`
- Adjust `hydrate.ts` / `dom.ts` to reflect types (as cast)
- Adds smart constructor for `VComp` (`vcomp`)
- Removes unsafe `domRef: any` in favor of union `type DOMRef = HTML | SVG | MathML`
- Refines `vcomp` `tag` to `'div'` (always) and `domRef: HTMLElement` (always)
- Refines `domRef` to `Text` for `VText`
- Adjusts tests to use `vcomp` smart constructor
- Adds "ns" field for `VText`, Haskell side.
- Refines mount callback to `VComp` in `dom.ts`
- Factors out `preamble` function for pre-`walk` activities in `hydration.ts`
- Intros and exports `NS` type `'html' | 'svg' | 'mathml'`