### PR TITLE
Multi-nixpkgs workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,8 +69,8 @@ jobs:
      - name: (JS) Miso examples (GHCJS 8.6)
        run: nix-build -A miso-examples
 
-     - name: (JS) Miso examples (GHCJS 9.12.2)
-       run: nix-build -A miso-examples-ghcjs9122
+#     - name: (JS) Miso examples (GHCJS 9.12.2)
+#       run: nix-build -A miso-examples-ghcjs9122
 
      - name: (JS) Miso third-party examples (2048, flatris, etc.) (GHCJS 9.12.2)
        run: nix-build -A more-examples -j1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,7 @@ jobs:
        run: nix-channel --update
 
      - name: Bun install
-       run: nix-build -A bun && nix-env -i ./result
+       run: nix-env -iA bun -f '<nixpkgs>'
 
      - name: Miso.ts tests
        run: bun run test
@@ -120,7 +120,7 @@ jobs:
        run: nix-channel --update
 
      - name: Bun install
-       run: nix-build -A bun && nix-env -i ./result
+       run: nix-env -iA bun -f '<nixpkgs>'
 
      - name: Bun build
        run: bun run build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,8 +69,8 @@ jobs:
      - name: (JS) Miso examples (GHCJS 8.6)
        run: nix-build -A miso-examples
 
-#     - name: (JS) Miso examples (GHCJS 9.12.2)
-#       run: nix-build -A miso-examples-ghcjs9122
+     - name: (JS) Miso examples (GHCJS 9.12.2)
+       run: nix-build -A miso-examples-ghcjs9122
 
      - name: (JS) Miso third-party examples (2048, flatris, etc.) (GHCJS 9.12.2)
        run: nix-build -A more-examples -j1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,43 +39,58 @@ jobs:
      - name: Bun build prod
        run: bun run build && bun run prod
 
-     - name: (JS) Miso GHCJS (GHC-8.6)
+     - name: (JS) Miso GHCJS (GHCJS 8.6)
        run: nix-build -A miso-ghcjs
 
-     - name: (JS) Miso GHCJS (GHC-9.12.2)
+     - name: (JS) Miso GHCJS (GHC 9.12.2)
        run: nix-build -A miso-ghcjs-9122
 
      - name: (JS) Miso GHCJS Production
        run: nix-build -A miso-ghcjs-prod
 
-     - name: (x86) Miso GHC
+     - name: (x86) Miso GHC (GHC 8.6.5)
        run: nix-build -A miso-ghc
 
-     - name: (x86) Haskell-miso.org server
+     - name: (x86) Miso GHC (GHC 9.12.2)
+       run: nix-build -A miso-ghc-9122
+
+     - name: (x86) Haskell-miso.org server (GHC 8.6.5)
        run: nix-build -A haskell-miso-server
 
-     - name: (JS) Haskell-miso.org client
+     - name: (JS) Haskell-miso.org client (GHCJS 8.6)
        run: nix-build -A haskell-miso-client
 
-     - name: (x86) sse.haskell-miso.org server
+     - name: (x86) sse.haskell-miso.org server (GHC 8.6.5)
        run: nix-build -A sse-server
 
-     - name: (JS) sse.haskell-miso.org client
+     - name: (JS) sse.haskell-miso.org client (GHCJS 8.6)
        run: nix-build -A sse-client
 
-     - name: (JS) Miso examples
+     - name: (JS) Miso examples (GHCJS 8.6)
        run: nix-build -A miso-examples
 
-     - name: (JS) Miso third-party examples (2048, flatris, etc.)
+     - name: (JS) Miso examples (GHCJS 9.12.2)
+       run: nix-build -A miso-examples-ghcjs9122
+
+     - name: (JS) Miso third-party examples (2048, flatris, etc.) (GHCJS 9.12.2)
        run: nix-build -A more-examples -j1
 
-     - name: (x86) Miso examples
+     - name: (x86) Miso examples (GHC 8.6.5)
        run: nix-build -A miso-examples-ghc
 
-     - name: (JS) Miso sample app
+     - name: (x86) Miso examples (GHC 9.12.2)
+       run: nix-build -A miso-examples-ghc9122
+
+     - name: (JS) Miso sample app (GHCJS 8.6)
        run: nix-build -A sample-app-js
 
-     - name: (x86) Miso sample app jsaddle
+     - name: (x86) Miso sample app jsaddle (GHC 8.6.5)
+       run: nix-build -A sample-app
+
+     - name: (JS) Miso sample app (GHCJS 9.12.2)
+       run: nix-build -A sample-app-js
+
+     - name: (x86) Miso sample app jsaddle (GHC 9.12.2)
        run: nix-build -A sample-app
 
      - name: (WASM) Miso examples

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,8 +42,8 @@ jobs:
      - name: (JS) Miso GHCJS (GHCJS 8.6)
        run: nix-build -A miso-ghcjs
 
-     - name: (JS) Miso GHCJS (GHC 9.12.2)
-       run: nix-build -A miso-ghcjs-9122
+#     - name: (JS) Miso GHCJS (GHC 9.12.2)
+#       run: nix-build -A miso-ghcjs-9122
 
      - name: (JS) Miso GHCJS Production
        run: nix-build -A miso-ghcjs-prod
@@ -51,8 +51,8 @@ jobs:
      - name: (x86) Miso GHC (GHC 8.6.5)
        run: nix-build -A miso-ghc
 
-     - name: (x86) Miso GHC (GHC 9.12.2)
-       run: nix-build -A miso-ghc-9122
+#     - name: (x86) Miso GHC (GHC 9.12.2)
+#       run: nix-build -A miso-ghc-9122
 
      - name: (x86) Haskell-miso.org server (GHC 8.6.5)
        run: nix-build -A haskell-miso-server
@@ -69,8 +69,8 @@ jobs:
      - name: (JS) Miso examples (GHCJS 8.6)
        run: nix-build -A miso-examples
 
-     - name: (JS) Miso examples (GHCJS 9.12.2)
-       run: nix-build -A miso-examples-ghcjs9122
+#     - name: (JS) Miso examples (GHCJS 9.12.2)
+#       run: nix-build -A miso-examples-ghcjs9122
 
      - name: (JS) Miso third-party examples (2048, flatris, etc.) (GHCJS 9.12.2)
        run: nix-build -A more-examples -j1
@@ -78,8 +78,8 @@ jobs:
      - name: (x86) Miso examples (GHC 8.6.5)
        run: nix-build -A miso-examples-ghc
 
-     - name: (x86) Miso examples (GHC 9.12.2)
-       run: nix-build -A miso-examples-ghc9122
+#     - name: (x86) Miso examples (GHC 9.12.2)
+#       run: nix-build -A miso-examples-ghc9122
 
      - name: (JS) Miso sample app (GHCJS 8.6)
        run: nix-build -A sample-app-js
@@ -87,11 +87,11 @@ jobs:
      - name: (x86) Miso sample app jsaddle (GHC 8.6.5)
        run: nix-build -A sample-app
 
-     - name: (JS) Miso sample app (GHCJS 9.12.2)
-       run: nix-build -A sample-app-js
+#    - name: (JS) Miso sample app (GHCJS 9.12.2)
+#       run: nix-build -A sample-app-js
 
-     - name: (x86) Miso sample app jsaddle (GHC 9.12.2)
-       run: nix-build -A sample-app
+#     - name: (x86) Miso sample app jsaddle (GHC 9.12.2)
+#       run: nix-build -A sample-app
 
      - name: (WASM) Miso examples
        run: nix-build -A wasmExamples && ./result/bin/build.sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,7 @@ jobs:
        run: nix-channel --update
 
      - name: Bun install
-       run: nix-env -iA bun -f '<nixpkgs>'
+       run: nix-env -iA bun -f '<nixpkgs>' && bun install
 
      - name: Miso.ts tests
        run: bun run test
@@ -120,7 +120,7 @@ jobs:
        run: nix-channel --update
 
      - name: Bun install
-       run: nix-env -iA bun -f '<nixpkgs>'
+       run: nix-env -iA bun -f '<nixpkgs>' && bun install
 
      - name: Bun build
        run: bun run build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,23 +26,24 @@ jobs:
        with:
          name: miso-haskell
          signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
+
      - name: Nix channel update
        run: nix-channel --update
 
      - name: Bun install
-       run: nix-env -iA bun -f '<nixpkgs>' && bun install
+       run: nix-build -A bun && nix-env -i ./result
 
      - name: Miso.ts tests
        run: bun run test
 
-     # - name: Miso.ts linting
-     #   run: bun run lint
-
      - name: Bun build prod
        run: bun run build && bun run prod
 
-     - name: (JS) Miso GHCJS
+     - name: (JS) Miso GHCJS (GHC-8.6)
        run: nix-build -A miso-ghcjs
+
+     - name: (JS) Miso GHCJS (GHC-9.12.2)
+       run: nix-build -A miso-ghcjs-9122
 
      - name: (JS) Miso GHCJS Production
        run: nix-build -A miso-ghcjs-prod
@@ -99,16 +100,22 @@ jobs:
        with:
          name: miso-haskell
          signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
+
      - name: Nix channel update
        run: nix-channel --update
+
      - name: Bun install
-       run: nix-env -iA bun -f '<nixpkgs>' && bun install
+       run: nix-build -A bun && nix-env -i ./result
+
      - name: Bun build
        run: bun run build
+
      - name: Build
        run: nix-build -A miso-ghcjs
+
      - name: Miso.ts test coverage
        run: bun run test
+
      - name: Deploy
        run: nix-build -A deploy -j1 && ./result
        env:

--- a/cabal.project
+++ b/cabal.project
@@ -10,6 +10,13 @@ index-state: 2025-02-11T14:26:56Z
 allow-newer:
   all:base
 
+if arch(javascript)
+  -- https://github.com/haskellari/splitmix/pull/73
+  source-repository-package
+    type: git
+    location: https://github.com/amesgen/splitmix
+    tag: 5f5b766d97dc735ac228215d240a3bb90bc2ff75
+
 if arch(wasm32)
   -- Required for TemplateHaskell. When using wasm32-wasi-cabal from
   -- ghc-wasm-meta, this is superseded by the global cabal.config.

--- a/default.nix
+++ b/default.nix
@@ -8,12 +8,12 @@ with pkgs.haskell.lib;
 
   # hackage release
   release =
-    with legacyPkgs.haskell.packages.ghcjs;
+    with pkgs.haskell.packages.ghc9122;
     sdistTarball (buildStrictly miso);
 
   # hackage release examples
   release-examples =
-    with legacyPkgs.haskell.packages.ghcjs;
+    with pkgs.haskell.packages.ghc9122;
     sdistTarball (buildStrictly miso-examples);
 
   # ghcjs9122

--- a/default.nix
+++ b/default.nix
@@ -1,76 +1,93 @@
-with (builtins.fromJSON (builtins.readFile ./nix/nixpkgs.json));
 { overlays ? []
 }:
-let
-  pkgs = import ./nix {
-    inherit overlays;
-  };
-in
+with (import ./nix { inherit overlays; });
+
 with pkgs.haskell.lib;
 {
-  inherit pkgs;
+  inherit pkgs legacyPkgs;
 
-  # hacakge release
+  # hackage release
   release =
-    with pkgs.haskell.packages.ghc9122;
+    with legacyPkgs.haskell.packages.ghcjs;
     sdistTarball (buildStrictly miso);
 
+  # hackage release examples
   release-examples =
-    with pkgs.pkgsCross.ghcjs.haskell.packages.ghc9122;
+    with legacyPkgs.haskell.packages.ghcjs;
     sdistTarball (buildStrictly miso-examples);
 
-  #js
-  miso-ghcjs = pkgs.pkgsCross.ghcjs.haskell.packages.ghc9122.miso;
-  inherit (pkgs.pkgsCross.ghcjs.haskell.packages.ghc9122) miso-examples sample-app-js;
+  # ghcjs9122
+  miso-ghcjs-9122 = pkgs.pkgsCross.ghcjs.haskell.packages.ghc9122.miso;
+  miso-examples-9122 = pkgs.pkgsCross.ghcjs.haskell.packages.ghc9122.miso-examples;
+  sample-app-js-9122 = pkgs.pkgsCross.ghcjs.haskell.packages.ghc9122.sample-app-js;
+
+  # ghcjs86
+  miso-ghcjs = legacyPkgs.haskell.packages.ghcjs.miso;
+  inherit (legacyPkgs.haskell.packages.ghcjs) miso-examples sample-app-js;
   
-  #native
-  miso-ghc = pkgs.haskell.packages.ghc9122.miso;
-  miso-examples-ghc = pkgs.haskell.packages.ghc9122.miso-examples;
-  inherit (pkgs.haskell.packages.ghc9122) sample-app;
+  # x86
+  miso-ghc = legacyPkgs.haskell.packages.ghc865.miso;
+  miso-ghc-9122 = pkgs.haskell.packages.ghc9122.miso;
+
+  # x86
+  miso-examples-ghc = legacyPkgs.haskell.packages.ghc865.miso-examples;
+  miso-examples-ghc-9122 = pkgs.haskell.packages.ghc9122.miso-examples;
+
+  inherit (legacyPkgs.haskell.packages.ghc865)
+    sample-app;
+
+  inherit (pkgs.haskell.packages.ghc9122)
+    sample-app-ghc9122;
 
   # Miso wasm examples
-  # nix-build -A wasmExamples
-  #   && ./result/bin/build.sh
-  #   && nix-build -A svgWasm
-  #   && http-server ./result/svg.wasmexe
   inherit (pkgs)
     wasmExamples
     svgWasm
     componentsWasm
     todoWasm;
 
-  #wasm utils
+  # wasm utils
   inherit (pkgs)
     wasm-ghc
     ghc-wasm-meta
     hello-world-web-wasm;
 
   # sse
-  inherit (pkgs.ssePkgs)
+  inherit (import ./examples/sse {})
     sse-runner
     sse-client
     sse-server;
 
-  #website
-  inherit (pkgs)
+  # website
+  inherit (import ./haskell-miso.org {})
     haskell-miso-dev
     haskell-miso-client
     haskell-miso-server
     haskell-miso-runner;
 
-  #code coverage
-  inherit (pkgs) coverage;
+  # code coverage
+  inherit (pkgs)
+    coverage;
 
-  #ci
-  deploy = pkgs.deploy rev;
-  inherit (pkgs) haskell-miso-org-test nixops;
+  # ci
+  inherit (legacyPkgs)
+    deploy
+    nixops
+    haskell-miso-org-test;
 
   # ghciwatch
-  inherit (pkgs) ghciwatch;
+  inherit (pkgs)
+    ghciwatch;
 
   # utils
-  inherit (pkgs.haskell.packages.ghc9122) miso-from-html;
+  inherit (pkgs.haskell.packages.ghc9122)
+    miso-from-html;
 
   # misc. examples
-  inherit (pkgs) more-examples;
+  inherit (legacyPkgs)
+    more-examples;
+
+  # bun
+  inherit (pkgs)
+    bun;
 }

--- a/default.nix
+++ b/default.nix
@@ -23,6 +23,7 @@ with pkgs.haskell.lib;
 
   # ghcjs86
   miso-ghcjs = legacyPkgs.haskell.packages.ghcjs.miso;
+  miso-ghcjs-prod = legacyPkgs.haskell.packages.ghcjs86.miso-prod;
   inherit (legacyPkgs.haskell.packages.ghcjs) miso-examples sample-app-js;
   
   # x86

--- a/default.nix
+++ b/default.nix
@@ -33,11 +33,13 @@ with pkgs.haskell.lib;
   miso-examples-ghc = legacyPkgs.haskell.packages.ghc865.miso-examples;
   miso-examples-ghc-9122 = pkgs.haskell.packages.ghc9122.miso-examples;
 
+  # sample app legacy build
   inherit (legacyPkgs.haskell.packages.ghc865)
     sample-app;
 
-  inherit (pkgs.haskell.packages.ghc9122)
-    sample-app-ghc9122;
+  # sample app
+  sample-app-ghc9122 =
+    pkgs.haskell.packages.ghc9122.sample-app;
 
   # Miso wasm examples
   inherit (pkgs)

--- a/default.nix
+++ b/default.nix
@@ -1,31 +1,32 @@
 with (builtins.fromJSON (builtins.readFile ./nix/nixpkgs.json));
-{ haddock ? true, tests ? false, overlays ? [] }:
+{ overlays ? []
+}:
 let
   pkgs = import ./nix {
-    inherit haddock tests overlays;
+    inherit overlays;
   };
-in with pkgs.haskell.lib;
+in
+with pkgs.haskell.lib;
 {
   inherit pkgs;
 
   # hacakge release
   release =
-    with pkgs.haskell.packages.ghc865;
+    with pkgs.haskell.packages.ghc9122;
     sdistTarball (buildStrictly miso);
 
   release-examples =
-    with pkgs.haskell.packages.ghcjs;
+    with pkgs.pkgsCross.ghcjs.haskell.packages.ghc9122;
     sdistTarball (buildStrictly miso-examples);
 
   #js
-  miso-ghcjs = pkgs.haskell.packages.ghcjs86.miso;
-  miso-ghcjs-prod = pkgs.haskell.packages.ghcjs86.miso-prod;
-  inherit (pkgs.haskell.packages.ghcjs86) miso-examples sample-app-js;
+  miso-ghcjs = pkgs.pkgsCross.ghcjs.haskell.packages.ghc9122.miso;
+  inherit (pkgs.pkgsCross.ghcjs.haskell.packages.ghc9122) miso-examples sample-app-js;
   
   #native
-  miso-ghc = pkgs.haskell.packages.ghc865.miso;
-  miso-examples-ghc = pkgs.haskell.packages.ghc865.miso-examples;
-  inherit (pkgs.haskell.packages.ghc865) sample-app;
+  miso-ghc = pkgs.haskell.packages.ghc9122.miso;
+  miso-examples-ghc = pkgs.haskell.packages.ghc9122.miso-examples;
+  inherit (pkgs.haskell.packages.ghc9122) sample-app;
 
   # Miso wasm examples
   # nix-build -A wasmExamples
@@ -68,11 +69,8 @@ in with pkgs.haskell.lib;
   inherit (pkgs) ghciwatch;
 
   # utils
-  inherit (pkgs.haskell.packages.ghc865) miso-from-html;
+  inherit (pkgs.haskell.packages.ghc9122) miso-from-html;
 
   # misc. examples
   inherit (pkgs) more-examples;
-
-  # typescript bundler / minifer / builder
-  inherit (pkgs) bun;
 }

--- a/examples/sse/default.nix
+++ b/examples/sse/default.nix
@@ -2,19 +2,16 @@
 with (import ../.. {});
 let
   inherit (pkgs) runCommand closurecompiler;
-  inherit (pkgs.haskell.packages) ghcjs86 ghc865;
-  client = ghcjs86.callCabal2nix "sse" ./. {};
-  server = ghc865.callCabal2nix "sse" ./. {};
+  ghc = pkgs.haskell.packages.ghc9122;
+  ghcjs = pkgs.pkgsCross.ghcjs.haskell.packages.ghc9122;
+  client = ghcjs.callCabal2nix "sse" ./. {};
+  server = ghc.callCabal2nix "sse" ./. {};
 in
 {
   sse-runner = runCommand "sse.haskell-miso.org" { inherit client server; } ''
     mkdir -p $out/{bin,static}
-    cp ${server}/bin/* $out/bin
-    ${closurecompiler}/bin/closure-compiler --compilation_level ADVANCED_OPTIMIZATIONS \
-      --jscomp_off=checkVars \
-      --externs=${client}/bin/client.jsexe/all.js.externs \
-      ${client}/bin/client.jsexe/all.js > temp.js
-    mv temp.js $out/static/all.js
+    cp -v ${server}/bin/* $out/bin
+    cp -v ${client}/bin/client.jsexe/all.js $out/static/all.js
   '';
   sse-client = client;
   sse-server = server;

--- a/examples/sse/default.nix
+++ b/examples/sse/default.nix
@@ -2,16 +2,20 @@
 with (import ../.. {});
 let
   inherit (pkgs) runCommand closurecompiler;
-  ghc = pkgs.haskell.packages.ghc9122;
-  ghcjs = pkgs.pkgsCross.ghcjs.haskell.packages.ghc9122;
+  ghc = legacyPkgs.haskell.packages.ghc865;
+  ghcjs = legacyPkgs.haskell.packages.ghcjs;
   client = ghcjs.callCabal2nix "sse" ./. {};
   server = ghc.callCabal2nix "sse" ./. {};
 in
 {
   sse-runner = runCommand "sse.haskell-miso.org" { inherit client server; } ''
     mkdir -p $out/{bin,static}
-    cp -v ${server}/bin/* $out/bin
-    cp -v ${client}/bin/client.jsexe/all.js $out/static/all.js
+    cp ${server}/bin/* $out/bin
+    ${closurecompiler}/bin/closure-compiler --compilation_level ADVANCED_OPTIMIZATIONS \
+      --jscomp_off=checkVars \
+      --externs=${client}/bin/client.jsexe/all.js.externs \
+      ${client}/bin/client.jsexe/all.js > temp.js
+    mv temp.js $out/static/all.js
   '';
   sse-client = client;
   sse-server = server;

--- a/examples/sse/nix/machine.nix
+++ b/examples/sse/nix/machine.nix
@@ -7,18 +7,18 @@
       enable = true;
       virtualHosts = {
         "sse.haskell-miso.org" = {
-      	   extraConfig = "
-      	     proxy_set_header Connection '';
-      	     proxy_http_version 1.1;
-      	     chunked_transfer_encoding off;
-      	     proxy_buffering off;
-      	     proxy_cache off;
-      	   ";
-           forceSSL = true;
-           enableACME = true;
-           locations = {
-	     "/" = {
-	        proxyPass = "http://localhost:3003";
+      	  extraConfig = "
+      	  proxy_set_header Connection '';
+      	  proxy_http_version 1.1;
+      	  chunked_transfer_encoding off;
+      	  proxy_buffering off;
+      	  proxy_cache off;
+      	  ";
+          forceSSL = true;
+          enableACME = true;
+          locations = {
+	          "/" = {
+	            proxyPass = "http://localhost:3003";
             };
           };
         };

--- a/haskell-miso.org/default.nix
+++ b/haskell-miso.org/default.nix
@@ -3,10 +3,11 @@ with (import ../default.nix {});
 let
   src = import ../nix/haskell/packages/source.nix pkgs;
   inherit (pkgs) runCommand closurecompiler;
-  inherit (pkgs.haskell.packages) ghcjs86 ghc865;
-  client = ghcjs86.callCabal2nix "haskell-miso" (src.haskell-miso-src) {};
-  server = ghc865.callCabal2nix "haskell-miso" (src.haskell-miso-src) {};
-  dev = ghc865.callCabal2nixWithOptions "haskell-miso" (src.haskell-miso-src) "-fdev" {};
+  ghc = pkgs.haskell.packages.ghc9122;
+  ghcjs = pkgs.pkgsCross.ghcjs.haskell.packages.ghc9122;
+  client = ghcjs.callCabal2nix "haskell-miso" (src.haskell-miso-src) {};
+  server = ghc.callCabal2nix "haskell-miso" (src.haskell-miso-src) {};
+  dev = ghc.callCabal2nixWithOptions "haskell-miso" (src.haskell-miso-src) "-fdev" {};
 in
 { haskell-miso-client = client;
   haskell-miso-server = server;
@@ -14,11 +15,7 @@ in
   haskell-miso-runner = 
     runCommand "haskell-miso.org" { inherit client server; } ''
       mkdir -p $out/{bin,static}
-      cp ${server}/bin/* $out/bin
-      ${closurecompiler}/bin/closure-compiler --compilation_level ADVANCED_OPTIMIZATIONS \
-        --jscomp_off=checkVars \
-        --externs=${client}/bin/client.jsexe/all.js.externs \
-        ${client}/bin/client.jsexe/all.js > temp.js
-      mv temp.js $out/static/all.js
+      cp -v ${server}/bin/* $out/bin
+      cp -v ${client}/bin/client.jsexe/all.js $out/static/all.js
     '';
 }

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -2,13 +2,13 @@ options:
 with (builtins.fromJSON (builtins.readFile ./nixpkgs.json));
 let
   nixpkgs = builtins.fetchTarball {
-    url = "https://github.com/NixOS/nixpkgs/archive/${rev}.tar.gz";
+    url = "https://github.com/alexfmpe/nixpkgs/archive/${rev}.tar.gz";
     inherit sha256;
   };
   config.allowUnfree = true;
   config.allowBroken = false;
   overlays = [ (import ./wasm)
-               (import ./overlay.nix options)
+               (import ./overlay.nix)
              ] ++ options.overlays;
 in
   import nixpkgs

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -10,7 +10,9 @@ let
   overlays = [ (import ./wasm)
                (import ./overlay.nix)
              ] ++ options.overlays;
+  legacyPkgs = import ./legacy options;
+  pkgs = import nixpkgs { inherit overlays config; };
 in
-  import nixpkgs
-    { inherit overlays config;
-    }
+{
+  inherit pkgs legacyPkgs;
+}

--- a/nix/haskell/packages/ghc/default.nix
+++ b/nix/haskell/packages/ghc/default.nix
@@ -1,6 +1,6 @@
 pkgs:
 let
-  source = import ../source.nix pkgs;
+  source = import ../../../source.nix pkgs;
 in
 with pkgs.haskell.lib;
 self: super:

--- a/nix/haskell/packages/ghc/default.nix
+++ b/nix/haskell/packages/ghc/default.nix
@@ -5,11 +5,23 @@ in
 with pkgs.haskell.lib;
 self: super:
 {
+  /* miso */
   miso = self.callCabal2nix "miso" source.miso {};
-  miso-examples = self.callCabal2nix "miso-examples" source.examples {};
-  miso-from-html = self.callCabal2nix "miso-from-html" source.miso-from-html {};
-  sample-app = self.callCabal2nix "app" source.sample-app {};
 
+  /* miso utils */
+  miso-from-html = self.callCabal2nix "miso-from-html" source.miso-from-html {};
+
+  /* examples */
+  miso-examples = self.callCabal2nix "miso-examples" source.examples {};
+  sample-app = self.callCabal2nix "app" source.sample-app {};
   jsaddle = self.callCabal2nix "jsaddle" "${source.jsaddle}/jsaddle" {};
-  jsaddle-warp = dontCheck (self.callCabal2nix "jsaddle-warp" "${source.jsaddle}/jsaddle-warp" {});
+  jsaddle-warp =
+    dontCheck (self.callCabal2nix "jsaddle-warp" "${source.jsaddle}/jsaddle-warp" {});
+
+  /* cruft */
+  crypton = dontCheck super.crypton;
+  cryptonite = dontCheck super.cryptonite;
+  monad-logger = doJailbreak super.monad-logger;
+  string-interpolate = doJailbreak super.string-interpolate;
+  servant-server = doJailbreak super.servant-server;
 }

--- a/nix/haskell/packages/ghcjs/default.nix
+++ b/nix/haskell/packages/ghcjs/default.nix
@@ -1,14 +1,13 @@
 pkgs:
 let
-  source = import ../source.nix pkgs;
+  source = import ../../../source.nix pkgs;
 in
 with pkgs.haskell.lib;
 with pkgs.lib;
 self: super:
 {
   /* miso */
-  miso = (self.callCabal2nixWithOptions "miso" source.miso "-ftests" {}).overrideAttrs
-    (drv: { doHaddock = true; });
+  miso = doHaddock (self.callCabal2nix "miso" source.miso {});
 
   /* examples */
   sample-app-js = self.callCabal2nix "app" source.sample-app {};

--- a/nix/haskell/packages/ghcjs/default.nix
+++ b/nix/haskell/packages/ghcjs/default.nix
@@ -1,4 +1,4 @@
-options: pkgs:
+pkgs:
 let
   source = import ../source.nix pkgs;
 in
@@ -6,53 +6,45 @@ with pkgs.haskell.lib;
 with pkgs.lib;
 self: super:
 {
-  inherit (pkgs.haskell.packages.ghc865) hpack;
+  /* miso */
+  miso = (self.callCabal2nixWithOptions "miso" source.miso "-ftests" {}).overrideAttrs
+    (drv: { doHaddock = true; });
+
+  /* examples */
   sample-app-js = self.callCabal2nix "app" source.sample-app {};
   jsaddle = self.callCabal2nix "jsaddle" "${source.jsaddle}/jsaddle" {};
-  jsaddle-warp = dontCheck (self.callCabal2nix "jsaddle-warp" "${source.jsaddle}/jsaddle-warp" {});
   flatris = self.callCabal2nix "flatris" source.flatris {};
-  miso-plane =
-    let
-      miso-plane = self.callCabal2nix "miso-plane" source.miso-plane {};
-    in
-      pkgs.runCommand "miso-plane" {} ''
-         mkdir $out
-         cp -rv ${source.miso-plane}/public/images $out
-         cp ${miso-plane}/bin/client.jsexe/* $out
-         rm $out/index.html
-         cp -v ${source.miso-plane}/public/index.html $out
-      '';
-  the2048 = import source.the2048 { inherit pkgs; inherit (self) miso; };
+  miso-plane-core = self.callCabal2nix "miso-plane" source.miso-plane {};
+  miso-plane = pkgs.runCommand "miso-plane" {} ''
+    mkdir -p $out
+    cp -rv ${source.miso-plane}/public/images $out
+    cp -v ${self.miso-plane-core}/bin/client.jsexe/* $out
+    chmod +w $out/index.html
+    cp -v ${source.miso-plane}/public/index.html $out
+  '';
+  the2048-core = self.callCabal2nix "hs2048" source.the2048 {};
+  the2048 = pkgs.runCommand "hs2048" {} ''
+    mkdir -p $out/bin
+    cp -rv ${self.the2048-core}/bin/*.jsexe $out/*
+    chmod +w $out/bin/*.jsexe
+    chmod +w $out/bin/*.jsexe/index.html
+    cp -v ${source.the2048}/static/main.css $out/bin/app.jsexe/main.css
+    cp -v ${source.the2048}/static/index.html $out/bin/app.jsexe/index.html
+  '';
   snake = self.callCabal2nix "miso-snake" source.snake {};
-  mkDerivation = args: super.mkDerivation (args // { doCheck = false; });
-  doctest = null;
-  miso-examples = (self.callCabal2nix "miso-examples" source.examples {}).overrideDerivation (drv: {
-    doHaddock = options.haddock;
-    postInstall = ''
-      mkdir -p $out/bin/mario.jsexe/imgs
-      mkdir -p $out/bin/threejs.jsexe
-      cp -r ${drv.src}/mario/imgs $out/bin/mario.jsexe/
-      cp ${drv.src}/xhr/index.html $out/bin/xhr.jsexe/
-      cp -fv ${drv.src}/three/index.html $out/bin/threejs.jsexe/
-      ${pkgs.closurecompiler}/bin/closure-compiler --compilation_level ADVANCED_OPTIMIZATIONS \
-         --jscomp_off=checkVars \
-         --externs=$out/bin/todo-mvc.jsexe/all.js.externs \
-         $out/bin/todo-mvc.jsexe/all.js > temp.js
-      mv temp.js $out/bin/todo-mvc.jsexe/all.js
-      cp -fv ${drv.src}/todo-mvc/index.html $out/bin/todo-mvc.jsexe/
-      cp -v ${source.todomvc-common}/base.css $out/bin/todo-mvc.jsexe
-      cp -v ${source.todomvc-app-css}/index.css $out/bin/todo-mvc.jsexe
-      '';
-  });
-  miso-prod = self.callCabal2nixWithOptions "miso" source.miso "-fproduction" {};
-  miso = (self.callCabal2nixWithOptions "miso" source.miso "-ftests" {}).overrideDerivation (drv: {
-    doHaddock = options.haddock;
-    postInstall = pkgs.lib.optionalString options.tests ''
-      ${pkgs.closurecompiler}/bin/closure-compiler --compilation_level ADVANCED_OPTIMIZATIONS \
-         --jscomp_off=checkVars \
-         --externs=$out/bin/tests.jsexe/all.js.externs \
-           $out/bin/tests.jsexe/all.js > temp.js
-           mv temp.js $out/bin/tests.jsexe/all.js
-         '';
-  });
+  miso-examples-core = self.callCabal2nix "miso-examples" source.examples {};
+  miso-examples = pkgs.runCommand "miso-examples" {} ''
+    mkdir -p $out/bin/mario.jsexe/imgs
+    cp -fr ${self.miso-examples-core}/bin/*.jsexe $out/*
+    cp -frv ${source.examples}/mario/imgs $out/bin/mario.jsexe/
+    chmod +w $out/bin/xhr.jsexe/index.html
+    cp -fv ${source.examples}/xhr/index.html $out/bin/xhr.jsexe/index.html
+    chmod +w $out/bin/threejs.jsexe/index.html
+    cp -fv ${source.examples}/three/index.html $out/bin/threejs.jsexe/index.html
+    chmod +w $out/bin/todo-mvc.jsexe/index.html
+    cp -fv ${source.examples}/todo-mvc/index.html $out/bin/todo-mvc.jsexe/index.html
+    chmod +w $out/bin/todo-mvc.jsexe
+    cp -fv ${source.todomvc-common}/base.css $out/bin/todo-mvc.jsexe/base.css
+    cp -fv ${source.todomvc-app-css}/index.css $out/bin/todo-mvc.jsexe/index.css
+  '';
 }

--- a/nix/legacy/default.nix
+++ b/nix/legacy/default.nix
@@ -1,0 +1,16 @@
+options:
+with (builtins.fromJSON (builtins.readFile ./nixpkgs.json));
+let
+  nixpkgs = builtins.fetchTarball {
+    url = "https://github.com/NixOS/nixpkgs/archive/${rev}.tar.gz";
+    inherit sha256;
+  };
+  config = {
+    allowUnfree = true;
+    allowBroken = false;
+  };
+  overlays = [ (import ./overlay.nix options) ];
+in
+  import nixpkgs
+    { inherit overlays config;
+    }

--- a/nix/legacy/haskell/packages/ghc/default.nix
+++ b/nix/legacy/haskell/packages/ghc/default.nix
@@ -1,0 +1,15 @@
+pkgs:
+let
+  source = import ../../../../source.nix pkgs;
+in
+with pkgs.haskell.lib;
+self: super:
+{
+  miso = self.callCabal2nix "miso" source.miso {};
+  miso-examples = self.callCabal2nix "miso-examples" source.examples {};
+  miso-from-html = self.callCabal2nix "miso-from-html" source.miso-from-html {};
+  sample-app = self.callCabal2nix "app" source.sample-app {};
+
+  jsaddle = self.callCabal2nix "jsaddle" "${source.jsaddle}/jsaddle" {};
+  jsaddle-warp = dontCheck (self.callCabal2nix "jsaddle-warp" "${source.jsaddle}/jsaddle-warp" {});
+}

--- a/nix/legacy/haskell/packages/ghcjs/default.nix
+++ b/nix/legacy/haskell/packages/ghcjs/default.nix
@@ -1,0 +1,48 @@
+options: pkgs:
+let
+  source = import ../../../../source.nix pkgs;
+in
+with pkgs.haskell.lib;
+with pkgs.lib;
+self: super:
+{
+  inherit (pkgs.haskell.packages.ghc865) hpack;
+  sample-app-js = self.callCabal2nix "app" source.sample-app {};
+  jsaddle = self.callCabal2nix "jsaddle" "${source.jsaddle}/jsaddle" {};
+  jsaddle-warp = dontCheck (self.callCabal2nix "jsaddle-warp" "${source.jsaddle}/jsaddle-warp" {});
+  flatris = self.callCabal2nix "flatris" source.flatris {};
+  miso-plane =
+    let
+      miso-plane = self.callCabal2nix "miso-plane" source.miso-plane {};
+    in
+      pkgs.runCommand "miso-plane" {} ''
+         mkdir $out
+         cp -rv ${source.miso-plane}/public/images $out
+         cp ${miso-plane}/bin/client.jsexe/* $out
+         rm $out/index.html
+         cp -v ${source.miso-plane}/public/index.html $out
+      '';
+  the2048 = import source.the2048 { inherit pkgs; inherit (self) miso; };
+  snake = self.callCabal2nix "miso-snake" source.snake {};
+  mkDerivation = args: super.mkDerivation (args // { doCheck = false; });
+  doctest = null;
+  miso-examples = (self.callCabal2nix "miso-examples" source.examples {}).overrideDerivation (drv: {
+    postInstall = ''
+      mkdir -p $out/bin/mario.jsexe/imgs
+      mkdir -p $out/bin/threejs.jsexe
+      cp -r ${drv.src}/mario/imgs $out/bin/mario.jsexe/
+      cp ${drv.src}/xhr/index.html $out/bin/xhr.jsexe/
+      cp -fv ${drv.src}/three/index.html $out/bin/threejs.jsexe/
+      ${pkgs.closurecompiler}/bin/closure-compiler --compilation_level ADVANCED_OPTIMIZATIONS \
+         --jscomp_off=checkVars \
+         --externs=$out/bin/todo-mvc.jsexe/all.js.externs \
+         $out/bin/todo-mvc.jsexe/all.js > temp.js
+      mv temp.js $out/bin/todo-mvc.jsexe/all.js
+      cp -fv ${drv.src}/todo-mvc/index.html $out/bin/todo-mvc.jsexe/
+      cp -v ${source.todomvc-common}/base.css $out/bin/todo-mvc.jsexe
+      cp -v ${source.todomvc-app-css}/index.css $out/bin/todo-mvc.jsexe
+      '';
+  });
+  miso-prod = self.callCabal2nixWithOptions "miso" source.miso "-fproduction" {};
+  miso = doHaddock (self.callCabal2nix "miso" source.miso {});
+}

--- a/nix/legacy/nixpkgs.json
+++ b/nix/legacy/nixpkgs.json
@@ -1,0 +1,4 @@
+{
+  "rev" : "868282b4aa56a01ef9306d2c7cfdddf14a4d89f7",
+  "sha256" : "1712zds1gns0zpkc2apw2fy60fdyfp84gz6qh2m9l7np5dcw6m5h"
+}

--- a/nix/legacy/overlay.nix
+++ b/nix/legacy/overlay.nix
@@ -1,0 +1,74 @@
+options: self: super: {
+
+  nixosPkgsSrc =
+    "https://github.com/nixos/nixpkgs/archive/6d1a044fc9ff3cc96fca5fa3ba9c158522bbf2a5.tar.gz";
+
+  haskell = super.haskell // {
+    packages = super.haskell.packages // {
+      ghc865 = super.haskell.packages.ghc865.override {
+        overrides = import ./haskell/packages/ghc self;
+      };
+      ghc864 = super.haskell.packages.ghc864.override {
+        overrides = selfGhc864: superGhc864: with super.haskell.lib; {
+          happy = dontCheck (selfGhc864.callHackage "happy" "1.19.9" {});
+          mkDerivation = args: superGhc864.mkDerivation (args // {
+            enableLibraryProfiling = false;
+            doCheck = false;
+            doHaddock = false;
+          });
+        };
+      };
+      ghcjs86 = super.haskell.packages.ghcjs86.override {
+        overrides = import ./haskell/packages/ghcjs options self;
+      };
+    };
+  };
+
+  nixops = super.nixops.overrideAttrs (drv: {
+    src = builtins.fetchTarball {
+      url = "https://nixos.org/releases/nixops/nixops-1.7/nixops-1.7.tar.bz2";
+      sha256 = "sha256:1iax9hz16ry1pm9yw2wab0np7140d7pv4rnk1bw63kq4gnxnr93c";
+    };
+  });
+
+  haskell-miso-org-test = self.nixosTest {
+    nodes.machine = { config, pkgs, ... }: {
+      imports = [ ../../haskell-miso.org/nix/machine.nix ];
+    };
+    testScript = {nodes, ...}:
+      ''
+      startAll;
+      $machine->waitForUnit("haskell-miso.service");
+      $machine->succeed("curl localhost:3002");
+      '';
+  };
+
+  deploy = super.writeScript "deploy" ''
+    export PATH=$PATH:${self.nixops}/bin
+    export PATH=$PATH:${self.jq}/bin
+    rm -rf ~/.nixops
+    mkdir -p ~/.aws
+    echo "[dev]" >> ~/.aws/credentials
+    echo "aws_access_key_id = $AWS_ACCESS_KEY_ID" >> ~/.aws/credentials
+    echo "aws_secret_access_key = $AWS_SECRET_ACCESS_KEY" >> ~/.aws/credentials
+    mkdir -p ~/.ssh
+    echo "Host *" > ~/.ssh/config
+    echo "  StrictHostKeyChecking=no" >> ~/.ssh/config
+    chmod 600 ~/.ssh/config
+    chown $USER ~/.ssh/config
+    echo $DEPLOY | jq > deploy.json
+    nixops import < deploy.json
+    rm deploy.json
+    nixops set-args --argstr email $EMAIL -d haskell-miso
+    nixops modify haskell-miso.org/nix/aws.nix -d haskell-miso -Inixpkgs=${self.nixosPkgsSrc}
+    nix --version
+    # https://github.com/NixOS/nixops/issues/1557
+    nix shell github:nixos/nixpkgs/8ad5e8132c5dcf977e308e7bf5517cc6cc0bf7d8#nix -c \
+      nixops ssh -d haskell-miso awsBox nix-collect-garbage -d
+    nix shell github:nixos/nixpkgs/8ad5e8132c5dcf977e308e7bf5517cc6cc0bf7d8#nix -c \
+      nixops deploy -j1 -d haskell-miso --option substituters "https://cache.nixos.org/"
+  '';
+  more-examples = with super.haskell.lib; {
+    inherit (self.haskell.packages.ghcjs) flatris the2048 snake miso-plane;
+  };
+}

--- a/nix/nixpkgs.json
+++ b/nix/nixpkgs.json
@@ -1,4 +1,4 @@
 {
-  "rev" : "868282b4aa56a01ef9306d2c7cfdddf14a4d89f7",
-  "sha256" : "1712zds1gns0zpkc2apw2fy60fdyfp84gz6qh2m9l7np5dcw6m5h"
+  "rev" : "b594b289740a2bc917ed9c66fef5d905f389cb96",
+  "sha256" : "sha256:1p25582cbrjlqv4kr64481m776vgppgxghinrdjpfjglkjj3aw2w"
 }

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -1,27 +1,11 @@
 self: super: {
 
-  nixosPkgsSrc =
-    "https://github.com/nixos/nixpkgs/archive/6d1a044fc9ff3cc96fca5fa3ba9c158522bbf2a5.tar.gz";
-
-  haskell-miso-org-test = self.nixosTest {
-    # virtualisation.memorySize = 1024 * 10;
-    nodes.machine = { config, pkgs, ... }: {
-      imports = [ ../haskell-miso.org/nix/machine.nix ];
-    };
-    name = "haskell-miso.org test runner";
-    testScript = {nodes, ...}:
-      ''
-      startAll;
-      $machine->waitForUnit("haskell-miso.service");
-      $machine->succeed("curl localhost:3002");
-      '';
-  };
-
+  # ghci watcher
   ghciwatch =
     (builtins.getFlake "github:MercuryTechnologies/ghciwatch")
       .outputs.packages."${super.system}".ghciwatch;
 
-  # dmj: ensure you call nix-shell -p yarn --run 'yarn install' first
+  # dmj: ensure you call 'bun run test' first
   # js nix packaging is more trouble than its worth right now
   coverage = self.stdenv.mkDerivation {
     name = "coverage";
@@ -32,17 +16,7 @@ self: super: {
     '';
   };
 
-  ssePkgs = import ../examples/sse {};
-
-  sample-app-tagged =
-    import ../sample-app {};
-
-  inherit (import ../haskell-miso.org {})
-    haskell-miso-dev
-    haskell-miso-client
-    haskell-miso-server
-    haskell-miso-runner;
-
+  # haskell stuff
   haskell = super.haskell // {
     packages = super.haskell.packages // {
       ghc9122 = super.haskell.packages.ghc9122.override {
@@ -51,42 +25,5 @@ self: super: {
           else import ./haskell/packages/ghc self;
       };
     };
-  };
-
-  nixops = super.nixops.overrideAttrs (drv: {
-    src = builtins.fetchTarball {
-      url = "https://nixos.org/releases/nixops/nixops-1.7/nixops-1.7.tar.bz2";
-      sha256 = "sha256:1iax9hz16ry1pm9yw2wab0np7140d7pv4rnk1bw63kq4gnxnr93c";
-    };
-  });
-
-  deploy = rev: super.writeScript "deploy" ''
-    export PATH=$PATH:${self.nixops}/bin
-    export PATH=$PATH:${self.jq}/bin
-    rm -rf ~/.nixops
-    mkdir -p ~/.aws
-    echo "[dev]" >> ~/.aws/credentials
-    echo "aws_access_key_id = $AWS_ACCESS_KEY_ID" >> ~/.aws/credentials
-    echo "aws_secret_access_key = $AWS_SECRET_ACCESS_KEY" >> ~/.aws/credentials
-    mkdir -p ~/.ssh
-    echo "Host *" > ~/.ssh/config
-    echo "  StrictHostKeyChecking=no" >> ~/.ssh/config
-    chmod 600 ~/.ssh/config
-    chown $USER ~/.ssh/config
-    echo $DEPLOY | jq > deploy.json
-    nixops import < deploy.json
-    rm deploy.json
-    nixops set-args --argstr email $EMAIL -d haskell-miso
-    nixops modify haskell-miso.org/nix/aws.nix -d haskell-miso -Inixpkgs=${self.nixosPkgsSrc}
-    nix --version
-    # https://github.com/NixOS/nixops/issues/1557
-    nix shell github:nixos/nixpkgs/8ad5e8132c5dcf977e308e7bf5517cc6cc0bf7d8#nix -c \
-      nixops ssh -d haskell-miso awsBox nix-collect-garbage -d
-    nix shell github:nixos/nixpkgs/8ad5e8132c5dcf977e308e7bf5517cc6cc0bf7d8#nix -c \
-      nixops deploy -j1 -d haskell-miso --option substituters "https://cache.nixos.org/"
-  '';
-  more-examples = with super.haskell.lib; {
-    inherit (self.pkgsCross.ghcjs.haskell.packages.ghc9122)
-      flatris the2048 snake miso-plane;
   };
 }

--- a/nix/source.nix
+++ b/nix/source.nix
@@ -20,10 +20,10 @@ let
     };
 in
 {
-  miso = make-src-filter ../../..;
-  examples = make-src-filter ../../../examples;
-  haskell-miso-src = make-src-filter ../../../haskell-miso.org;
-  sample-app = make-src-filter ../../../sample-app;
+  miso             = make-src-filter ../.;
+  examples         = make-src-filter ../examples;
+  sample-app       = make-src-filter ../sample-app;
+  haskell-miso-src = make-src-filter ../haskell-miso.org;
   miso-from-html = fetchFromGitHub {
     owner = "dmjio";
     repo = "miso-from-html";

--- a/nix/wasm/default.nix
+++ b/nix/wasm/default.nix
@@ -45,6 +45,10 @@ self: super:
         src = self.wasmHelloWorld;
       };
 
+  # nix-build -A wasmExamples
+  #   && ./result/bin/build.sh
+  #   && nix-build -A svgWasm
+  #   && http-server ./result/svg.wasmexe
   svgWasm =
     self.wasmPkgExample {
        name = "svg";

--- a/shell.nix
+++ b/shell.nix
@@ -6,6 +6,5 @@ if pkg == "ghcjs"
 then miso-ghcjs.env
 else miso-ghc.env.overrideAttrs (d: {  
   shellHook = ''
-    alias runner="${pkgs.haskell.packages.ghc865.ghcid}/bin/ghcid -c 'cabal repl'"
   '';
 })

--- a/shell.nix
+++ b/shell.nix
@@ -6,6 +6,6 @@ if pkg == "ghcjs"
 then miso-ghcjs.env
 else miso-ghc.env.overrideAttrs (d: {  
   shellHook = ''
-    alias runner="${pkgs.haskell.packages.ghc865.ghcid}/bin/ghcid -c 'cabal repl'"
+    alias runner="${legacyPkgs.haskell.packages.ghc865.ghcid}/bin/ghcid -c 'cabal repl'"
   '';
 })

--- a/shell.nix
+++ b/shell.nix
@@ -4,7 +4,7 @@ with (import ./default.nix {});
 
 if pkg == "ghcjs"
 then miso-ghcjs.env
-else miso-ghc.env.overrideAttrs (d: {  
+else miso-ghc-9122.env.overrideAttrs (d: {
   shellHook = ''
     alias runner="${legacyPkgs.haskell.packages.ghc865.ghcid}/bin/ghcid -c 'cabal repl'"
   '';

--- a/shell.nix
+++ b/shell.nix
@@ -6,5 +6,6 @@ if pkg == "ghcjs"
 then miso-ghcjs.env
 else miso-ghc.env.overrideAttrs (d: {  
   shellHook = ''
+    alias runner="${pkgs.haskell.packages.ghc865.ghcid}/bin/ghcid -c 'cabal repl'"
   '';
 })

--- a/src/Miso.hs
+++ b/src/Miso.hs
@@ -61,7 +61,7 @@ module Miso
 import           Control.Monad (void)
 import           Control.Monad.IO.Class (liftIO)
 import           Data.IORef (newIORef)
-import           Language.Javascript.JSaddle (Object(Object), JSM)
+import           Language.Javascript.JSaddle (Object(Object))
 #ifndef GHCJS_BOTH
 import           Data.FileEmbed (embedStringFile)
 import           Language.Javascript.JSaddle (eval)

--- a/src/Miso/Exception.hs
+++ b/src/Miso/Exception.hs
@@ -17,7 +17,6 @@ module Miso.Exception
   ) where
 ----------------------------------------------------------------------------
 import           Control.Exception
-import           Data.Typeable
 import           Language.Javascript.JSaddle
 ----------------------------------------------------------------------------
 import           Miso.String (MisoString, ms)
@@ -48,7 +47,7 @@ data MisoException
   -- ^ Thrown when a @Component@ is sampled, yet not mounted.
   | AlreadyMountedException MisoString
   -- ^ Thrown when a @Component@ is attempted to be mounted twice.
-  deriving (Show, Eq, Typeable)
+  deriving (Show, Eq)
 ----------------------------------------------------------------------------
 instance Exception MisoException
 ----------------------------------------------------------------------------

--- a/src/Miso/Internal.hs
+++ b/src/Miso/Internal.hs
@@ -284,7 +284,6 @@ runView prerender (Node ns tag key attrs kids) snk logLevel events = do
 runView _ (Text t) _ _ _ = do
   vtree <- create
   FFI.set "type" ("vtext" :: JSString) vtree
-  FFI.set "ns" ("text" :: JSString) vtree
   FFI.set "text" t vtree
   pure $ VTree vtree
 runView prerender (TextRaw str) snk logLevel events =

--- a/src/Miso/Internal.hs
+++ b/src/Miso/Internal.hs
@@ -284,6 +284,7 @@ runView prerender (Node ns tag key attrs kids) snk logLevel events = do
 runView _ (Text t) _ _ _ = do
   vtree <- create
   FFI.set "type" ("vtext" :: JSString) vtree
+  FFI.set "ns" ("text" :: JSString) vtree
   FFI.set "text" t vtree
   pure $ VTree vtree
 runView prerender (TextRaw str) snk logLevel events =

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -16,26 +16,42 @@
 ----------------------------------------------------------------------------
 module Main where
 ----------------------------------------------------------------------------
-import           Data.Foldable (toList)
 import           Control.Exception hiding (assert)
 import           Control.Monad
-import           Control.Monad.IO.Class (liftIO)
+import           Control.Monad.IO.Class     (liftIO)
 import           Control.Monad.Trans.State
-import           Data.Aeson hiding (Result(..))
+import           Data.Aeson                 hiding (Result(..))
+import qualified Data.HashMap.Strict        as H
 import           Data.Scientific
-import qualified Data.Vector as V
+import qualified Data.Vector                as V
 import           Debug.Trace
-import           Language.Javascript.JSaddle hiding (catch, Object(Object))
-import qualified Language.Javascript.JSaddle as J
+import           GHCJS.Marshal
+import           GHCJS.Types
+import qualified JavaScript.Object.Internal as OI
 import           System.IO.Unsafe
 import           Test.QuickCheck hiding (total)
 import           Test.QuickCheck.Instances
 import           Test.QuickCheck.Monadic
 ----------------------------------------------------------------------------
-import           Miso hiding (run)
+import           Miso hiding (run, (.=))
+----------------------------------------------------------------------------
+instance Arbitrary Value where
+  arbitrary = sized sizedArbitraryValue
+----------------------------------------------------------------------------
+sizedArbitraryValue :: Int -> Gen Value
+sizedArbitraryValue n
+  | n <= 0 = oneof [pure Null, bool, number, string]
+  | otherwise = resize n' $ oneof [pure Null, bool, string, number, array, object']
+  where
+    n' = n `div` 2
+    bool = Bool <$> arbitrary
+    number = Number <$> arbitrary
+    string = String <$> arbitrary
+    array = Array <$> arbitrary
+    object' = Object <$> arbitrary
 ----------------------------------------------------------------------------
 compareValue :: Value -> Value -> Bool
-compareValue (Object x) (Object y) = and $ zipWith compareValue (toList x) (toList y)
+compareValue (Object x) (Object y) = and $ zipWith compareValue (H.elems x) (H.elems y)
 compareValue (Array x) (Array y)   = and $ zipWith compareValue (V.toList x) (V.toList y)
 compareValue (String x) (String y) = x == y
 compareValue (Bool x) (Bool y)     = x == y
@@ -110,21 +126,21 @@ runTests t = do
 ----------------------------------------------------------------------------
 instance ToJSVal TestResult where
   toJSVal t = do
-    o@(J.Object j) <- create
-    set "passed" (passed t) o
-    set "failed" (failed t) o
-    set "total" (total t) o
-    set "duration" (duration' t) o
-    set "tests" (tests t) o
+    o@(OI.Object j) <- OI.create
+    flip (OI.setProp "passed") o =<< toJSVal (passed t)
+    flip (OI.setProp "failed") o =<< toJSVal (failed t)
+    flip (OI.setProp "total") o =<< toJSVal (total t)
+    flip (OI.setProp "duration") o =<< toJSVal (duration' t)
+    flip (OI.setProp "tests") o =<< toJSVal (tests t)
     pure j
 ----------------------------------------------------------------------------
 instance ToJSVal Test where
   toJSVal t = do
-    o@(J.Object j) <- create
-    set "name" (name t) o
-    set "result" (result t) o
-    set "message" (message t) o
-    set "duration" (duration t) o
+    o@(OI.Object j) <- OI.create
+    flip (OI.setProp "name") o =<< toJSVal (name t)
+    flip (OI.setProp "result") o =<< toJSVal (result t)
+    flip (OI.setProp "message") o =<< toJSVal (message t)
+    flip (OI.setProp "duration") o =<< toJSVal (duration t)
     pure j
 ----------------------------------------------------------------------------
 it :: String -> IO (Bool, String) -> TestM ()


### PR DESCRIPTION
📦 Introduce a multi-nixpkgs workflow (`legacyPkgs` and `pkgs`)

Because nixpkgs has removed `python27` we can no longer build `nixops` (it has also been removed, unfortunately). So until a new `nixops` comes onto the scene we must keep around our old nixpkgs for deployment (for now).

- Copy old `nix/` folder into `legacy/`, repurpose `nix/` to use `pkgsCross.ghcjs`
- Introduce `legacyPkgs` (`ghcjs86`, `closure-compiler`, `nixops-1.7`)
- Introduce recent `pkgs` (`ghcjs9122`, `bun`)
- Hoist `source.nix` to top-level (consumed by all), adjust paths accordingly
- Put new JS backend (`ghcjs9122`) `miso` build under CI
- Keep `deploy` script, `haskell-miso.org` and `sse` examples under `legacyPkgs`
- Use `doHaddock`
- Formatting of `nix`
- Update `cabal.project` to include new js backend dep. overrides
- Updates tests to be `ghcjs9122` ready, drops default test build (rely on `ts/` tests primarily)

Using mutliple nixpkgs allows us to safely consume the new JS backend
without breaking the existing `ghcjs86` that the project was originally built upon.

This opens up the door to use haskell.nix or other nix paradigms (flakes) and packages now that we're on a (much) newer nixpkgs.