### PR TITLE
Add nginx NixOS test, --dry-run in CI.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -102,6 +102,9 @@ jobs:
      - name: (x86) NixOS test runner for haskell-miso.org
        run: nix-build -A haskell-miso-org-test
 
+     - name: (x86) Nginx example hosting check
+       run: nix-build -A hosted-check --dry-run
+
   deploy:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/master'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -103,7 +103,7 @@ jobs:
        run: nix-build -A haskell-miso-org-test
 
      - name: (x86) Nginx example hosting check
-       run: nix-build -A hosted-check --dry-run
+       run: nix-build -A nginx-nixos-test --dry-run
 
   deploy:
     runs-on: ubuntu-latest

--- a/default.nix
+++ b/default.nix
@@ -90,6 +90,11 @@ with pkgs.haskell.lib;
   inherit (legacyPkgs)
     more-examples;
 
+  # dmj: make a NixOS test to ensure examples can be hosted
+  # dry-running this ensures we catch the failure before deploy
+  inherit (legacyPkgs)
+    hosted-check;
+
   # bun
   inherit (pkgs)
     bun;

--- a/default.nix
+++ b/default.nix
@@ -93,7 +93,7 @@ with pkgs.haskell.lib;
   # dmj: make a NixOS test to ensure examples can be hosted
   # dry-running this ensures we catch the failure before deploy
   inherit (legacyPkgs)
-    hosted-check;
+    nginx-nixos-test;
 
   # bun
   inherit (pkgs)

--- a/haskell-miso.org/nix/nginx.nix
+++ b/haskell-miso.org/nix/nginx.nix
@@ -41,7 +41,7 @@ with (import ../../default.nix {});
           enableACME = true;
           locations = {
           "/" = {
-            root = "${pkgs.coverage}/report";
+            root = "${coverage}/report";
            };
          };
        };
@@ -59,7 +59,7 @@ with (import ../../default.nix {});
           enableACME = true;
           locations = {
           "/" = {
-            root = "${pkgs.more-examples.flatris}/bin/app.jsexe";
+            root = "${more-examples.flatris}/bin/app.jsexe";
            };
          };
        };
@@ -68,7 +68,7 @@ with (import ../../default.nix {});
           enableACME = true;
           locations = {
           "/" = {
-            root = pkgs.more-examples.miso-plane;
+            root = more-examples.miso-plane;
            };
          };
        };
@@ -77,7 +77,7 @@ with (import ../../default.nix {});
           enableACME = true;
           locations = {
           "/" = {
-            root = pkgs.more-examples.the2048;
+            root = more-examples.the2048;
            };
          };
        };
@@ -95,7 +95,7 @@ with (import ../../default.nix {});
           enableACME = true;
           locations = {
           "/" = {
-            root = "${pkgs.more-examples.snake}/bin/app.jsexe";
+            root = "${more-examples.snake}/bin/app.jsexe";
            };
          };
        };

--- a/nix/legacy/overlay.nix
+++ b/nix/legacy/overlay.nix
@@ -44,7 +44,7 @@ options: self: super: {
       '';
   };
 
-  hosted-check = self.nixosTest {
+  nginx-nixos-test = self.nixosTest {
     nodes.machine = { config, pkgs, ... }: {
       imports = [ ../../haskell-miso.org/nix/nginx.nix
                 ];

--- a/nix/legacy/overlay.nix
+++ b/nix/legacy/overlay.nix
@@ -33,13 +33,27 @@ options: self: super: {
 
   haskell-miso-org-test = self.nixosTest {
     nodes.machine = { config, pkgs, ... }: {
-      imports = [ ../../haskell-miso.org/nix/machine.nix ];
+      imports = [ ../../haskell-miso.org/nix/machine.nix
+                ];
     };
     testScript = {nodes, ...}:
       ''
       startAll;
       $machine->waitForUnit("haskell-miso.service");
       $machine->succeed("curl localhost:3002");
+      '';
+  };
+
+  hosted-check = self.nixosTest {
+    nodes.machine = { config, pkgs, ... }: {
+      imports = [ ../../haskell-miso.org/nix/nginx.nix
+                ];
+    };
+    testScript = {nodes, ...}:
+      ''
+      startAll;
+      $machine->waitForUnit("nginx.service");
+      $machine->succeed("curl localhost:80");
       '';
   };
 


### PR DESCRIPTION
- [x] Adds a NixOS module test for nginx, checks we can curl port 80
- [x]  Adds a `--dry-run` on this module in CI (during PR `build` phase), this will ensure we avoid deployment failures (as seen in https://github.com/dmjio/miso/commit/7d54368d462758d8ff220246aa453f457dc05d66) when nix scripts are modified and derivation names are orphaned (since they will be caught in the PR before merge to `master`)