### PR TITLE
Add miso build for GHC/GHCJS-9.12.2 in CI, remove broken haddock

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,8 +42,8 @@ jobs:
      - name: (JS) Miso GHCJS (GHCJS 8.6)
        run: nix-build -A miso-ghcjs
 
-#     - name: (JS) Miso GHCJS (GHC 9.12.2)
-#       run: nix-build -A miso-ghcjs-9122
+     - name: (JS) Miso GHCJS (GHCJS 9.12.2)
+       run: nix-build -A miso-ghcjs-9122
 
      - name: (JS) Miso GHCJS Production
        run: nix-build -A miso-ghcjs-prod
@@ -51,8 +51,8 @@ jobs:
      - name: (x86) Miso GHC (GHC 8.6.5)
        run: nix-build -A miso-ghc
 
-#     - name: (x86) Miso GHC (GHC 9.12.2)
-#       run: nix-build -A miso-ghc-9122
+     - name: (x86) Miso GHC (GHC 9.12.2)
+       run: nix-build -A miso-ghc-9122
 
      - name: (x86) Haskell-miso.org server (GHC 8.6.5)
        run: nix-build -A haskell-miso-server

--- a/nix/haskell/packages/ghcjs/default.nix
+++ b/nix/haskell/packages/ghcjs/default.nix
@@ -7,7 +7,7 @@ with pkgs.lib;
 self: super:
 {
   /* miso */
-  miso = doHaddock (self.callCabal2nix "miso" source.miso {});
+  miso = self.callCabal2nix "miso" source.miso {};
 
   /* examples */
   sample-app-js = self.callCabal2nix "app" source.sample-app {};


### PR DESCRIPTION
- Put miso-ghcjs-9122 and miso-ghc-9122 under CI.
- Haddock is not currently producing docs inside derivations on new crossPkgs js backend derivations (therefore remove), it also causes some strange build failures when enabled (tldr; don't use `haskell.lib.doHaddock` w/ `crossPkgs.ghcjs.haskell.packages.ghc9122.<your-pkg>`