### PR TITLE
Add addStyle, addStyleSheet.

### DIFF
--- a/examples/todo-mvc/Main.hs
+++ b/examples/todo-mvc/Main.hs
@@ -100,7 +100,13 @@ app = defaultApp emptyModel updateModel viewModel
 
 updateModel :: Msg -> Effect Model Msg ()
 updateModel NoOp = pure ()
-updateModel FocusOnInput = io (focus "input-box")
+updateModel FocusOnInput = do
+  io $ do
+    focus "input-box"
+#ifdef NATIVE
+    addStyleSheet "https://cdn.jsdelivr.net/npm/todomvc-common@1.0.5/base.min.css"
+    addStyleSheet "https://cdn.jsdelivr.net/npm/todomvc-app-css@2.4.3/index.min.css"
+#endif
 updateModel (CurrentTime time) = io $ consoleLog $ S.ms (show time)
 updateModel Add = do
     model@Model{..} <- get

--- a/src/Miso.hs
+++ b/src/Miso.hs
@@ -56,6 +56,8 @@ module Miso
   , blur
   , alert
   , reload
+  , addStyle
+  , addStyleSheet
   ) where
 -----------------------------------------------------------------------------
 import           Control.Monad (void)

--- a/src/Miso/FFI.hs
+++ b/src/Miso/FFI.hs
@@ -50,6 +50,8 @@ module Miso.FFI
    , reload
    , getComponent
    , setBodyComponent
+   , addStyle
+   , addStyleSheet
    ) where
 -----------------------------------------------------------------------------
 import           Control.Concurrent (ThreadId, forkIO)
@@ -370,4 +372,32 @@ setBodyComponent name = do
   component <- toJSVal name
   moduleMiso <- jsg "miso"
   void $ moduleMiso # "setBodyComponent" $ [component]
+-----------------------------------------------------------------------------
+-- | Appends a 'style_' element containing CSS to 'head_'
+--
+-- > addCssStyle "body { background-color: green; }"
+--
+-- > <head><style>body { background-color: green; }</style></head>
+--
+addStyle :: MisoString -> JSM ()
+addStyle css = do
+  style <- jsg "document" # "createElement" $ ["style"]
+  (style <# "innerHTML") css
+  void $ jsg "document" ! "head" # "appendChild" $ [style]
+-----------------------------------------------------------------------------
+-- | Appends a StyleSheet 'link_' element to 'head_'
+-- The 'link_' tag will contain a URL to a CSS file.
+--
+-- *<link href="https://domain.com/style.css" rel="stylesheet" />*
+--
+-- > addStyleSheet "https://cdn.jsdelivr.net/npm/todomvc-common@1.0.5/base.min.css"
+--
+-- > <head><link href="https://cdn.jsdelivr.net/npm/todomvc-common@1.0.5/base.min.css" ref="stylesheet"></head>
+--
+addStyleSheet :: MisoString -> JSM ()
+addStyleSheet url = do
+  link <- jsg "document" # "createElement" $ ["link"]
+  _ <- link # "setAttribute" $ ["rel","stylesheet"]
+  _ <- link # "setAttribute" $ ["href", fromMisoString url]
+  void $ jsg "document" ! "head" # "appendChild" $ [link]
 -----------------------------------------------------------------------------


### PR DESCRIPTION
Users have requested to be able to set CSS styles dynamically (in `<head>`) on initial application load.

- [x] This patch adds two functions to append either raw `<style> /* css goes here */</style>` or a `<link href="/path/to/style.css" rel="stylesheet">` to `<head>`.
- [x] The TodoMVC example has been adjusted to use this with the saddle workflow
- [x] Re-export top-level