### PR TITLE
Add top-level styles to App.

### DIFF
--- a/examples/todo-mvc/Main.hs
+++ b/examples/todo-mvc/Main.hs
@@ -93,6 +93,10 @@ main :: IO ()
 main = run $ startApp app
   { events = defaultEvents <> keyboardEvents
   , initialAction = Just FocusOnInput
+  , styles =
+      [ Href "https://cdn.jsdelivr.net/npm/todomvc-common@1.0.5/base.min.css"
+      , Href "https://cdn.jsdelivr.net/npm/todomvc-app-css@2.4.3/index.min.css"
+      ]
   }
 
 app :: App Effect Model Msg ()
@@ -100,13 +104,8 @@ app = defaultApp emptyModel updateModel viewModel
 
 updateModel :: Msg -> Effect Model Msg ()
 updateModel NoOp = pure ()
-updateModel FocusOnInput = do
-  io $ do
-    focus "input-box"
-#ifdef NATIVE
-    addStyleSheet "https://cdn.jsdelivr.net/npm/todomvc-common@1.0.5/base.min.css"
-    addStyleSheet "https://cdn.jsdelivr.net/npm/todomvc-app-css@2.4.3/index.min.css"
-#endif
+updateModel FocusOnInput =
+  io (focus "input-box")
 updateModel (CurrentTime time) = io $ consoleLog $ S.ms (show time)
 updateModel Add = do
     model@Model{..} <- get

--- a/src/Miso.hs
+++ b/src/Miso.hs
@@ -94,6 +94,7 @@ miso :: Eq model => (URI -> App effect model action a) -> JSM ()
 miso f = withJS $ do
   app@App {..} <- f <$> getCurrentURI
   initialize app $ \snk -> do
+    renderStyles styles
     VTree (Object vtree) <- runView Prerender (view model) snk logLevel events
     let name = getMountPoint mountPoint
     setBodyComponent name
@@ -107,6 +108,7 @@ miso f = withJS $ do
 startApp :: Eq model => App effect model action a -> JSM ()
 startApp app@App {..} = withJS $
   initialize app $ \snk -> do
+    renderStyles styles
     vtree <- runView DontPrerender (view model) snk logLevel events
     let name = getMountPoint mountPoint
     setBodyComponent name

--- a/src/Miso/Html/Types.hs
+++ b/src/Miso/Html/Types.hs
@@ -90,5 +90,5 @@ prop k v = Property k (toJSON v)
 -- <https://developer.mozilla.org/en-US/docs/Web/CSS>
 --
 style_ :: Map MisoString MisoString -> Attribute action
-style_ = Style
+style_ = Styles
 -----------------------------------------------------------------------------

--- a/src/Miso/Internal.hs
+++ b/src/Miso/Internal.hs
@@ -24,6 +24,7 @@ module Miso.Internal
   , notify
   , runView
   , sample
+  , renderStyles
   , Prerender(..)
   ) where
 -----------------------------------------------------------------------------
@@ -330,7 +331,7 @@ setAttrs vnode attrs snk logLevel events =
       o <- getProp "props" vnode
       FFI.set k value (Object o)
     Event attr -> attr snk vnode logLevel events
-    Style styles -> do
+    Styles styles -> do
       cssObj <- getProp "css" vnode
       forM_ (M.toList styles) $ \(k,v) -> do
         FFI.set k v (Object cssObj)
@@ -369,4 +370,11 @@ registerComponent componentState = liftIO
 -- | Millisecond helper, converts microseconds to milliseconds
 millis :: Int -> Int
 millis = (*1000)
+-----------------------------------------------------------------------------
+-- | Registers components in the global state
+renderStyles :: [CSS] -> JSM ()
+renderStyles styles =
+  forM_ styles $ \case
+    Href url -> FFI.addStyleSheet url
+    Style css -> FFI.addStyle css
 -----------------------------------------------------------------------------

--- a/src/Miso/Render.hs
+++ b/src/Miso/Render.hs
@@ -120,7 +120,7 @@ renderAttrs (Property key value) =
   , stringUtf8 "\""
   ]
 renderAttrs (Event _) = mempty
-renderAttrs (Style style) =
+renderAttrs (Styles styles) =
   mconcat
   [ "style"
   , stringUtf8 "=\""
@@ -131,7 +131,7 @@ renderAttrs (Style style) =
       , fromMisoString v
       , charUtf8 ';'
       ]
-    | (k,v) <- M.toList style
+    | (k,v) <- M.toList styles
     ]
   , stringUtf8 "\""
   ]

--- a/src/Miso/Types.hs
+++ b/src/Miso/Types.hs
@@ -24,6 +24,7 @@ module Miso.Types
   , Key              (..)
   , Attribute        (..)
   , NS               (..)
+  , CSS              (..)
   , LogLevel         (..)
   , Component        (..)
   , SomeComponent    (..)
@@ -67,6 +68,10 @@ data App effect model action a = App
   , events :: M.Map MisoString Bool
   -- ^ List of delegated events that the body element will listen for.
   --   You can start with 'Miso.Event.Types.defaultEvents' and modify as needed.
+  , styles :: [CSS]
+  -- ^ List of CSS styles expressed as either a URL ('Href') or as 'Style' text.
+  -- These styles are appended dynamically to the <head> section of your HTML page
+  -- before the initial draw on <body> occurs.
   , initialAction :: Maybe action
   -- ^ Initial action that is run after the application has loaded, optional since *1.9*
   , mountPoint :: Maybe MisoString
@@ -78,6 +83,17 @@ data App effect model action a = App
   -- ^ natural transformation to allow others to use their own
   -- custom Monad stack.
   }
+-----------------------------------------------------------------------------
+-- | Allow users to express CSS and append it to <head> before the first draw
+--
+-- > Href "http://domain.com/style.css
+--
+data CSS
+  = Href MisoString
+  -- ^ 'Href' is a URL meant to link to hosted CSS
+  | Style MisoString
+  -- ^ 'Style' is meant to be raw CSS in a 'style_' tag
+  deriving (Show, Eq)
 -----------------------------------------------------------------------------
 -- | Convenience for extracting mount point
 getMountPoint :: Maybe MisoString -> MisoString
@@ -95,6 +111,7 @@ defaultApp m u v = App
   , view = v
   , subs = []
   , events = defaultEvents
+  , styles = []
   , mountPoint = Nothing
   , logLevel = Off
   , initialAction = Nothing
@@ -252,7 +269,7 @@ instance ToKey Word where toKey = Key . toMisoString
 data Attribute action
   = Property MisoString Value
   | Event (Sink action -> Object -> LogLevel -> Events -> JSM ())
-  | Style (M.Map MisoString MisoString)
+  | Styles (M.Map MisoString MisoString)
   deriving Functor
 -----------------------------------------------------------------------------
 -- | @IsString@ instance


### PR DESCRIPTION
🍜 `App { styles :: [CSS] } `
====================

```haskell
main :: IO ()
main = run app { 
  styles = [ Href "https://your-domain/style.css"
           , Style "body { background-color: red; }" 
           ] 
}

app :: App Effect Model Action ()
app = defaultApp module update view
```

- Allow users to add `CSS` styles to top-level `App`.
- This allows users to adjust styles using hot-reload w/ `jsaddle`.
- Promotes 'addStyleSheet' and 'addStyle' to first class functions in App.
- Guarantees that style will be present before first page draw.
- Renames existing internal `Style` to `Styles`, we now claim `CSS (Style)` for the external API.
- Updates todo-mvc example to reflect this.

Previously `addStyle` and `addStyleSheet` would run on `initialAction` to append CSS to a page, but the downside of doing so was that the page might have already drawn (without styles applied). By hoisting `styles :: [CSS]` into app we can guarantee that all drawing will occur only after all styles have been applied to the `document`. Before `runView` is called all styles are appended to `<head>`.

Both  `addStyle` and `addStyleSheet` are still available for use