### PR TITLE
Modernize file reader example, test ergonomics

### DIFF
--- a/examples/file-reader/Main.hs
+++ b/examples/file-reader/Main.hs
@@ -1,106 +1,163 @@
-{-# LANGUAGE CPP #-}
-{-# LANGUAGE DataKinds #-}
-{-# LANGUAGE DeriveGeneric #-}
+-----------------------------------------------------------------------------
+{-# LANGUAGE CPP             #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
-
+{-# LANGUAGE TemplateHaskell #-}
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Main
+-- Copyright   :  (C) 2016-2025 David M. Johnson
+-- License     :  BSD3-style (see the file LICENSE)
+-- Maintainer  :  David M. Johnson <code@dmj.io>
+-- Stability   :  experimental
+-- Portability :  non-portable
+----------------------------------------------------------------------------
 module Main where
-
-import Control.Monad.State
-import Control.Concurrent.MVar
-import Miso
-import Miso.String
-
-#ifdef GHCJS_NEW
-import GHC.JS.Foreign.Callback
-#endif
-import GHCJS.Types
-#ifdef GHCJS_OLD
-import GHCJS.Foreign.Callback
-#endif
-
+----------------------------------------------------------------------------
+import           Control.Concurrent.MVar (newEmptyMVar, putMVar, readMVar)
+import           Control.Monad (void)
+import           Control.Monad.IO.Class (liftIO)
+import           Language.Javascript.JSaddle ((!), (!!), (#), JSVal, (<#))
+import qualified Language.Javascript.JSaddle as J
+import           Prelude hiding ((!!), null, unlines)
+----------------------------------------------------------------------------
+import           Miso (App(styles), View,Effect, defaultApp, run, CSS(..), scheduleIO, startApp, io, (=:))
+import qualified Miso as M
+import           Miso.Lens ((.=), Lens, lens)
+import           Miso.String (MisoString, unlines, null)
+----------------------------------------------------------------------------
 -- | Model
 newtype Model
   = Model
-  { info :: MisoString
+  { _info :: MisoString
   } deriving (Eq, Show)
-
+----------------------------------------------------------------------------
+-- | info Lens
+info :: Lens Model MisoString
+info = lens _info $ \r x -> r { _info = x }
+----------------------------------------------------------------------------
 -- | Action
 data Action
-    = ReadFile
-    | SetContent MisoString
-    deriving (Show, Eq)
-
+  = ReadFile
+  | SetContent MisoString
+  | ClickInput
+  deriving (Show, Eq)
+----------------------------------------------------------------------------
+-- | WASM support
+#ifdef WASM
+foreign export javascript "hs_start" main :: IO ()
+#endif
+----------------------------------------------------------------------------
 -- | Main entry point
 main :: IO ()
-main = run $ startApp (defaultApp (Model "") updateModel viewModel)
-
--- | Update your model
+main = run $ startApp app
+  { styles =
+    [ Href "https://cdn.jsdelivr.net/npm/bulma@1.0.2/css/bulma.min.css"
+    , Style css
+    ]
+  }
+----------------------------------------------------------------------------
+-- | Custom styling
+css :: MisoString
+css = unlines
+  [ ".content-container {"
+  , "  min-height: 300px;"
+  , "  display: flex;"
+  , "  flex-direction: column;"
+  , "  justify-content: center;"
+  , "}"
+  , ""
+  , "#codeDisplay {"
+  , "  min-height: 200px;"
+  , "  background-color: #f5f5f5;"
+  , "  border-radius: 4px;"
+  , "  padding: 1rem;"
+  , "  white-space: pre-wrap;"
+  , "  font-family: monospace;"
+  , "}"
+  ]
+----------------------------------------------------------------------------
+-- | Miso application
+app :: App Effect Model Action ()
+app = defaultApp (Model mempty) updateModel viewModel
+----------------------------------------------------------------------------
+-- | Update function
 updateModel :: Action -> Effect Model Action ()
-updateModel ReadFile = do
-    m <- get
-    m <# do
-        fileReaderInput <- getElementById "fileReader"
-        file <- getFile fileReaderInput
-        reader <- newReader
-        mvar <- newEmptyMVar
-        setOnLoad reader =<< do
-            asyncCallback $ do
-                r <- getResult reader
-                putMVar mvar r
-        readText reader file
-        SetContent <$> readMVar mvar
-updateModel (SetContent c) = modify $ \m -> m { info = c }
-
--- | View function, with routing
+updateModel ReadFile = scheduleIO $ do
+  fileReaderInput <- M.getElementById "fileReader"
+  file <- fileReaderInput ! ("files" :: String) !! 0
+  reader <- J.new (J.jsg ("FileReader" :: String)) ([] :: [JSVal])
+  mvar <- liftIO newEmptyMVar
+  (reader <# ("onload" :: String)) =<< do
+    M.asyncCallback $ do
+      result <- J.fromJSValUnchecked =<< reader ! ("result" :: String)
+      liftIO (putMVar mvar result)
+  void $ reader # ("readAsText" :: String) $ [file] 
+  SetContent <$> liftIO (readMVar mvar)
+updateModel (SetContent c) = info .= c
+updateModel ClickInput = io $ do
+  fileReader <- M.getElementById "fileReader"
+  void $ fileReader # ("click" :: String) $ ([] :: [JSVal])
+----------------------------------------------------------------------------  
+-- | View function
 viewModel :: Model -> View Action
-viewModel Model{..} = view
-  where
-    view =
-        div_
-            []
-            [ "FileReader API example"
-            , input_
-                [ id_ "fileReader"
-                , type_ "file"
-                , onChange (const ReadFile)
-                ]
-            , div_ [] [text info]
+viewModel Model{..} =
+  M.section_
+  [ M.class_ "section"
+  ]
+  [ M.div_
+    [ M.class_ "container"
+    ]
+    [ M.h1_
+      [ M.class_ "title has-text-centered"
+      ]
+      [ "🍜 Miso File Reader example"
+      ]
+    , M.div_
+      [ M.class_ "columns is-centered mt-5"
+      ]
+      [ M.div_
+        [ M.class_ "column is-narrow content-container"
+        ]
+        [ M.div_
+          [ M.class_ "field"
+          ]
+          [ M.div_
+            [ M.class_ "control"
             ]
-
-#ifdef GHCJS_NEW
-foreign import javascript unsafe "(() => { return new FileReader(); })"
-  newReader :: IO JSVal
-
-foreign import javascript unsafe "((x) => { return x.files[0]; })"
-  getFile :: JSVal -> IO JSVal
-
-foreign import javascript unsafe "((x, y) => { x.onload = y; })"
-  setOnLoad :: JSVal -> Callback (IO ()) -> IO ()
-
-foreign import javascript unsafe "((x) => { return x.result; })"
-  getResult :: JSVal -> IO MisoString
-
-foreign import javascript unsafe "((x, y) => { x.readAsText(y); })"
-  readText :: JSVal -> JSVal -> IO ()
-#endif
-
-#ifdef GHCJS_OLD
-foreign import javascript unsafe "$r = new FileReader();"
-  newReader :: IO JSVal
-
-foreign import javascript unsafe "$r = $1.files[0];"
-  getFile :: JSVal -> IO JSVal
-
-foreign import javascript unsafe "$1.onload = $2;"
-  setOnLoad :: JSVal -> Callback (IO ()) -> IO ()
-
-foreign import javascript unsafe "$r = $1.result;"
-  getResult :: JSVal -> IO MisoString
-
-foreign import javascript unsafe "$1.readAsText($2);"
-  readText :: JSVal -> JSVal -> IO ()
-#endif
+            [ M.button_
+              [ M.class_ "button is-primary is-large"
+              , M.onClick ClickInput
+              ]
+              [ "Select File" ]
+            , M.input_
+              [ M.style_ ("display" =: "none")
+              , M.id_ "fileReader"
+              , M.type_ "file"
+              , M.class_ "button is-large"
+              , M.onChange (\_ -> ReadFile)
+              ]
+            ]
+          ]
+        ]
+      ]
+    , M.div_
+      [ M.class_ "column content-container"
+      ]
+      [ M.div_
+        [ M.id_ "codeDisplay"
+        , M.class_ "box"
+        ]
+        [ M.p_
+          [ M.class_ "has-text-grey-light"
+          ]
+          [ M.pre_
+            []
+            [ M.text _info
+            ]
+          | not (null _info)
+          ]
+        ]
+      ]
+    ]
+  ]

--- a/examples/miso-examples.cabal
+++ b/examples/miso-examples.cabal
@@ -127,7 +127,7 @@ executable threejs
 
 executable file-reader
   import:
-    common-options, js-only
+    common-options
   default-language:
     Haskell2010
   main-is:
@@ -142,7 +142,7 @@ executable file-reader
     aeson,
     base < 5,
     containers,
-    ghcjs-base,
+    jsaddle,
     miso,
     mtl
 

--- a/src/Miso.hs
+++ b/src/Miso.hs
@@ -58,6 +58,9 @@ module Miso
   , reload
   , addStyle
   , addStyleSheet
+  , syncCallback
+  , syncCallback1
+  , asyncCallback
   ) where
 -----------------------------------------------------------------------------
 import           Control.Monad (void)

--- a/src/Miso/FFI.hs
+++ b/src/Miso/FFI.hs
@@ -64,7 +64,7 @@ import           Language.Javascript.JSaddle
 import           Prelude hiding ((!!))
 -----------------------------------------------------------------------------
 import           Miso.String
------------------------------------------------------------------------------
+----------------------------------------------------------------------------
 -- | Run given `JSM` action asynchronously, in a separate thread.
 forkJSM :: JSM () -> JSM ThreadId
 forkJSM a = do


### PR DESCRIPTION
- Use [miso-from-html](https://github.com/dmjio/miso-from-html) to process claude.ai generated bulma css
- Drop old FFI statements, port to `jsaddle`
- Update cabal file to support WASM and native workflows
- Use `Miso.Lens` for (info field)
- Test `import Miso` ergonomicity
- Use custom css `Style` and bulma cdn for `Href`
- Expose additional `Miso.FFI`, `syncCallback`, etc
- Drop `ghcjs-base`