### PR TITLE
Fully drain event queue during synchronous unmount.

### DIFF
--- a/src/Miso/Internal.hs
+++ b/src/Miso/Internal.hs
@@ -90,7 +90,7 @@ initialize App {..} getView = do
           atomicWriteIORef componentModel newModel
       syncPoint
       eventLoop newModel
-  componentMainThread <- FFI.forkJSM (eventLoop model)
+  _ <- FFI.forkJSM (eventLoop model)
   registerComponent ComponentState {..}
   delegator componentMount componentVTree events (logLevel `elem` [DebugEvents, DebugAll])
   forM_ initialAction componentSink
@@ -107,7 +107,6 @@ data Prerender
 data ComponentState model action
   = ComponentState
   { componentName       :: MisoString
-  , componentMainThread :: ThreadId
   , componentSubThreads :: [ThreadId]
   , componentMount      :: JSVal
   , componentVTree      :: IORef VTree


### PR DESCRIPTION
- This obviates the need for `threadDelay` since all events are processed before unmounting, in a synchronous callback.

- Let the GC recycle the component thread. Since `componentName` is deleted from the global `componentMap`, all references will go out of scope.