### PR TITLE
Revert translate, keep interface simple, synonym Effect

### DIFF
--- a/examples/canvas2d/Main.hs
+++ b/examples/canvas2d/Main.hs
@@ -39,7 +39,7 @@ main = run $ do
 updateModel
   :: (Image, Image, Image)
   -> Action
-  -> Effect Model Action ()
+  -> Effect Model Action
 updateModel _ GetTime = do
   m <- get
   m <# do

--- a/examples/components/Main.hs
+++ b/examples/components/Main.hs
@@ -52,24 +52,24 @@ loggerSub msg = \_ ->
         liftIO $ threadDelay (secs 10)
         consoleLog msg
 
-app :: App Effect MainModel MainAction ()
+app :: App MainModel MainAction
 app = defaultApp False updateModel1 viewModel1
 
-component2 :: Component Effect Model Action ()
+component2 :: Component Model Action
 component2 =
     component "component-2"
         counterApp2
             { subs = [loggerSub "component-2 sub"]
             }
 
-component3 :: Component Effect (Bool, Model) Action ()
+component3 :: Component (Bool, Model) Action
 component3 =
     component "component-3"
         counterApp3
             { subs = [loggerSub "component-3 sub"]
             }
 
-component4 :: Component Effect Model Action ()
+component4 :: Component Model Action
 component4 =
     component "component-4"
         counterApp4
@@ -81,7 +81,7 @@ viewModel1 :: MainModel -> View MainAction
 viewModel1 x =
     div_
         []
-        [ "Component Effect 1 - Three sub components nested recursively below me"
+        [ "Component 1 - Three sub components nested recursively below me"
         , br_ []
         , "The +/- for Components 3 and 4 will affect the state of Component 2"
         , br_ []
@@ -99,7 +99,7 @@ viewModel1 x =
         ]
 
 -- | Updates model, optionally introduces side effects
-updateModel1 :: MainAction -> Effect MainModel MainAction ()
+updateModel1 :: MainAction -> Effect MainModel MainAction
 updateModel1 Toggle = modify not
 updateModel1 UnMountMain =
   io (consoleLog "Component 2 was unmounted!")
@@ -112,11 +112,11 @@ updateModel1 SampleChild = do
         "Sampling child component 2 from parent component main (unsafe): " <>
           ms (show componentTwoModel)
 
-counterApp2 :: App Effect Model Action ()
+counterApp2 :: App Model Action
 counterApp2 = defaultApp 0 updateModel2 viewModel2
 
 -- | Updates model, optionally introduces side effects
-updateModel2 :: Action -> Effect Model Action ()
+updateModel2 :: Action -> Effect Model Action
 updateModel2 AddOne = modify (+1)
 updateModel2 SubtractOne = modify (subtract 1)
 updateModel2 UnMount =
@@ -142,11 +142,11 @@ viewModel2 x =
           ] 
         ]
 
-counterApp3 :: App Effect (Bool, Model) Action ()
+counterApp3 :: App (Bool, Model) Action
 counterApp3 = defaultApp (True, 0) updateModel3 viewModel3
 
 -- | Updates model, optionally introduces side effects
-updateModel3 :: Action -> Effect (Bool, Model) Action ()
+updateModel3 :: Action -> Effect (Bool, Model) Action
 updateModel3 AddOne = do
   modify (fmap (+1))
   io (notify component2 AddOne)
@@ -180,11 +180,11 @@ viewModel3 (toggle, x) =
                | toggle
                ]
 
-counterApp4 :: App Effect Model Action ()
+counterApp4 :: App Model Action
 counterApp4 = defaultApp 0 updateModel4 viewModel4
 
 -- | Updates model, optionally introduces side effects
-updateModel4 :: Action -> Effect Model Action ()
+updateModel4 :: Action -> Effect Model Action
 updateModel4 AddOne = do
   modify (+1)
   io (notify component2 AddOne)
@@ -206,7 +206,7 @@ viewModel4 :: Model -> View Action
 viewModel4 x =
     div_
         []
-        [ "This is the view for Component Effect 4"
+        [ "This is the view for Component 4"
         , button_ [onClick AddOne] [text "+"]
         , text (ms x)
         , button_ [onClick SubtractOne] [text "-"]

--- a/examples/fetch/Main.hs
+++ b/examples/fetch/Main.hs
@@ -80,7 +80,7 @@ getGithubAPI
   -> JSM ()
 getGithubAPI = fetch (Proxy @GithubAPI) "https://api.github.com"
 ----------------------------------------------------------------------------
-updateModel :: Action -> Effect Model Action ()
+updateModel :: Action -> Effect Model Action
 updateModel FetchGitHub = withSink $ \snk -> getGithubAPI (snk . SetGitHub) (snk . ErrorHandler)
 updateModel (SetGitHub apiInfo) =
   info ?= apiInfo

--- a/examples/fetch/Main.hs
+++ b/examples/fetch/Main.hs
@@ -62,7 +62,7 @@ data Action
 foreign export javascript "hs_start" main :: IO ()
 #endif
 ----------------------------------------------------------------------------
-app :: App Effect Model Action ()
+app :: App Model Action
 app = defaultApp emptyModel updateModel viewModel
 ----------------------------------------------------------------------------
 emptyModel :: Model

--- a/examples/file-reader/Main.hs
+++ b/examples/file-reader/Main.hs
@@ -78,11 +78,11 @@ css = unlines
   ]
 ----------------------------------------------------------------------------
 -- | Miso application
-app :: App Effect Model Action ()
+app :: App Model Action
 app = defaultApp (Model mempty) updateModel viewModel
 ----------------------------------------------------------------------------
 -- | Update function
-updateModel :: Action -> Effect Model Action ()
+updateModel :: Action -> Effect Model Action
 updateModel ReadFile = scheduleIO $ do
   fileReaderInput <- M.getElementById "fileReader"
   file <- fileReaderInput ! ("files" :: String) !! 0

--- a/examples/mario/Main.hs
+++ b/examples/mario/Main.hs
@@ -71,7 +71,7 @@ mario =
         , window = (0, 0)
         }
 
-updateMario :: Action -> Effect Model Action ()
+updateMario :: Action -> Effect Model Action
 updateMario Start = get >>= step
 updateMario (GetArrows arrs) = do
   modify newModel
@@ -92,7 +92,7 @@ updateMario (WindowCoords coords) = do
     where
       newModel m = m { window = coords }
 
-step :: Model -> Effect Model Action ()
+step :: Model -> Effect Model Action
 step m@Model{..} = k <# Time <$> now
   where
     k =

--- a/examples/router/Main.hs
+++ b/examples/router/Main.hs
@@ -40,7 +40,7 @@ main = run $
        }
 
 -- | Update your model
-updateModel :: Action -> Effect Model Action ()
+updateModel :: Action -> Effect Model Action
 updateModel (HandleURI u) = modify $ \m -> m { uri = u }
 updateModel (ChangeURI u) = scheduleIO_ (pushURI u)
 

--- a/examples/simple/Main.hs
+++ b/examples/simple/Main.hs
@@ -41,11 +41,11 @@ main = run $ startApp app
   }
 
 -- | Application definition (uses 'defaultApp' smart constructor)
-app :: App Effect Model Action ()
+app :: App Model Action
 app = defaultApp (Model 0) updateModel viewModel
 
 -- | UpdateModels model, optionally introduces side effects
-updateModel :: Action -> Effect Model Action ()
+updateModel :: Action -> Effect Model Action
 updateModel (AddOne event) = do
   value += 1
   io $ consoleLog (ms (show event))

--- a/examples/sse/server/Main.hs
+++ b/examples/sse/server/Main.hs
@@ -64,7 +64,7 @@ sendEvents chan =
         threadDelay (10 ^ (6 :: Int))
 
 -- | Page for setting HTML doctype and header
-newtype Page = Page (App Effect Model Action ())
+newtype Page = Page (App Model Action)
 
 instance ToHtml Page where
     toHtml (Page x) =

--- a/examples/sse/shared/Common.hs
+++ b/examples/sse/shared/Common.hs
@@ -60,7 +60,7 @@ the404 =
 goHome :: URI
 goHome = allLinks' linkURI (Proxy :: Proxy ClientRoutes)
 
-sse :: URI -> App Effect Model Action ()
+sse :: URI -> App Model Action
 sse currentURI
   = app { subs =
           [ sseSub "/sse" handleSseMsg
@@ -79,7 +79,7 @@ handleSseMsg (SSEMessage msg) = ServerMsg msg
 handleSseMsg SSEClose = ServerMsg "SSE connection closed"
 handleSseMsg SSEError = ServerMsg "SSE error"
 
-updateModel :: Action -> Effect Model Action ()
+updateModel :: Action -> Effect Model Action
 updateModel (ServerMsg msg) = modify update
   where
     update m = m { modelMsg = "Event received: " ++ msg }

--- a/examples/svg/Main.hs
+++ b/examples/svg/Main.hs
@@ -24,13 +24,13 @@ main = run $ startApp app
   }
 
 -- | Application definition (uses 'defaultApp' smart constructor)
-app :: App Effect Model Action ()
+app :: App Model Action
 app = defaultApp emptyModel updateModel viewModel
 
 emptyModel :: Model
 emptyModel = Model (0, 0)
 
-updateModel :: Action -> Effect Model Action ()
+updateModel :: Action -> Effect Model Action
 updateModel (HandlePointer pointer) = modify update
   where
     update m = m { mouseCoords = client pointer }

--- a/examples/three/Main.hs
+++ b/examples/three/Main.hs
@@ -86,7 +86,7 @@ viewModel _ =
 updateModel ::
     IORef Context ->
     Action ->
-    Effect Double Action ()
+    Effect Double Action
 updateModel ref Init = do
   io (initContext ref)
   issue GetTime

--- a/examples/todo-mvc/Main.hs
+++ b/examples/todo-mvc/Main.hs
@@ -99,10 +99,10 @@ main = run $ startApp app
       ]
   }
 
-app :: App Effect Model Msg ()
+app :: App Model Msg
 app = defaultApp emptyModel updateModel viewModel
 
-updateModel :: Msg -> Effect Model Msg ()
+updateModel :: Msg -> Effect Model Msg
 updateModel NoOp = pure ()
 updateModel FocusOnInput =
   io (focus "input-box")

--- a/examples/websocket/Main.hs
+++ b/examples/websocket/Main.hs
@@ -37,13 +37,13 @@ main = run $ startApp app
       url = URL "wss://echo.websocket.org"
       protocols = Protocols []
 
-app :: App Effect Model Action ()
+app :: App Model Action
 app = defaultApp emptyModel updateModel appView
 
 emptyModel :: Model
 emptyModel = Model (Message "") mempty
 
-updateModel :: Action -> Effect Model Action ()
+updateModel :: Action -> Effect Model Action
 updateModel (HandleWebSocket (WebSocketMessage (Message m))) =
   modify $ \model -> model { received = m }
 updateModel (SendMessage msg) =

--- a/haskell-miso.org/nix/nginx.nix
+++ b/haskell-miso.org/nix/nginx.nix
@@ -77,7 +77,7 @@ with (import ../../default.nix {});
           enableACME = true;
           locations = {
           "/" = {
-            root = more-examples.the2048;
+            root = more-examples.hs2048;
            };
          };
        };

--- a/haskell-miso.org/shared/Common.hs
+++ b/haskell-miso.org/shared/Common.hs
@@ -61,7 +61,7 @@ type ClientRoutes = Routes (View Action)
 type ServerRoutes = Routes (Get '[HTML] Page)
 
 -- | Component synonym
-type HaskellMisoComponent = App Effect Model Action ()
+type HaskellMisoComponent = App Model Action
 
 -- | Links
 uriHome, uriExamples, uriDocs, uriCommunity, uri404 :: URI
@@ -100,7 +100,7 @@ haskellMisoComponent uri
   , logLevel = DebugAll
   }
   
-app :: URI -> App Effect Model Action ()
+app :: URI -> App Model Action
 app currentUri = defaultApp emptyModel updateModel viewModel
   where
     emptyModel = Model currentUri False
@@ -109,7 +109,7 @@ app currentUri = defaultApp emptyModel updateModel viewModel
           Left _ -> the404 m
           Right v -> v
 
-updateModel :: Action -> Effect Model Action ()
+updateModel :: Action -> Effect Model Action
 updateModel = \case
   HandleURI u ->
     modify $ \m -> m { uri = u }

--- a/nix/haskell/packages/ghcjs/default.nix
+++ b/nix/haskell/packages/ghcjs/default.nix
@@ -21,14 +21,14 @@ self: super:
     chmod +w $out/index.html
     cp -v ${source.miso-plane}/public/index.html $out
   '';
-  the2048-core = self.callCabal2nix "hs2048" source.the2048 {};
-  the2048 = pkgs.runCommand "hs2048" {} ''
+  hs2048-core = self.callCabal2nix "hs2048" source.hs2048 {};
+  hs2048 = pkgs.runCommand "hs2048" {} ''
     mkdir -p $out/bin
-    cp -rv ${self.the2048-core}/bin/*.jsexe $out/*
+    cp -rv ${self.hs2048-core}/bin/*.jsexe $out/*
     chmod +w $out/bin/*.jsexe
     chmod +w $out/bin/*.jsexe/index.html
-    cp -v ${source.the2048}/static/main.css $out/bin/app.jsexe/main.css
-    cp -v ${source.the2048}/static/index.html $out/bin/app.jsexe/index.html
+    cp -v ${source.hs2048}/static/main.css $out/bin/app.jsexe/main.css
+    cp -v ${source.hs2048}/static/index.html $out/bin/app.jsexe/index.html
   '';
   snake = self.callCabal2nix "miso-snake" source.snake {};
   miso-examples-core = self.callCabal2nix "miso-examples" source.examples {};

--- a/nix/legacy/haskell/packages/ghcjs/default.nix
+++ b/nix/legacy/haskell/packages/ghcjs/default.nix
@@ -22,7 +22,7 @@ self: super:
          rm $out/index.html
          cp -v ${source.miso-plane}/public/index.html $out
       '';
-  the2048 = import source.the2048 { inherit pkgs; inherit (self) miso; };
+  hs2048 = import source.hs2048 { inherit pkgs; inherit (self) miso; };
   snake = self.callCabal2nix "miso-snake" source.snake {};
   mkDerivation = args: super.mkDerivation (args // { doCheck = false; });
   doctest = null;

--- a/nix/legacy/overlay.nix
+++ b/nix/legacy/overlay.nix
@@ -83,6 +83,6 @@ options: self: super: {
       nixops deploy -j1 -d haskell-miso --option substituters "https://cache.nixos.org/"
   '';
   more-examples = with super.haskell.lib; {
-    inherit (self.haskell.packages.ghcjs) flatris the2048 snake miso-plane;
+    inherit (self.haskell.packages.ghcjs) flatris hs2048 snake miso-plane;
   };
 }

--- a/nix/source.nix
+++ b/nix/source.nix
@@ -49,7 +49,7 @@ in
     rev = "cbeb74e";
     sha256 = "sha256-QhoeeTVO+zWwgUmLXvpd3mgtLa5+G36Eryxdx/ofgp4=";
   };
-  the2048 = fetchFromGitHub {
+  hs2048 = fetchFromGitHub {
     owner = "dmjio";
     repo = "hs2048";
     rev = "c8c19d6";

--- a/nix/source.nix
+++ b/nix/source.nix
@@ -40,26 +40,26 @@ in
   flatris = fetchFromGitHub {
     owner = "dmjio";
     repo = "hs-flatris";
-    rev = "088a95d";
-    sha256 = "sha256-5R/LTgH+jVHQWT1Mk9erC7wJPj2R1z7snrNQeun7eCs=";
+    rev = "4d8ea97";
+    sha256 = "sha256-VLbVdatgIxF680LVQ/nC9tVb9p9hlTCpXKp8U9vkss8=";
   };
   miso-plane = fetchFromGitHub {
     owner = "dmjio";
     repo = "miso-plane";
-    rev = "225ce5b7ddd57e716b96f8029dbef16d7dda15fd";
-    sha256 = "sha256-DuDDM0ePZCIASX8TB0YxIivXMhV7x7uaPb/HbJJILUs=";
+    rev = "cbeb74e";
+    sha256 = "sha256-QhoeeTVO+zWwgUmLXvpd3mgtLa5+G36Eryxdx/ofgp4=";
   };
   the2048 = fetchFromGitHub {
     owner = "dmjio";
     repo = "hs2048";
-    rev = "ea963a4";
-    sha256 = "sha256-72eDj8gkSVIyM1r+wDODEHjsLzYC7Lk3tO1MiSrADPU=";
+    rev = "c8c19d6";
+    sha256 = "sha256-SwLZX//1vj4qsPun7gz23gHWcyWKYl++Sw34zJLqKp4=";
   };
   snake = fetchFromGitHub {
     owner = "dmjio";
     repo = "miso-snake";
-    rev = "5740e0f";
-    sha256 = "sha256-qStRWDP0jFccPhVUWoP7o1P8+MvJq7cJSDUuBmUfsyg=";
+    rev = "d26c0a3";
+    sha256 = "sha256-jD1kBqOMFrhxt+yUcXLTLL+qv71X4/uOI4qdkpO6nGA=";
   };
   todomvc-common = fetchFromGitHub {
     owner = "tastejs";

--- a/sample-app/Main.hs
+++ b/sample-app/Main.hs
@@ -30,7 +30,7 @@ main :: IO ()
 main = run (startApp app)
 ----------------------------------------------------------------------------
 -- | `defaultApp` takes as arguments the initial model, update function, view function
-app :: App Effect Model Action ()
+app :: App Model Action
 app = defaultApp emptyModel updateModel viewModel
 ----------------------------------------------------------------------------
 -- | Empty application state
@@ -38,7 +38,7 @@ emptyModel :: Model
 emptyModel = Model 0
 ----------------------------------------------------------------------------
 -- | Updates model, optionally introduces side effects
-updateModel :: Action -> Effect Model Action ()
+updateModel :: Action -> Effect Model Action
 updateModel = \case
   AddOne        -> counter += 1
   SubtractOne   -> counter -= 1

--- a/src/Miso.hs
+++ b/src/Miso.hs
@@ -82,7 +82,7 @@ import           Miso.Util
 -- Assumes the pre-rendered DOM is already present.
 -- Note: Uses @mountPoint@ as the @Component@ name.
 -- Always mounts to /<body>/. Copies page into the virtual DOM.
-miso :: Eq model => (URI -> App effect model action a) -> JSM ()
+miso :: Eq model => (URI -> App model action) -> JSM ()
 miso f = withJS $ do
   app@App {..} <- f <$> getURI
   initialize app $ \snk -> do
@@ -97,7 +97,7 @@ miso f = withJS $ do
 -----------------------------------------------------------------------------
 -- | Runs a miso application
 -- Initializes application at @mountPoint@ (defaults to /<body>/ when @Nothing@)
-startApp :: Eq model => App effect model action a -> JSM ()
+startApp :: Eq model => App model action -> JSM ()
 startApp app@App {..} = withJS $
   initialize app $ \snk -> do
     renderStyles styles

--- a/src/Miso/Effect.hs
+++ b/src/Miso/Effect.hs
@@ -133,13 +133,13 @@ effectSub model sub = do
 --   , ...
 --   }
 -- @
+type Effect model action = EffectCore model action ()
+-----------------------------------------------------------------------------
+-- | The EffectCore Monad, underlies @Effect@
 newtype EffectCore model action a = EffectCore (StateT model (Writer [Sub action]) a)
   deriving (Functor, Applicative, Monad, MonadState model, MonadWriter [Sub action])
 -----------------------------------------------------------------------------
--- | Synonym used for 'App'
-type Effect model action = EffectCore model action ()
------------------------------------------------------------------------------
--- | @MonadFail@ instance for @Effect@
+-- | @MonadFail@ instance for @EffectCore@
 instance MonadFail (EffectCore model action) where
   fail s = do
     io $ consoleError (ms s)

--- a/src/Miso/Effect.hs
+++ b/src/Miso/Effect.hs
@@ -67,21 +67,21 @@ mapSub :: (a -> b) -> Sub a -> Sub b
 mapSub f sub = \g -> sub (g . f)
 -----------------------------------------------------------------------------
 -- | Smart constructor for an 'Effect' with no actions.
-noEff :: model -> Effect model action ()
+noEff :: model -> Effect model action
 noEff = put
 -----------------------------------------------------------------------------
 -- | Smart constructor for an 'Effect' with exactly one action.
 infixl 0 <#
-(<#) :: model -> JSM action -> Effect model action ()
+(<#) :: model -> JSM action -> Effect model action
 (<#) m action = put m >> tell [ \sink -> sink =<< action ]
 -----------------------------------------------------------------------------
 -- | `Effect` smart constructor, flipped
 infixr 0 #>
-(#>) :: JSM action -> model -> Effect model action ()
+(#>) :: JSM action -> model -> Effect model action
 (#>) = flip (<#)
 -----------------------------------------------------------------------------
 -- | Smart constructor for an 'Effect' with multiple actions.
-batchEff :: model -> [JSM action] -> Effect model action ()
+batchEff :: model -> [JSM action] -> Effect model action
 batchEff model actions = put model >> do
   forM_ actions $ \action ->
     tell [ \sink -> sink =<< action ]
@@ -94,7 +94,7 @@ batchEff model actions = put model >> do
 -- widget which has an associated callback. The callback can then call the sink
 -- to turn events into actions. To do this without accessing a sink requires
 -- going via a @'Sub'scription@ which introduces a leaky-abstraction.
-effectSub :: model -> Sub action -> Effect model action ()
+effectSub :: model -> Sub action -> Effect model action
 effectSub model sub = do
   put model
   tell [sub]
@@ -133,11 +133,14 @@ effectSub model sub = do
 --   , ...
 --   }
 -- @
-newtype Effect model action a = Effect (StateT model (Writer [Sub action]) a)
+newtype EffectCore model action a = EffectCore (StateT model (Writer [Sub action]) a)
   deriving (Functor, Applicative, Monad, MonadState model, MonadWriter [Sub action])
 -----------------------------------------------------------------------------
+-- | Synonym used for 'App'
+type Effect model action = EffectCore model action ()
+-----------------------------------------------------------------------------
 -- | @MonadFail@ instance for @Effect@
-instance MonadFail (Effect model action) where
+instance MonadFail (EffectCore model action) where
   fail s = do
     io $ consoleError (ms s)
 #if __GLASGOW_HASKELL__ <= 881
@@ -149,15 +152,15 @@ instance MonadFail (Effect model action) where
 -- | Internal function used to unwrap an 'Effect'
 runEffect
     :: model
-    -> Effect model action a
+    -> Effect model action
     -> (model, [Sub action])
-runEffect m (Effect action) = runWriter (execStateT action m)
+runEffect m (EffectCore action) = runWriter (execStateT action m)
 -----------------------------------------------------------------------------
 -- | Schedule a single IO action for later execution.
 --
 -- Note that multiple IO action can be scheduled using
 -- @Control.Monad.Writer.Class.tell@ from the @mtl@ library.
-scheduleIO :: JSM action -> Effect model action ()
+scheduleIO :: JSM action -> Effect model action
 scheduleIO action = scheduleSub (\sink -> action >>= sink)
 -----------------------------------------------------------------------------
 -- | Like 'scheduleIO' but doesn't cause an action to be dispatched to
@@ -165,13 +168,13 @@ scheduleIO action = scheduleSub (\sink -> action >>= sink)
 --
 -- This is handy for scheduling IO computations where you don't care
 -- about their results or when they complete.
-scheduleIO_ :: JSM () -> Effect model action ()
+scheduleIO_ :: JSM () -> Effect model action
 scheduleIO_ action = scheduleSub (\_ -> action)
 -----------------------------------------------------------------------------
 -- | Like 'scheduleIO_ but generalized to any instance of 'Foldable'
 --
 -- This is handy for scheduling IO computations that return a `Maybe` value
-scheduleIOFor_ :: Foldable f => JSM (f action) -> Effect model action ()
+scheduleIOFor_ :: Foldable f => JSM (f action) -> Effect model action
 scheduleIOFor_ action = scheduleSub $ \sink -> action >>= flip for_ sink
 -----------------------------------------------------------------------------
 -- | Like 'scheduleIO' but schedules a subscription which is an IO
@@ -183,16 +186,16 @@ scheduleIOFor_ action = scheduleSub $ \sink -> action >>= flip for_ sink
 -- can then call the sink to turn events into actions. To do this
 -- without accessing a sink requires going via a @'Sub'scription@
 -- which introduces a leaky-abstraction.
-scheduleSub :: Sub action -> Effect model action ()
-scheduleSub sub = Effect $ lift $ tell [ sub ]
+scheduleSub :: Sub action -> Effect model action
+scheduleSub sub = EffectCore $ lift $ tell [ sub ]
 -----------------------------------------------------------------------------
 -- | 'withSink' allows users to access the sink of the 'Component' or top-level
 -- 'App' in their application. This is useful for introducing I/O into the system.
 --
 -- > update FetchJSON = withSink $ \sink -> getJSON (sink . ReceivedJSON) (sink . HandleError)
 --
-withSink :: (Sink action -> JSM ()) -> Effect model action ()
-withSink f = Effect $ lift $ tell [ f ]
+withSink :: (Sink action -> JSM ()) -> Effect model action
+withSink f = tell [ f ]
 -----------------------------------------------------------------------------
 -- | A synonym for @tell@, specialized to @Effect@
 --
@@ -203,7 +206,7 @@ withSink f = Effect $ lift $ tell [ f ]
 -- @since 1.9.0.0
 --
 -- Used to issue new @action@
-issue :: action -> Effect model action ()
+issue :: action -> Effect model action
 issue action = tell [ \sink -> sink action ]
 -----------------------------------------------------------------------------
 -- | A shorter synonym for @scheduleIO_@
@@ -216,6 +219,6 @@ issue action = tell [ \sink -> sink action ]
 --
 -- This is handy for scheduling IO computations where you don't care
 -- about their results or when they complete.
-io :: JSM () -> Effect model action ()
+io :: JSM () -> Effect model action
 io = scheduleIO_
 -----------------------------------------------------------------------------

--- a/src/Miso/Render.hs
+++ b/src/Miso/Render.hs
@@ -47,7 +47,7 @@ class ToHtml a where
   toHtml :: a -> L.ByteString
 ----------------------------------------------------------------------------
 -- | Render a @Component@ to a @L.ByteString@
-instance ToHtml (Component effect model action a) where
+instance ToHtml (Component model action) where
   toHtml = renderComponent
 ----------------------------------------------------------------------------
 -- | Render a @View@ to a @L.ByteString@
@@ -65,7 +65,7 @@ instance ToHtml a => MimeRender HTML a where
 renderView :: View a -> L.ByteString
 renderView = toLazyByteString . renderBuilder
 ----------------------------------------------------------------------------
-renderComponent :: Component effect model action a -> L.ByteString
+renderComponent :: Component model action -> L.ByteString
 renderComponent (Component _ _ App {..}) = renderView (view model)
 ----------------------------------------------------------------------------
 intercalate :: Builder -> [Builder] -> Builder

--- a/src/Miso/Types.hs
+++ b/src/Miso/Types.hs
@@ -55,10 +55,10 @@ import           Miso.Event.Types
 import           Miso.String (MisoString, toMisoString)
 -----------------------------------------------------------------------------
 -- | Application entry point
-data App effect model action a = App
+data App model action = App
   { model :: model
   -- ^ initial model
-  , update :: action -> effect model action a
+  , update :: action -> Effect model action
   -- ^ Function to update model, optionally providing effects.
   --   See the @Transition@ monad for succinctly expressing model transitions.
   , view :: model -> View action
@@ -79,9 +79,6 @@ data App effect model action a = App
   -- If 'Nothing' is provided, the entire document body is used as a mount point.
   , logLevel :: LogLevel
   -- ^ Debugging for prerendering and event delegation
-  , translate :: effect model action a -> Effect model action a
-  -- ^ natural transformation to allow users to provide their own
-  -- custom Monad stack.
   }
 -----------------------------------------------------------------------------
 -- | Allow users to express CSS and append it to <head> before the first draw
@@ -102,9 +99,9 @@ getMountPoint = fromMaybe "body"
 -- | Smart constructor for @App@ with sane defaults.
 defaultApp
   :: model
-  -> (action -> Effect model action a)
+  -> (action -> Effect model action)
   -> (model -> View action)
-  -> App Effect model action a
+  -> App model action
 defaultApp m u v = App
   { model = m
   , update = u
@@ -115,7 +112,6 @@ defaultApp m u v = App
   , mountPoint = Nothing
   , logLevel = Off
   , initialAction = Nothing
-  , translate = id
   }
 -----------------------------------------------------------------------------
 -- | Optional Logging for debugging miso internals (useful to see if prerendering is successful)
@@ -143,29 +139,29 @@ data View action
 -----------------------------------------------------------------------------
 -- | Existential wrapper used to allow the nesting of @Component@ in @App@
 data SomeComponent
-   = forall effect model action a . Eq model
-  => SomeComponent (Component effect model action a)
+   = forall model action . Eq model
+  => SomeComponent (Component model action)
 -----------------------------------------------------------------------------
 -- | Used with @component@ to parameterize @App@ by @name@
-data Component effect model action a
+data Component model action
   = Component
   { componentKey :: Maybe Key
   , componentName :: MisoString
-  , componentApp :: App effect model action a
+  , componentApp :: App model action
   }
 -----------------------------------------------------------------------------
 -- | Smart constructor for parameterizing @App@ by @name@
 -- Needed when calling @embed@ and @embedWith@
 component
   :: MisoString  
-  -> App effect model action a
-  -> Component effect model action a
+  -> App model action
+  -> Component model action
 component = Component Nothing
 -----------------------------------------------------------------------------
 -- | Used in the @view@ function to @embed@ @Component@s in @App@
 embed
   :: Eq model
-  => Component effect model action a
+  => Component model action
   -> [Attribute b]
   -> View b
 embed comp attrs = Embed attrs (SomeComponent comp)
@@ -173,7 +169,7 @@ embed comp attrs = Embed attrs (SomeComponent comp)
 -- | Used in the @view@ function to @embed@ @Component@s in @App@, with @Key@
 embedKeyed
   :: Eq model
-  => Component effect model action a
+  => Component model action
   -> Key
   -> [Attribute b]
   -> View b
@@ -195,12 +191,12 @@ instance ToView (View action) where
   type ToViewAction (View action) = action
   toView = id
 -----------------------------------------------------------------------------
-instance ToView (Component effect model action a) where
-  type ToViewAction (Component effect model action a) = action
+instance ToView (Component model action) where
+  type ToViewAction (Component model action) = action
   toView (Component _ _ app) = toView app
 -----------------------------------------------------------------------------
-instance ToView (App effect model action a) where
-  type ToViewAction (App effect model action a) = action
+instance ToView (App model action) where
+  type ToViewAction (App model action) = action
   toView App {..} = toView (view model)
 -----------------------------------------------------------------------------
 -- | Namespace of DOM elements.


### PR DESCRIPTION
- Introduce `EffectCore`
- Re-export `Effect` as synonym on `EffectCore`
- Drop two type variables on `App` and one on `Effect`.
- Drop `translate` function.

This was nice to add, but it does make the interface more intimidating, and not simple. So we'd like to keep it simple for newcomers. We can always add this back if there is a compelling use case for a custom monad (opposed to Effect).