### PR TITLE
Expose more of the fetch API

### DIFF
--- a/src/Miso/Fetch.hs
+++ b/src/Miso/Fetch.hs
@@ -57,7 +57,7 @@
 ----------------------------------------------------------------------------
 module Miso.Fetch
   ( -- * Class
-    Fetch (fetch)
+    Fetch (..)
     -- ** Simple non-Servant API
   , fetchJSON
   ) where

--- a/src/Miso/Fetch.hs
+++ b/src/Miso/Fetch.hs
@@ -58,6 +58,8 @@
 module Miso.Fetch
   ( -- * Class
     Fetch (fetch)
+    -- ** Simple non-Servant API
+  , fetchJSON
   ) where
 -----------------------------------------------------------------------------
 import           Data.Aeson


### PR DESCRIPTION
As discussed just now on Matrix.

For the type class, there's an argument for only exposing it through some internal module rather than from the top-level `Miso` module where it would clutter the haddocks with a pretty niche part of the API. I'll leave that up to @dmjio. Personally I'd seriously consider factoring out the whole fetch API in to a separate library, not tied to Miso, but that suggestion was, not unreasonably, firmly rejected.