### PR TITLE
Hide Success warning for all GHC JS

### DIFF
--- a/miso.cabal
+++ b/miso.cabal
@@ -68,7 +68,7 @@ common jsaddle
       jsaddle-wasm < 0.2
 
 common client
-  if impl(ghcjs)
+  if impl(ghcjs) || arch(javascript)
     build-depends:
       ghcjs-base -any
 

--- a/miso.cabal
+++ b/miso.cabal
@@ -68,7 +68,7 @@ common jsaddle
       jsaddle-wasm < 0.2
 
 common client
-  if impl(ghcjs) || arch(javascript)
+  if impl(ghcjs)
     build-depends:
       ghcjs-base -any
 

--- a/src/Miso/FFI/Internal.hs
+++ b/src/Miso/FFI/Internal.hs
@@ -65,7 +65,7 @@ import           Data.Aeson hiding (Object)
 import qualified Data.Aeson as A
 import           Data.Maybe (isJust)
 import qualified Data.JSString as JSS
-#ifdef GHCJS_OLD
+#ifdef GHCJS_BOTH
 import           Language.Javascript.JSaddle
 #else
 import           Language.Javascript.JSaddle hiding (Success)


### PR DESCRIPTION
- This warning is related to Success not being exposed