### PR TITLE
Adds PolyKinds to `Miso.Route` to make `Verb` working properly with HasRouter

### DIFF
--- a/src/Miso/Router.hs
+++ b/src/Miso/Router.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE TypeFamilies          #-}
 {-# LANGUAGE TypeOperators         #-}
 {-# LANGUAGE GADTs                 #-}
+{-# LANGUAGE PolyKinds             #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Miso.Router


### PR DESCRIPTION
It seems that we need `PolyKinds` to make `HasRouter` working properly with servant endpoints such as `Verb`.