### PR TITLE
Add an OSX builder

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: [ubuntu-latest, macos-latest]
     if: github.ref != 'refs/heads/master'
     steps:
      - uses: DeterminateSystems/nix-installer-action@main


### PR DESCRIPTION
- This will help us cache stuff for Darwin users
- Push darwin binaries to our cachix cache so new users won't have to build ghcjs9122