### PR TITLE
Add global install instructions for ghcjs

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,6 +431,13 @@ Using [GHCup](https://www.haskell.org/ghcup/) you should be able to acquire the 
 > [!NOTE]
 > This will put `javascript-unknown-ghcjs-ghc` in your `$PATH`, along with `javascript-unknown-ghcjs-ghc-pkg`. You might also need to specify in your `cabal.project` file that you are using the JS backend.
 
+> [!TIP]
+> Alternatively, if you'd like to install the compiler into your global environment (so you don't need to develop inside a `bash` shell) you can use the following command.
+>
+> ```bash
+> ❯ nix-env -iA pkgs.pkgsCross.ghcjs.haskell.packages.ghc9122.ghc -f https://github.com/alexfmpe/nixpkgs/archive/b594b289740a2bc917ed9c66fef5d905f389cb96.tar.gz
+> ```
+
 - `cabal.project`
 
 ```yaml


### PR DESCRIPTION
- Describes how to use nix to install ghcjs on your system's global environment