### PR TITLE
Re-export <&> from base

### DIFF
--- a/src/Miso/Lens.hs
+++ b/src/Miso/Lens.hs
@@ -102,10 +102,9 @@ module Miso.Lens
   , Lens'
     -- ** Smart constructor
   , lens
-    -- ** Utils
-  , (<&>)
     -- ** Re-exports
   , (&)
+  , (<&>)
     -- ** Combinators
   , (.~)
   , (?~)
@@ -140,6 +139,7 @@ import Control.Monad.State (MonadState, modify, gets)
 import Control.Category (Category (..))
 import Control.Arrow ((<<<))
 import Data.Function ((&))
+import Data.Functor((<&>))
 ----------------------------------------------------------------------------
 -- | A @Lens@ is a generalized getter and setter.
 --
@@ -638,9 +638,4 @@ lens
   -> (record -> field -> record)
   -> Lens record field
 lens = Lens
-----------------------------------------------------------------------------
--- | Functor utility, a flipped infix @fmap@.
-infixl 1 <&>
-(<&>) :: Functor f => f a -> (a -> b) -> f b
-f <&> x = x <$> f
 ----------------------------------------------------------------------------


### PR DESCRIPTION
Slightly reduce import confusion, less code, benefit from more comprehensive docs in base :slightly_smiling_face: 
The operator has been available in base since base-4.11.0.0 which corresponds to ghc 8.4.1 which is well within the range of GHCs that miso aims to support.

![image](https://github.com/user-attachments/assets/2f98eeaa-35dc-4425-a17f-6bb769bf6bc9)


