### PR TITLE
Drop js-only from fetch example

### DIFF
--- a/examples/fetch/Main.hs
+++ b/examples/fetch/Main.hs
@@ -57,11 +57,6 @@ data Action
   | ErrorHandler MisoString
   deriving (Show, Eq)
 ----------------------------------------------------------------------------
--- | WASM support
-#ifdef WASM
-foreign export javascript "hs_start" main :: IO ()
-#endif
-----------------------------------------------------------------------------
 app :: App Model Action
 app = defaultApp emptyModel updateModel viewModel
 ----------------------------------------------------------------------------

--- a/examples/miso-examples.cabal
+++ b/examples/miso-examples.cabal
@@ -148,7 +148,7 @@ executable file-reader
 
 executable fetch
   import:
-    common-options, js-only
+    common-options
   default-language:
     Haskell2010
   main-is:

--- a/nix/wasm/default.nix
+++ b/nix/wasm/default.nix
@@ -71,6 +71,7 @@ self: super:
   # to populate examples
   wasmExamples = self.writeScriptBin "build.sh" ''
     nix shell '${self.wasm-flake}' --command wasm32-wasi-cabal update
+    nix shell '${self.wasm-flake}' --command wasm32-wasi-cabal clean
     nix shell '${self.wasm-flake}' --command wasm32-wasi-cabal build miso examples
   '';
 


### PR DESCRIPTION
Fetch example is now agnostic to GHC backend