### PR TITLE
Fix ghc warnings and type errors in haddocks

### DIFF
--- a/examples/components/Main.hs
+++ b/examples/components/Main.hs
@@ -7,7 +7,6 @@ module Main where
 import Control.Concurrent
 import Control.Monad
 import Control.Monad.IO.Class (liftIO)
-import Control.Monad.State (modify)
 
 import Miso
 import Miso.String

--- a/examples/mario/Main.hs
+++ b/examples/mario/Main.hs
@@ -5,7 +5,6 @@
 
 module Main where
 
-import Control.Monad.State (modify, get)
 import Data.Bool
 import Data.Function
 import qualified Data.Map as M

--- a/examples/router/Main.hs
+++ b/examples/router/Main.hs
@@ -7,7 +7,6 @@
 {-# LANGUAGE TypeOperators #-}
 module Main where
 
-import Control.Monad.State (modify)
 import Data.Proxy
 import Miso
 import Servant.API

--- a/examples/sse/shared/Common.hs
+++ b/examples/sse/shared/Common.hs
@@ -12,7 +12,6 @@ module Common (
     the404,
 ) where
 
-import Control.Monad.State (modify)
 import Data.Proxy
 import Servant.API
 import Servant.Links
@@ -67,8 +66,8 @@ sse currentURI
           ]
         }
   where
-    app = defaultApp (Model currentURI "No event received") updateModel view
-    view m
+    app = defaultApp (Model currentURI "No event received") updateModel viewModel
+    viewModel m
         | Right r <- route (Proxy :: Proxy ClientRoutes) home modelUri m =
             r
         | otherwise = the404
@@ -79,10 +78,9 @@ handleSseMsg SSEClose = ServerMsg "SSE connection closed"
 handleSseMsg SSEError = ServerMsg "SSE error"
 
 updateModel :: Action -> Effect Model Action
-updateModel (ServerMsg msg) = modify update
-  where
-    update m = m { modelMsg = "Event received: " ++ msg }
-updateModel (HandleURI u) = modify update
-  where
-    update m = m { modelUri = u }
-updateModel (ChangeURI u) = io (pushURI u)
+updateModel (ServerMsg msg) =
+    modify $ \m -> m { modelMsg = "Event received: " ++ msg }
+updateModel (HandleURI u) =
+    modify $ \m -> m { modelUri = u }
+updateModel (ChangeURI u) =
+    io (pushURI u)

--- a/examples/todo-mvc/Main.hs
+++ b/examples/todo-mvc/Main.hs
@@ -106,7 +106,7 @@ updateModel FocusOnInput =
 updateModel (CurrentTime time) = io $ consoleLog $ S.ms (show time)
 updateModel Add = do
     model@Model{..} <- get
-    noEff
+    put
         model
             { uid = uid + 1
             , field = mempty

--- a/src/Miso/Lens.hs
+++ b/src/Miso/Lens.hs
@@ -91,7 +91,7 @@
 --
 -- data Action = AddOne | SubtractOne
 --
--- updateModel :: Action -> 'Effect' Model Action ()
+-- updateModel :: Action -> 'Effect' Model Action
 -- updateModel AddOne      = value '+=' 1
 -- updateModel SubtractOne = value '-=' 1
 -- @
@@ -349,7 +349,7 @@ l <~ mb = do
 -- value :: Lens Model Int
 -- value = lens _value $ \\p x -> p { _value = x }
 --
--- update :: Action -> Effect Model Action ()
+-- update :: Action -> Effect Model Action
 -- update AddOne = do
 --   value %= (+1)
 -- @
@@ -375,7 +375,7 @@ modifying = (%=)
 -- value :: Lens Model Int
 -- value = lens _value $ \\p x -> p { _value = x }
 --
--- update :: Action -> Effect Model Action ()
+-- update :: Action -> Effect Model Action
 -- update AddOne = do
 --   result <- value <%= (+1)
 --   io $ consoleLog (ms result)
@@ -399,7 +399,7 @@ l <%= f = do
 -- value :: Lens Model Int
 -- value = lens _value $ \\p x -> p { _value = x }
 --
--- update :: Action -> Effect Model Action ()
+-- update :: Action -> Effect Model Action
 -- update (Assign x) = do
 --   result <- value <.= x
 --   io $ consoleLog (ms result) -- x
@@ -423,7 +423,7 @@ l <.= b = do
 -- value :: Lens Model (Maybe Int)
 -- value = lens _value $ \\p x -> p { _value = x }
 --
--- update :: Action -> Effect Model Action ()
+-- update :: Action -> Effect Model Action
 -- update (SetValue x) = do
 --   result <- value <?= x
 --   io $ consoleLog (ms result) -- Just 1
@@ -449,7 +449,7 @@ l <?= b = do
 -- value :: Lens Model Int
 -- value = lens _value $ \\p x -> p { _value = x }
 --
--- update :: Action -> Effect Model Action ()
+-- update :: Action -> Effect Model Action
 -- update (Assign x) = do
 --   value .= x
 --   previousValue <- value <<.= 1
@@ -476,7 +476,7 @@ l <<.= b = do
 -- value :: Lens Model Int
 -- value = lens _value $ \p x -> p { _value = x }
 --
--- update :: Action -> Effect Model Action ()
+-- update :: Action -> Effect Model Action
 -- update (Modify f) = do
 --   value .= 2
 --   result <- value <<%= f
@@ -500,7 +500,7 @@ l <<%= f = do
 -- value :: Lens Model Int
 -- value = lens _value $ \\p x -> p { _value = x }
 --
--- update' :: Action -> Effect Model Action ()
+-- update' :: Action -> Effect Model Action
 -- update' (SetValue v) = value .= v
 -- @
 infix 4 .=
@@ -524,7 +524,7 @@ assign = (.=)
 -- value :: Lens Model Int
 -- value = lens _value $ \p x -> p { _value = x }
 --
--- update :: Action -> Effect Model Action ()
+-- update :: Action -> Effect Model Action
 -- update (SetValue x) = do
 --   value .= x
 --   result <- use value
@@ -545,7 +545,7 @@ use _lens = gets (^. _lens)
 -- value :: Lens Model (Maybe Int)
 -- value = lens _value $ \\p x -> p { _value = x }
 --
--- update :: Action -> Effect Model Action ()
+-- update :: Action -> Effect Model Action
 -- update (AssignValue x) = value ?= x
 -- @
 infix 4 ?=
@@ -564,7 +564,7 @@ infix 4 ?=
 -- value :: Lens Model Int
 -- value = lens _value $ \\p x -> p { _value = x }
 --
--- update :: Action -> Effect Model Action ()
+-- update :: Action -> Effect Model Action
 -- update (IncrementBy x) = value += x
 --
 infix 4 +=
@@ -583,7 +583,7 @@ infix 4 +=
 -- value :: Lens Model Int
 -- value = lens _value $ \\p x -> p { _value = x }
 --
--- update :: Action -> Effect Model Action ()
+-- update :: Action -> Effect Model Action
 -- update (MultiplyBy x) = value *= x
 -- @
 infix 4 *=
@@ -602,7 +602,7 @@ infix 4 *=
 -- value :: Lens Model Double
 -- value = lens _value $ \\p x -> p { _value = x }
 --
--- update :: Action -> Effect Model Action ()
+-- update :: Action -> Effect Model Action
 -- update (DivideBy x) = value //= x
 -- @
 infix 4 //=
@@ -621,7 +621,7 @@ infix 4 //=
 -- value :: Lens Model Double
 -- value = lens _value $ \\p x -> p { _value = x }
 --
--- update :: Action -> Effect Model Action ()
+-- update :: Action -> Effect Model Action
 -- update (SubtractBy x) = value -= x
 -- @
 infix 4 -=


### PR DESCRIPTION
Followup on https://github.com/dmjio/miso/pull/913 which deprecated bunch of functions and reexposed stuff from Control.Monad.State. Also noticed that all lens examples have an extraneous argument to Effect which should be removed.