### PR TITLE
Remove deprecated and add newly introduced SVG attributes

### DIFF
--- a/src/Miso/Svg.hs
+++ b/src/Miso/Svg.hs
@@ -33,11 +33,7 @@ module Miso.Svg
    , module Miso.Svg.Event
    ) where
 -----------------------------------------------------------------------------
-import Miso.Svg.Attribute
-  hiding ( filter_, path_, title_, mask_
-         , glyphRef_, clipPath_, colorProfile_
-         , cursor_, style_
-         )
+import Miso.Svg.Attribute hiding (filter_, path_, mask_, clipPath_, cursor_, style_)
 import Miso.Svg.Element
 import Miso.Svg.Event
 -----------------------------------------------------------------------------

--- a/src/Miso/Svg/Attribute.hs
+++ b/src/Miso/Svg/Attribute.hs
@@ -14,36 +14,22 @@
 ----------------------------------------------------------------------------
 module Miso.Svg.Attribute
   ( -- *** Attributes
-    accentHeight_
-  , accelerate_
-  , accumulate_
+    accumulate_
   , additive_
-  , alphabetic_
-  , allowReorder_
   , amplitude_
-  , arabicForm_
-  , ascent_
   , attributeName_
-  , attributeType_
-  , autoReverse_
   , azimuth_
   , baseFrequency_
-  , baseProfile_
-  , bbox_
   , begin_
   , bias_
   , by_
   , calcMode_
-  , capHeight_
   , class_'
   , clipPathUnits_
-  , contentScriptType_
-  , contentStyleType_
   , cx_
   , cy_
   , d_
-  , decelerate_
-  , descent_
+  -- TODO decoding
   , diffuseConstant_
   , divisor_
   , dur_
@@ -53,71 +39,60 @@ module Miso.Svg.Attribute
   , elevation_
   , end_
   , exponent_
-  , externalResourcesRequired_
-  , filterRes_
   , filterUnits_
-  , format_
+  -- TODO fr
+  -- TODO glyph-orientation-horizontal
+  -- TODO glyph-orientation-vertical
+  -- TODO href
+  -- TODO hreflang
   , from_
   , fx_
   , fy_
-  , g1_
-  , g2_
-  , glyphName_
-  , glyphRef_
   , gradientTransform_
   , gradientUnits_
-  , hanging_
   , height_
-  , horizAdvX_
-  , horizOriginX_
-  , horizOriginY_
   , id_
-  , ideographic_
   , in_'
   , in2_
   , intercept_
-  , k_
   , k1_
   , k2_
   , k3_
   , k4_
   , kernelMatrix_
-  , kernelUnitLength_
   , keyPoints_
   , keySplines_
   , keyTimes_
   , lang_
   , lengthAdjust_
   , limitingConeAngle_
-  , local_
   , markerHeight_
   , markerUnits_
   , markerWidth_
   , maskContentUnits_
   , maskUnits_
-  , mathematical_
   , max_
   , media_
   , method_
   , min_
   , mode_
-  , name_
   , numOctaves_
-  , offset_
   , operator_
   , order_
   , orient_
-  , orientation_
+  -- TODO paint-order
+  -- TODO ping
   , origin_
-  , overlinePosition_
-  , overlineThickness_
-  , panose1_
   , path_
   , pathLength_
   , patternContentUnits_
   , patternTransform_
   , patternUnits_
-  , pointOrder_
+  -- TODO referrerPolicy
+  -- TODO rel
+  -- TODO requiredExtensions
+  -- TODO requiredFeatures
+  -- TODO side
   , points_
   , pointsAtX_
   , pointsAtY_
@@ -129,11 +104,8 @@ module Miso.Svg.Attribute
   , radius_
   , refX_
   , refY_
-  , renderingIntent_
   , repeatCount_
   , repeatDur_
-  , requiredExtensions_
-  , requiredFeatures_
   , restart_
   , result_
   , rotate_
@@ -145,16 +117,10 @@ module Miso.Svg.Attribute
   , spacing_
   , specularConstant_
   , specularExponent_
-  , speed_
   , spreadMethod_
   , startOffset_
   , stdDeviation_
-  , stemh_
-  , stemv_
   , stitchTiles_
-  , strikethroughPosition_
-  , strikethroughThickness_
-  , string_
   , style_
   , surfaceScale_
   , systemLanguage_
@@ -163,66 +129,40 @@ module Miso.Svg.Attribute
   , targetX_
   , targetY_
   , textLength_
-  , title_
   , to_
   , transform_
+  -- TODO transform-origin
   , type_'
-  , u1_
-  , u2_
-  , underlinePosition_
-  , underlineThickness_
-  , unicode_
-  , unicodeRange_
-  , unitsPerEm_
-  , vAlphabetic_
-  , vHanging_
-  , vIdeographic_
-  , vMathematical_
   , values_
-  , version_
-  , vertAdvY_
-  , vertOriginX_
-  , vertOriginY_
+  -- TODO vector-effect
+  -- TODO version
   , viewBox_
-  , viewTarget_
+  -- TODO zoomAndPan
   , width_
-  , widths_
   , x_
-  , xHeight_
   , x1_
   , x2_
   , xChannelSelector_
-  , xlinkActuate_
-  , xlinkArcrole_
-  , xlinkHref_
-  , xlinkRole_
-  , xlinkShow_
-  , xlinkTitle_
-  , xlinkType_
-  , xmlBase_
-  , xmlLang_
-  , xmlSpace_
   , y_
   , y1_
   , y2_
   , yChannelSelector_
   , z_
-  , zoomAndPan_
+  -- *** Presentation attributes
+  --
+  -- | All SVG presentation attributes can be used as CSS properties.
   , alignmentBaseline_
   , baselineShift_
   , clipPath_
   , clipRule_
-  , clip_
   , colorInterpolationFilters_
   , colorInterpolation_
-  , colorProfile_
-  , colorRendering_
+  -- TODO crossorigin
   , color_
   , cursor_
   , direction_
   , display_
   , dominantBaseline_
-  , enableBackground_
   , fillOpacity_
   , fillRule_
   , fill_
@@ -232,14 +172,10 @@ module Miso.Svg.Attribute
   , fontFamily_
   , fontSizeAdjust_
   , fontSize_
-  , fontStretch_
   , fontStyle_
   , fontVariant_
   , fontWeight_
-  , glyphOrientationHorizontal_
-  , glyphOrientationVertical_
   , imageRendering_
-  , kerning_
   , letterSpacing_
   , lightingColor_
   , markerEnd_
@@ -276,14 +212,6 @@ import Miso.String        ( MisoString )
 attr :: MisoString -> MisoString -> Attribute action
 attr = textProp
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/accent-height>
-accentHeight_ ::  MisoString -> Attribute action
-accentHeight_ = attr "accent-height"
------------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/accelerate>
-accelerate_ ::  MisoString -> Attribute action
-accelerate_ = attr "accelerate"
------------------------------------------------------------------------------
 -- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/accumulate>
 accumulate_ ::  MisoString -> Attribute action
 accumulate_ = attr "accumulate"
@@ -292,37 +220,13 @@ accumulate_ = attr "accumulate"
 additive_ ::  MisoString -> Attribute action
 additive_ = attr "additive"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/alphabetic>
-alphabetic_ ::  MisoString -> Attribute action
-alphabetic_ = attr "alphabetic"
------------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/allowReorder>
-allowReorder_ ::  MisoString -> Attribute action
-allowReorder_ = attr "allowReorder"
------------------------------------------------------------------------------
 -- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/amplitude>
 amplitude_ ::  MisoString -> Attribute action
 amplitude_ = attr "amplitude"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/arabic-form>
-arabicForm_ ::  MisoString -> Attribute action
-arabicForm_ = attr "arabic-form"
------------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/ascent>
-ascent_ ::  MisoString -> Attribute action
-ascent_ = attr "ascent"
------------------------------------------------------------------------------
 -- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/attributeName>
 attributeName_ ::  MisoString -> Attribute action
 attributeName_ = attr "attributeName"
------------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/attributeType>
-attributeType_ ::  MisoString -> Attribute action
-attributeType_ = attr "attributeType"
------------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/autoReverse>
-autoReverse_ ::  MisoString -> Attribute action
-autoReverse_ = attr "autoReverse"
 -----------------------------------------------------------------------------
 -- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/azimuth>
 azimuth_ ::  MisoString -> Attribute action
@@ -331,14 +235,6 @@ azimuth_ = attr "azimuth"
 -- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/baseFrequency>
 baseFrequency_ ::  MisoString -> Attribute action
 baseFrequency_ = attr "baseFrequency"
------------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/baseProfile>
-baseProfile_ ::  MisoString -> Attribute action
-baseProfile_ = attr "baseProfile"
------------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/bbox>
-bbox_ ::  MisoString -> Attribute action
-bbox_ = attr "bbox"
 -----------------------------------------------------------------------------
 -- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/begin>
 begin_ ::  MisoString -> Attribute action
@@ -356,10 +252,6 @@ by_ = attr "by"
 calcMode_ ::  MisoString -> Attribute action
 calcMode_ = attr "calcMode"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/cap-height>
-capHeight_ ::  MisoString -> Attribute action
-capHeight_ = attr "cap-height"
------------------------------------------------------------------------------
 -- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/class>
 class_' ::  MisoString -> Attribute action
 class_' = attr "class"
@@ -367,14 +259,6 @@ class_' = attr "class"
 -- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/clipPathUnits>
 clipPathUnits_ ::  MisoString -> Attribute action
 clipPathUnits_ = attr "clipPathUnits"
------------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/contentScriptType>
-contentScriptType_ ::  MisoString -> Attribute action
-contentScriptType_ = attr "contentScriptType"
------------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/contentStyleType>
-contentStyleType_ ::  MisoString -> Attribute action
-contentStyleType_ = attr "contentStyleType"
 -----------------------------------------------------------------------------
 -- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/cx>
 cx_ ::  MisoString -> Attribute action
@@ -387,14 +271,6 @@ cy_ = attr "cy"
 -- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/d>
 d_ ::  MisoString -> Attribute action
 d_ = attr "d"
------------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/decelerate>
-decelerate_ ::  MisoString -> Attribute action
-decelerate_ = attr "decelerate"
------------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/descent>
-descent_ ::  MisoString -> Attribute action
-descent_ = attr "descent"
 -----------------------------------------------------------------------------
 -- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/diffuseConstant>
 diffuseConstant_ ::  MisoString -> Attribute action
@@ -432,21 +308,9 @@ end_ = attr "end"
 exponent_ ::  MisoString -> Attribute action
 exponent_ = attr "exponent"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/externalResourcesRequired>
-externalResourcesRequired_ ::  MisoString -> Attribute action
-externalResourcesRequired_ = attr "externalResourcesRequired"
------------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/filterRes>
-filterRes_ ::  MisoString -> Attribute action
-filterRes_ = attr "filterRes"
------------------------------------------------------------------------------
 -- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/filterUnits>
 filterUnits_ ::  MisoString -> Attribute action
 filterUnits_ = attr "filterUnits"
------------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/format>
-format_ ::  MisoString -> Attribute action
-format_ = attr "format"
 -----------------------------------------------------------------------------
 -- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/from>
 from_ ::  MisoString -> Attribute action
@@ -460,22 +324,6 @@ fx_ = attr "fx"
 fy_ ::  MisoString -> Attribute action
 fy_ = attr "fy"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/g1>
-g1_ ::  MisoString -> Attribute action
-g1_ = attr "g1"
------------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/g2>
-g2_ ::  MisoString -> Attribute action
-g2_ = attr "g2"
------------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/glyph-name>
-glyphName_ ::  MisoString -> Attribute action
-glyphName_ = attr "glyph-name"
------------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/glyphRef>
-glyphRef_ ::  MisoString -> Attribute action
-glyphRef_ = attr "glyphRef"
------------------------------------------------------------------------------
 -- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/gradientTransform>
 gradientTransform_ ::  MisoString -> Attribute action
 gradientTransform_ = attr "gradientTransform"
@@ -484,33 +332,13 @@ gradientTransform_ = attr "gradientTransform"
 gradientUnits_ ::  MisoString -> Attribute action
 gradientUnits_ = attr "gradientUnits"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/hanging>
-hanging_ ::  MisoString -> Attribute action
-hanging_ = attr "hanging"
------------------------------------------------------------------------------
 -- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/height>
 height_ ::  MisoString -> Attribute action
 height_ = attr "height"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/horiz-adv-x>
-horizAdvX_ ::  MisoString -> Attribute action
-horizAdvX_ = attr "horiz-adv-x"
------------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/horiz-origin-x>
-horizOriginX_ ::  MisoString -> Attribute action
-horizOriginX_ = attr "horiz-origin-x"
------------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/horiz-origin-y>
-horizOriginY_ ::  MisoString -> Attribute action
-horizOriginY_ = attr "horiz-origin-y"
------------------------------------------------------------------------------
 -- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/id>
 id_ ::  MisoString -> Attribute action
 id_ = attr "id"
------------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/ideographic>
-ideographic_ ::  MisoString -> Attribute action
-ideographic_ = attr "ideographic"
 -----------------------------------------------------------------------------
 -- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/in>
 in_' ::  MisoString -> Attribute action
@@ -523,10 +351,6 @@ in2_ = attr "in2"
 -- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/intercept>
 intercept_ ::  MisoString -> Attribute action
 intercept_ = attr "intercept"
------------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/k>
-k_ ::  MisoString -> Attribute action
-k_ = attr "k"
 -----------------------------------------------------------------------------
 -- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/k1>
 k1_ ::  MisoString -> Attribute action
@@ -547,10 +371,6 @@ k4_ = attr "k4"
 -- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/kernelMatrix>
 kernelMatrix_ ::  MisoString -> Attribute action
 kernelMatrix_ = attr "kernelMatrix"
------------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/kernelUnitLength>
-kernelUnitLength_ ::  MisoString -> Attribute action
-kernelUnitLength_ = attr "kernelUnitLength"
 -----------------------------------------------------------------------------
 -- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/keyPoints>
 keyPoints_ ::  MisoString -> Attribute action
@@ -576,10 +396,6 @@ lengthAdjust_ = attr "lengthAdjust"
 limitingConeAngle_ ::  MisoString -> Attribute action
 limitingConeAngle_ = attr "limitingConeAngle"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/local>
-local_ ::  MisoString -> Attribute action
-local_ = attr "local"
------------------------------------------------------------------------------
 -- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/markerHeight>
 markerHeight_ ::  MisoString -> Attribute action
 markerHeight_ = attr "markerHeight"
@@ -599,10 +415,6 @@ maskContentUnits_ = attr "maskContentUnits"
 -- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/maskUnits>
 maskUnits_ ::  MisoString -> Attribute action
 maskUnits_ = attr "maskUnits"
------------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/mathematical>
-mathematical_ ::  MisoString -> Attribute action
-mathematical_ = attr "mathematical"
 -----------------------------------------------------------------------------
 -- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/max>
 max_ ::  MisoString -> Attribute action
@@ -624,17 +436,9 @@ min_ = attr "min"
 mode_ ::  MisoString -> Attribute action
 mode_ = attr "mode"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/name>
-name_ ::  MisoString -> Attribute action
-name_ = attr "name"
------------------------------------------------------------------------------
 -- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/numOctaves>
 numOctaves_ ::  MisoString -> Attribute action
 numOctaves_ = attr "numOctaves"
------------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/offset>
-offset_ ::  MisoString -> Attribute action
-offset_ = attr "offset"
 -----------------------------------------------------------------------------
 -- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/operator>
 operator_ ::  MisoString -> Attribute action
@@ -648,25 +452,9 @@ order_ = attr "order"
 orient_ ::  MisoString -> Attribute action
 orient_ = attr "orient"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/orientation>
-orientation_ ::  MisoString -> Attribute action
-orientation_ = attr "orientation"
------------------------------------------------------------------------------
 -- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/origin>
 origin_ ::  MisoString -> Attribute action
 origin_ = attr "origin"
------------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/overline-position>
-overlinePosition_ ::  MisoString -> Attribute action
-overlinePosition_ = attr "overline-position"
------------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/overline-thickness>
-overlineThickness_ ::  MisoString -> Attribute action
-overlineThickness_ = attr "overline-thickness"
------------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/panose-1>
-panose1_ ::  MisoString -> Attribute action
-panose1_ = attr "panose-1"
 -----------------------------------------------------------------------------
 -- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/path>
 path_ ::  MisoString -> Attribute action
@@ -687,10 +475,6 @@ patternTransform_ = attr "patternTransform"
 -- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/patternUnits>
 patternUnits_ ::  MisoString -> Attribute action
 patternUnits_ = attr "patternUnits"
------------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/point-order>
-pointOrder_ ::  MisoString -> Attribute action
-pointOrder_ = attr "point-order"
 -----------------------------------------------------------------------------
 -- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/points>
 points_ ::  MisoString -> Attribute action
@@ -736,10 +520,6 @@ refX_ = attr "refX"
 refY_ ::  MisoString -> Attribute action
 refY_ = attr "refY"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/rendering-intent>
-renderingIntent_ ::  MisoString -> Attribute action
-renderingIntent_ = attr "rendering-intent"
------------------------------------------------------------------------------
 -- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/repeatCount>
 repeatCount_ ::  MisoString -> Attribute action
 repeatCount_ = attr "repeatCount"
@@ -747,14 +527,6 @@ repeatCount_ = attr "repeatCount"
 -- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/repeatDur>
 repeatDur_ ::  MisoString -> Attribute action
 repeatDur_ = attr "repeatDur"
------------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/requiredExtensions>
-requiredExtensions_ ::  MisoString -> Attribute action
-requiredExtensions_ = attr "requiredExtensions"
------------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/requiredFeatures>
-requiredFeatures_ ::  MisoString -> Attribute action
-requiredFeatures_ = attr "requiredFeatures"
 -----------------------------------------------------------------------------
 -- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/restart>
 restart_ ::  MisoString -> Attribute action
@@ -800,10 +572,6 @@ specularConstant_ = attr "specularConstant"
 specularExponent_ ::  MisoString -> Attribute action
 specularExponent_ = attr "specularExponent"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/speed>
-speed_ ::  MisoString -> Attribute action
-speed_ = attr "speed"
------------------------------------------------------------------------------
 -- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/spreadMethod>
 spreadMethod_ ::  MisoString -> Attribute action
 spreadMethod_ = attr "spreadMethod"
@@ -816,29 +584,9 @@ startOffset_ = attr "startOffset"
 stdDeviation_ ::  MisoString -> Attribute action
 stdDeviation_ = attr "stdDeviation"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/stemh>
-stemh_ ::  MisoString -> Attribute action
-stemh_ = attr "stemh"
------------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/stemv>
-stemv_ ::  MisoString -> Attribute action
-stemv_ = attr "stemv"
------------------------------------------------------------------------------
 -- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/stitchTiles>
 stitchTiles_ ::  MisoString -> Attribute action
 stitchTiles_ = attr "stitchTiles"
------------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/strikethrough-position>
-strikethroughPosition_ ::  MisoString -> Attribute action
-strikethroughPosition_ = attr "strikethrough-position"
------------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/strikethrough-thickness>
-strikethroughThickness_ ::  MisoString -> Attribute action
-strikethroughThickness_ = attr "strikethrough-thickness"
------------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/string>
-string_ ::  MisoString -> Attribute action
-string_ = attr "string"
 -----------------------------------------------------------------------------
 -- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/style>
 style_ ::  MisoString -> Attribute action
@@ -872,10 +620,6 @@ targetY_ = attr "targetY"
 textLength_ ::  MisoString -> Attribute action
 textLength_ = attr "textLength"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/title>
-title_ ::  MisoString -> Attribute action
-title_ = attr "title"
------------------------------------------------------------------------------
 -- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/to>
 to_ ::  MisoString -> Attribute action
 to_ = attr "to"
@@ -888,93 +632,21 @@ transform_ = attr "transform"
 type_' ::  MisoString -> Attribute action
 type_' = attr "type"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/u1>
-u1_ ::  MisoString -> Attribute action
-u1_ = attr "u1"
------------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/u2>
-u2_ ::  MisoString -> Attribute action
-u2_ = attr "u2"
------------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/underline-position>
-underlinePosition_ ::  MisoString -> Attribute action
-underlinePosition_ = attr "underline-position"
------------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/underline-thickness>
-underlineThickness_ ::  MisoString -> Attribute action
-underlineThickness_ = attr "underline-thickness"
------------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/unicode>
-unicode_ ::  MisoString -> Attribute action
-unicode_ = attr "unicode"
------------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/unicode-range>
-unicodeRange_ ::  MisoString -> Attribute action
-unicodeRange_ = attr "unicode-range"
------------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/units-per-em>
-unitsPerEm_ ::  MisoString -> Attribute action
-unitsPerEm_ = attr "units-per-em"
------------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/v-alphabetic>
-vAlphabetic_ ::  MisoString -> Attribute action
-vAlphabetic_ = attr "v-alphabetic"
------------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/v-hanging>
-vHanging_ ::  MisoString -> Attribute action
-vHanging_ = attr "v-hanging"
------------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/v-ideographic>
-vIdeographic_ ::  MisoString -> Attribute action
-vIdeographic_ = attr "v-ideographic"
------------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/v-mathematical>
-vMathematical_ ::  MisoString -> Attribute action
-vMathematical_ = attr "v-mathematical"
------------------------------------------------------------------------------
 -- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/values>
 values_ ::  MisoString -> Attribute action
 values_ = attr "values"
------------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/version>
-version_ ::  MisoString -> Attribute action
-version_ = attr "version"
------------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/vert-adv-y>
-vertAdvY_ ::  MisoString -> Attribute action
-vertAdvY_ = attr "vert-adv-y"
------------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/vert-origin-x>
-vertOriginX_ ::  MisoString -> Attribute action
-vertOriginX_ = attr "vert-origin-x"
------------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/vert-origin-y>
-vertOriginY_ ::  MisoString -> Attribute action
-vertOriginY_ = attr "vert-origin-y"
 -----------------------------------------------------------------------------
 -- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/viewBox>
 viewBox_ ::  MisoString -> Attribute action
 viewBox_ = attr "viewBox"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/viewTarget>
-viewTarget_ ::  MisoString -> Attribute action
-viewTarget_ = attr "viewTarget"
------------------------------------------------------------------------------
 -- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/width>
 width_ ::  MisoString -> Attribute action
 width_ = attr "width"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/widths>
-widths_ ::  MisoString -> Attribute action
-widths_ = attr "widths"
------------------------------------------------------------------------------
 -- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/x>
 x_ ::  MisoString -> Attribute action
 x_ = attr "x"
------------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/x-height>
-xHeight_ ::  MisoString -> Attribute action
-xHeight_ = attr "x-height"
 -----------------------------------------------------------------------------
 -- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/x1>
 x1_ ::  MisoString -> Attribute action
@@ -987,46 +659,6 @@ x2_ = attr "x2"
 -- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/xChannelSelector>
 xChannelSelector_ ::  MisoString -> Attribute action
 xChannelSelector_ = attr "x-channel-selector"
------------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/xlinkActuate>
-xlinkActuate_ ::  MisoString -> Attribute action
-xlinkActuate_ = attr "xlinkActuate"
------------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/xlinkArcrole>
-xlinkArcrole_ ::  MisoString -> Attribute action
-xlinkArcrole_ = attr "xlinkArcrole"
------------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/xlinkHref>
-xlinkHref_ ::  MisoString -> Attribute action
-xlinkHref_ = attr "xlinkHref"
------------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/xlinkRole>
-xlinkRole_ ::  MisoString -> Attribute action
-xlinkRole_ = attr "xlinkRole"
------------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/xlinkShow>
-xlinkShow_ ::  MisoString -> Attribute action
-xlinkShow_ = attr "xlinkShow"
------------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/xlinkTitle>
-xlinkTitle_ ::  MisoString -> Attribute action
-xlinkTitle_ = attr "xlinkTitle"
------------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/xlinkType>
-xlinkType_ ::  MisoString -> Attribute action
-xlinkType_ = attr "xlinkType"
------------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/xmlBase>
-xmlBase_ ::  MisoString -> Attribute action
-xmlBase_ = attr "xmlBase"
------------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/xmlLang>
-xmlLang_ ::  MisoString -> Attribute action
-xmlLang_ = attr "xmlLang"
------------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/xmlSpace>
-xmlSpace_ ::  MisoString -> Attribute action
-xmlSpace_ = attr "xmlSpace"
 -----------------------------------------------------------------------------
 -- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/y>
 y_ ::  MisoString -> Attribute action
@@ -1048,10 +680,6 @@ yChannelSelector_ = attr "yChannelSelector"
 z_ ::  MisoString -> Attribute action
 z_ = attr "z"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/zoomAndPan>
-zoomAndPan_ ::  MisoString -> Attribute action
-zoomAndPan_ = attr "zoomAndPan"
------------------------------------------------------------------------------
 -- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/alignment-baseline>
 alignmentBaseline_ ::  MisoString -> Attribute action
 alignmentBaseline_ = attr "alignment-baseline"
@@ -1068,10 +696,6 @@ clipPath_ = attr "clip-path"
 clipRule_ ::  MisoString -> Attribute action
 clipRule_ = attr "clip-rule"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/clip>
-clip_ ::  MisoString -> Attribute action
-clip_ = attr "clip"
------------------------------------------------------------------------------
 -- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/color-interpolation-filters>
 colorInterpolationFilters_ ::  MisoString -> Attribute action
 colorInterpolationFilters_ = attr "color-interpolation-filters"
@@ -1079,14 +703,6 @@ colorInterpolationFilters_ = attr "color-interpolation-filters"
 -- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/color-interpolation>
 colorInterpolation_ ::  MisoString -> Attribute action
 colorInterpolation_ = attr "color-interpolation"
------------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/color-profile>
-colorProfile_ ::  MisoString -> Attribute action
-colorProfile_ = attr "color-profile"
------------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/color-rendering>
-colorRendering_ ::  MisoString -> Attribute action
-colorRendering_ = attr "color-rendering"
 -----------------------------------------------------------------------------
 -- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/color>
 color_ ::  MisoString -> Attribute action
@@ -1107,10 +723,6 @@ display_ = attr "display"
 -- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/dominant-baseline>
 dominantBaseline_ ::  MisoString -> Attribute action
 dominantBaseline_ = attr "dominant-baseline"
------------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/enable-background>
-enableBackground_ ::  MisoString -> Attribute action
-enableBackground_ = attr "enable-background"
 -----------------------------------------------------------------------------
 -- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/fill-opacity>
 fillOpacity_ ::  MisoString -> Attribute action
@@ -1148,10 +760,6 @@ fontSizeAdjust_ = attr "font-size-adjust"
 fontSize_ ::  MisoString -> Attribute action
 fontSize_ = attr "font-size"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/font-stretch>
-fontStretch_ ::  MisoString -> Attribute action
-fontStretch_ = attr "font-stretch"
------------------------------------------------------------------------------
 -- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/font-style>
 fontStyle_ ::  MisoString -> Attribute action
 fontStyle_ = attr "font-style"
@@ -1164,21 +772,9 @@ fontVariant_ = attr "font-variant"
 fontWeight_ ::  MisoString -> Attribute action
 fontWeight_ = attr "font-weight"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/glyph-orientation-horizontal>
-glyphOrientationHorizontal_ ::  MisoString -> Attribute action
-glyphOrientationHorizontal_ = attr "glyph-orientation-horizontal"
------------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/glyph-orientation-vertical>
-glyphOrientationVertical_ ::  MisoString -> Attribute action
-glyphOrientationVertical_ = attr "glyph-orientation-vertical"
------------------------------------------------------------------------------
 -- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/image-rendering>
 imageRendering_ ::  MisoString -> Attribute action
 imageRendering_ = attr "image-rendering"
------------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/kerning>
-kerning_ ::  MisoString -> Attribute action
-kerning_ = attr "kerning"
 -----------------------------------------------------------------------------
 -- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/letter-spacing>
 letterSpacing_ ::  MisoString -> Attribute action

--- a/src/Miso/Svg/Attribute.hs
+++ b/src/Miso/Svg/Attribute.hs
@@ -9,7 +9,7 @@
 -- Stability   :  experimental
 -- Portability :  non-portable
 --
--- <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute>
+-- <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute>
 --
 ----------------------------------------------------------------------------
 module Miso.Svg.Attribute
@@ -203,711 +203,711 @@ import Miso.String        ( MisoString )
 attr :: MisoString -> MisoString -> Attribute action
 attr = textProp
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/accumulate>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/accumulate>
 accumulate_ ::  MisoString -> Attribute action
 accumulate_ = attr "accumulate"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/additive>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/additive>
 additive_ ::  MisoString -> Attribute action
 additive_ = attr "additive"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/amplitude>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/amplitude>
 amplitude_ ::  MisoString -> Attribute action
 amplitude_ = attr "amplitude"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/attributeName>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/attributeName>
 attributeName_ ::  MisoString -> Attribute action
 attributeName_ = attr "attributeName"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/azimuth>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/azimuth>
 azimuth_ ::  MisoString -> Attribute action
 azimuth_ = attr "azimuth"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/baseFrequency>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/baseFrequency>
 baseFrequency_ ::  MisoString -> Attribute action
 baseFrequency_ = attr "baseFrequency"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/begin>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/begin>
 begin_ ::  MisoString -> Attribute action
 begin_ = attr "begin"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/bias>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/bias>
 bias_ ::  MisoString -> Attribute action
 bias_ = attr "bias"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/by>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/by>
 by_ ::  MisoString -> Attribute action
 by_ = attr "by"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/calcMode>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/calcMode>
 calcMode_ ::  MisoString -> Attribute action
 calcMode_ = attr "calcMode"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/class>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/class>
 class_' ::  MisoString -> Attribute action
 class_' = attr "class"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/clipPathUnits>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/clipPathUnits>
 clipPathUnits_ ::  MisoString -> Attribute action
 clipPathUnits_ = attr "clipPathUnits"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/cx>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/cx>
 cx_ ::  MisoString -> Attribute action
 cx_ = attr "cx"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/cy>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/cy>
 cy_ ::  MisoString -> Attribute action
 cy_ = attr "cy"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/d>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/d>
 d_ ::  MisoString -> Attribute action
 d_ = attr "d"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/decoding>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/decoding>
 decoding_ ::  MisoString -> Attribute action
 decoding_ = attr "decoding"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/diffuseConstant>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/diffuseConstant>
 diffuseConstant_ ::  MisoString -> Attribute action
 diffuseConstant_ = attr "diffuseConstant"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/divisor>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/divisor>
 divisor_ ::  MisoString -> Attribute action
 divisor_ = attr "divisor"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/dur>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/dur>
 dur_ ::  MisoString -> Attribute action
 dur_ = attr "dur"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/dx>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/dx>
 dx_ ::  MisoString -> Attribute action
 dx_ = attr "dx"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/dy>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/dy>
 dy_ ::  MisoString -> Attribute action
 dy_ = attr "dy"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/edgeMode>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/edgeMode>
 edgeMode_ ::  MisoString -> Attribute action
 edgeMode_ = attr "edgeMode"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/elevation>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/elevation>
 elevation_ ::  MisoString -> Attribute action
 elevation_ = attr "elevation"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/end>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/end>
 end_ ::  MisoString -> Attribute action
 end_ = attr "end"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/exponent>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/exponent>
 exponent_ ::  MisoString -> Attribute action
 exponent_ = attr "exponent"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/filterUnits>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/filterUnits>
 filterUnits_ ::  MisoString -> Attribute action
 filterUnits_ = attr "filterUnits"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/fr>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/fr>
 fr_ ::  MisoString -> Attribute action
 fr_ = attr "fr"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/from>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/from>
 from_ ::  MisoString -> Attribute action
 from_ = attr "from"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/fx>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/fx>
 fx_ ::  MisoString -> Attribute action
 fx_ = attr "fx"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/fy>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/fy>
 fy_ ::  MisoString -> Attribute action
 fy_ = attr "fy"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/gradientTransform>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/gradientTransform>
 gradientTransform_ ::  MisoString -> Attribute action
 gradientTransform_ = attr "gradientTransform"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/gradientUnits>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/gradientUnits>
 gradientUnits_ ::  MisoString -> Attribute action
 gradientUnits_ = attr "gradientUnits"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/height>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/height>
 height_ ::  MisoString -> Attribute action
 height_ = attr "height"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/href>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/href>
 href_ ::  MisoString -> Attribute action
 href_ = attr "href"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/id>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/id>
 id_ ::  MisoString -> Attribute action
 id_ = attr "id"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/in>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/in>
 in_' ::  MisoString -> Attribute action
 in_' = attr "in"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/in2>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/in2>
 in2_ ::  MisoString -> Attribute action
 in2_ = attr "in2"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/intercept>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/intercept>
 intercept_ ::  MisoString -> Attribute action
 intercept_ = attr "intercept"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/k1>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/k1>
 k1_ ::  MisoString -> Attribute action
 k1_ = attr "k1"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/k2>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/k2>
 k2_ ::  MisoString -> Attribute action
 k2_ = attr "k2"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/k3>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/k3>
 k3_ ::  MisoString -> Attribute action
 k3_ = attr "k3"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/k4>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/k4>
 k4_ ::  MisoString -> Attribute action
 k4_ = attr "k4"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/kernelMatrix>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/kernelMatrix>
 kernelMatrix_ ::  MisoString -> Attribute action
 kernelMatrix_ = attr "kernelMatrix"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/keyPoints>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/keyPoints>
 keyPoints_ ::  MisoString -> Attribute action
 keyPoints_ = attr "keyPoints"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/keySplines>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/keySplines>
 keySplines_ ::  MisoString -> Attribute action
 keySplines_ = attr "keySplines"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/keyTimes>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/keyTimes>
 keyTimes_ ::  MisoString -> Attribute action
 keyTimes_ = attr "keyTimes"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/lang>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/lang>
 lang_ ::  MisoString -> Attribute action
 lang_ = attr "lang"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/lengthAdjust>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/lengthAdjust>
 lengthAdjust_ ::  MisoString -> Attribute action
 lengthAdjust_ = attr "lengthAdjust"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/limitingConeAngle>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/limitingConeAngle>
 limitingConeAngle_ ::  MisoString -> Attribute action
 limitingConeAngle_ = attr "limitingConeAngle"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/markerHeight>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/markerHeight>
 markerHeight_ ::  MisoString -> Attribute action
 markerHeight_ = attr "markerHeight"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/markerUnits>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/markerUnits>
 markerUnits_ ::  MisoString -> Attribute action
 markerUnits_ = attr "markerUnits"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/markerWidth>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/markerWidth>
 markerWidth_ ::  MisoString -> Attribute action
 markerWidth_ = attr "markerWidth"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/maskContentUnits>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/maskContentUnits>
 maskContentUnits_ ::  MisoString -> Attribute action
 maskContentUnits_ = attr "maskContentUnits"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/maskUnits>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/maskUnits>
 maskUnits_ ::  MisoString -> Attribute action
 maskUnits_ = attr "maskUnits"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/max>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/max>
 max_ ::  MisoString -> Attribute action
 max_ = attr "max"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/media>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/media>
 media_ ::  MisoString -> Attribute action
 media_ = attr "media"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/method>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/method>
 method_ ::  MisoString -> Attribute action
 method_ = attr "method"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/min>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/min>
 min_ ::  MisoString -> Attribute action
 min_ = attr "min"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/mode>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/mode>
 mode_ ::  MisoString -> Attribute action
 mode_ = attr "mode"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/numOctaves>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/numOctaves>
 numOctaves_ ::  MisoString -> Attribute action
 numOctaves_ = attr "numOctaves"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/operator>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/operator>
 operator_ ::  MisoString -> Attribute action
 operator_ = attr "operator"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/order>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/order>
 order_ ::  MisoString -> Attribute action
 order_ = attr "order"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/orient>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/orient>
 orient_ ::  MisoString -> Attribute action
 orient_ = attr "orient"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/origin>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/origin>
 origin_ ::  MisoString -> Attribute action
 origin_ = attr "origin"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/path>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/path>
 path_ ::  MisoString -> Attribute action
 path_ = attr "path"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/paint-order>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/paint-order>
 paintOrder_ ::  MisoString -> Attribute action
 paintOrder_ = attr "paint-order"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/pathLength>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/pathLength>
 pathLength_ ::  MisoString -> Attribute action
 pathLength_ = attr "pathLength"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/patternContentUnits>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/patternContentUnits>
 patternContentUnits_ ::  MisoString -> Attribute action
 patternContentUnits_ = attr "patternContentUnits"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/patternTransform>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/patternTransform>
 patternTransform_ ::  MisoString -> Attribute action
 patternTransform_ = attr "patternTransform"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/patternUnits>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/patternUnits>
 patternUnits_ ::  MisoString -> Attribute action
 patternUnits_ = attr "patternUnits"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/points>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/points>
 points_ ::  MisoString -> Attribute action
 points_ = attr "points"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/pointsAtX>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/pointsAtX>
 pointsAtX_ ::  MisoString -> Attribute action
 pointsAtX_ = attr "pointsAtX"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/pointsAtY>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/pointsAtY>
 pointsAtY_ ::  MisoString -> Attribute action
 pointsAtY_ = attr "pointsAtY"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/pointsAtZ>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/pointsAtZ>
 pointsAtZ_ ::  MisoString -> Attribute action
 pointsAtZ_ = attr "pointsAtZ"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/preserveAlpha>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/preserveAlpha>
 preserveAlpha_ ::  MisoString -> Attribute action
 preserveAlpha_ = attr "preserveAlpha"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/preserveAspectRatio>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/preserveAspectRatio>
 preserveAspectRatio_ ::  MisoString -> Attribute action
 preserveAspectRatio_ = attr "preserveAspectRatio"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/primitiveUnits>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/primitiveUnits>
 primitiveUnits_ ::  MisoString -> Attribute action
 primitiveUnits_ = attr "primitiveUnits"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/r>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/r>
 r_ ::  MisoString -> Attribute action
 r_ = attr "r"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/radius>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/radius>
 radius_ ::  MisoString -> Attribute action
 radius_ = attr "radius"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/refX>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/refX>
 refX_ ::  MisoString -> Attribute action
 refX_ = attr "refX"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/refY>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/refY>
 refY_ ::  MisoString -> Attribute action
 refY_ = attr "refY"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/repeatCount>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/repeatCount>
 repeatCount_ ::  MisoString -> Attribute action
 repeatCount_ = attr "repeatCount"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/repeatDur>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/repeatDur>
 repeatDur_ ::  MisoString -> Attribute action
 repeatDur_ = attr "repeatDur"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/restart>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/restart>
 restart_ ::  MisoString -> Attribute action
 restart_ = attr "restart"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/result>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/result>
 result_ ::  MisoString -> Attribute action
 result_ = attr "result"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/rotate>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/rotate>
 rotate_ ::  MisoString -> Attribute action
 rotate_ = attr "rotate"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/rx>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/rx>
 rx_ ::  MisoString -> Attribute action
 rx_ = attr "rx"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/ry>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/ry>
 ry_ ::  MisoString -> Attribute action
 ry_ = attr "ry"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/scale>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/scale>
 scale_ ::  MisoString -> Attribute action
 scale_ = attr "scale"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/seed>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/seed>
 seed_ ::  MisoString -> Attribute action
 seed_ = attr "seed"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/side>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/side>
 side_ ::  MisoString -> Attribute action
 side_ = attr "side"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/slope>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/slope>
 slope_ ::  MisoString -> Attribute action
 slope_ = attr "slope"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/spacing>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/spacing>
 spacing_ ::  MisoString -> Attribute action
 spacing_ = attr "spacing"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/specularConstant>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/specularConstant>
 specularConstant_ ::  MisoString -> Attribute action
 specularConstant_ = attr "specularConstant"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/specularExponent>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/specularExponent>
 specularExponent_ ::  MisoString -> Attribute action
 specularExponent_ = attr "specularExponent"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/spreadMethod>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/spreadMethod>
 spreadMethod_ ::  MisoString -> Attribute action
 spreadMethod_ = attr "spreadMethod"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/startOffset>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/startOffset>
 startOffset_ ::  MisoString -> Attribute action
 startOffset_ = attr "startOffset"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/stdDeviation>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/stdDeviation>
 stdDeviation_ ::  MisoString -> Attribute action
 stdDeviation_ = attr "stdDeviation"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/stitchTiles>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/stitchTiles>
 stitchTiles_ ::  MisoString -> Attribute action
 stitchTiles_ = attr "stitchTiles"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/style>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/style>
 style_ ::  MisoString -> Attribute action
 style_ = attr "style"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/surfaceScale>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/surfaceScale>
 surfaceScale_ ::  MisoString -> Attribute action
 surfaceScale_ = attr "surfaceScale"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/systemLanguage>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/systemLanguage>
 systemLanguage_ ::  MisoString -> Attribute action
 systemLanguage_ = attr "systemLanguage"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/tabindex>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/tabindex>
 tabindex_ ::  MisoString -> Attribute action
 tabindex_ = attr "tabindex"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/tableValues>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/tableValues>
 tableValues_ ::  MisoString -> Attribute action
 tableValues_ = attr "tableValues"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/target>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/target>
 target_ ::  MisoString -> Attribute action
 target_ = attr "target"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/targetX>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/targetX>
 targetX_ ::  MisoString -> Attribute action
 targetX_ = attr "targetX"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/targetY>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/targetY>
 targetY_ ::  MisoString -> Attribute action
 targetY_ = attr "targetY"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/textLength>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/textLength>
 textLength_ ::  MisoString -> Attribute action
 textLength_ = attr "textLength"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/to>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/to>
 to_ ::  MisoString -> Attribute action
 to_ = attr "to"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/transform>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/transform>
 transform_ ::  MisoString -> Attribute action
 transform_ = attr "transform"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/transform-origin>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/transform-origin>
 transformOrigin_ ::  MisoString -> Attribute action
 transformOrigin_ = attr "transform-origin"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/type>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/type>
 type_' ::  MisoString -> Attribute action
 type_' = attr "type"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/values>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/values>
 values_ ::  MisoString -> Attribute action
 values_ = attr "values"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/vector-effect>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/vector-effect>
 vectorEffect_ ::  MisoString -> Attribute action
 vectorEffect_ = attr "vector-effect"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/viewBox>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/viewBox>
 viewBox_ ::  MisoString -> Attribute action
 viewBox_ = attr "viewBox"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/width>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/width>
 width_ ::  MisoString -> Attribute action
 width_ = attr "width"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/x>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/x>
 x_ ::  MisoString -> Attribute action
 x_ = attr "x"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/x1>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/x1>
 x1_ ::  MisoString -> Attribute action
 x1_ = attr "x1"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/x2>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/x2>
 x2_ ::  MisoString -> Attribute action
 x2_ = attr "x2"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/xChannelSelector>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/xChannelSelector>
 xChannelSelector_ ::  MisoString -> Attribute action
 xChannelSelector_ = attr "x-channel-selector"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/y>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/y>
 y_ ::  MisoString -> Attribute action
 y_ = attr "y"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/y1>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/y1>
 y1_ ::  MisoString -> Attribute action
 y1_ = attr "y1"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/y2>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/y2>
 y2_ ::  MisoString -> Attribute action
 y2_ = attr "y2"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/yChannelSelector>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/yChannelSelector>
 yChannelSelector_ ::  MisoString -> Attribute action
 yChannelSelector_ = attr "yChannelSelector"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/z>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/z>
 z_ ::  MisoString -> Attribute action
 z_ = attr "z"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/alignment-baseline>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/alignment-baseline>
 alignmentBaseline_ ::  MisoString -> Attribute action
 alignmentBaseline_ = attr "alignment-baseline"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/baseline-shift>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/baseline-shift>
 baselineShift_ ::  MisoString -> Attribute action
 baselineShift_ = attr "baseline-shift"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/clip-path>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/clip-path>
 clipPath_ ::  MisoString -> Attribute action
 clipPath_ = attr "clip-path"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/clip-rule>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/clip-rule>
 clipRule_ ::  MisoString -> Attribute action
 clipRule_ = attr "clip-rule"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/color-interpolation>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/color-interpolation>
 colorInterpolation_ ::  MisoString -> Attribute action
 colorInterpolation_ = attr "color-interpolation"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/color-interpolation-filters>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/color-interpolation-filters>
 colorInterpolationFilters_ ::  MisoString -> Attribute action
 colorInterpolationFilters_ = attr "color-interpolation-filters"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/crossorigin>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/crossorigin>
 crossorigin_ ::  MisoString -> Attribute action
 crossorigin_ = attr "crossorigin"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/color>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/color>
 color_ ::  MisoString -> Attribute action
 color_ = attr "color"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/cursor>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/cursor>
 cursor_ ::  MisoString -> Attribute action
 cursor_ = attr "cursor"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/direction>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/direction>
 direction_ ::  MisoString -> Attribute action
 direction_ = attr "direction"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/display>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/display>
 display_ ::  MisoString -> Attribute action
 display_ = attr "display"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/dominant-baseline>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/dominant-baseline>
 dominantBaseline_ ::  MisoString -> Attribute action
 dominantBaseline_ = attr "dominant-baseline"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/fill-opacity>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/fill-opacity>
 fillOpacity_ ::  MisoString -> Attribute action
 fillOpacity_ = attr "fill-opacity"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/fill-rule>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/fill-rule>
 fillRule_ ::  MisoString -> Attribute action
 fillRule_ = attr "fill-rule"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/fill>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/fill>
 fill_ ::  MisoString -> Attribute action
 fill_ = attr "fill"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/filter>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/filter>
 filter_ ::  MisoString -> Attribute action
 filter_ = attr "filter"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/flood-color>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/flood-color>
 floodColor_ ::  MisoString -> Attribute action
 floodColor_ = attr "flood-color"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/flood-opacity>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/flood-opacity>
 floodOpacity_ ::  MisoString -> Attribute action
 floodOpacity_ = attr "flood-opacity"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/font-family>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/font-family>
 fontFamily_ ::  MisoString -> Attribute action
 fontFamily_ = attr "font-family"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/font-size-adjust>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/font-size-adjust>
 fontSizeAdjust_ ::  MisoString -> Attribute action
 fontSizeAdjust_ = attr "font-size-adjust"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/font-size>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/font-size>
 fontSize_ ::  MisoString -> Attribute action
 fontSize_ = attr "font-size"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/font-style>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/font-style>
 fontStyle_ ::  MisoString -> Attribute action
 fontStyle_ = attr "font-style"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/font-variant>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/font-variant>
 fontVariant_ ::  MisoString -> Attribute action
 fontVariant_ = attr "font-variant"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/font-weight>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/font-weight>
 fontWeight_ ::  MisoString -> Attribute action
 fontWeight_ = attr "font-weight"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/image-rendering>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/image-rendering>
 imageRendering_ ::  MisoString -> Attribute action
 imageRendering_ = attr "image-rendering"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/letter-spacing>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/letter-spacing>
 letterSpacing_ ::  MisoString -> Attribute action
 letterSpacing_ = attr "letter-spacing"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/lighting-color>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/lighting-color>
 lightingColor_ ::  MisoString -> Attribute action
 lightingColor_ = attr "lighting-color"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/marker-end>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/marker-end>
 markerEnd_ ::  MisoString -> Attribute action
 markerEnd_ = attr "marker-end"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/marker-mid>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/marker-mid>
 markerMid_ ::  MisoString -> Attribute action
 markerMid_ = attr "marker-mid"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/marker-start>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/marker-start>
 markerStart_ ::  MisoString -> Attribute action
 markerStart_ = attr "marker-start"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/mask>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/mask>
 mask_ ::  MisoString -> Attribute action
 mask_ = attr "mask"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/opacity>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/opacity>
 opacity_ ::  MisoString -> Attribute action
 opacity_ = attr "opacity"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/overflow>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/overflow>
 overflow_ ::  MisoString -> Attribute action
 overflow_ = attr "overflow"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/pointer-events>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/pointer-events>
 pointerEvents_ ::  MisoString -> Attribute action
 pointerEvents_ = attr "pointer-events"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/shape-rendering>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/shape-rendering>
 shapeRendering_ ::  MisoString -> Attribute action
 shapeRendering_ = attr "shape-rendering"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/stop-color>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/stop-color>
 stopColor_ ::  MisoString -> Attribute action
 stopColor_ = attr "stop-color"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/stop-opacity>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/stop-opacity>
 stopOpacity_ ::  MisoString -> Attribute action
 stopOpacity_ = attr "stop-opacity"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/stroke-dasharray>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/stroke-dasharray>
 strokeDasharray_ ::  MisoString -> Attribute action
 strokeDasharray_ = attr "stroke-dasharray"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/stroke-dashoffset>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/stroke-dashoffset>
 strokeDashoffset_ ::  MisoString -> Attribute action
 strokeDashoffset_ = attr "stroke-dashoffset"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/stroke-linecap>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/stroke-linecap>
 strokeLinecap_ ::  MisoString -> Attribute action
 strokeLinecap_ = attr "stroke-linecap"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/stroke-linejoin>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/stroke-linejoin>
 strokeLinejoin_ ::  MisoString -> Attribute action
 strokeLinejoin_ = attr "stroke-linejoin"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/stroke-miterlimit>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/stroke-miterlimit>
 strokeMiterlimit_ ::  MisoString -> Attribute action
 strokeMiterlimit_ = attr "stroke-miterlimit"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/stroke-opacity>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/stroke-opacity>
 strokeOpacity_ ::  MisoString -> Attribute action
 strokeOpacity_ = attr "stroke-opacity"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/stroke-width>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/stroke-width>
 strokeWidth_ ::  MisoString -> Attribute action
 strokeWidth_ = attr "stroke-width"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/stroke>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/stroke>
 stroke_ ::  MisoString -> Attribute action
 stroke_ = attr "stroke"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/text-anchor>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/text-anchor>
 textAnchor_ ::  MisoString -> Attribute action
 textAnchor_ = attr "text-anchor"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/text-decoration>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/text-decoration>
 textDecoration_ ::  MisoString -> Attribute action
 textDecoration_ = attr "text-decoration"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/text-rendering>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/text-rendering>
 textRendering_ ::  MisoString -> Attribute action
 textRendering_ = attr "text-rendering"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/unicode-bidi>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/unicode-bidi>
 unicodeBidi_ ::  MisoString -> Attribute action
 unicodeBidi_ = attr "unicode-bidi"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/visibility>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/visibility>
 visibility_ ::  MisoString -> Attribute action
 visibility_ = attr "visibility"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/word-spacing>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/word-spacing>
 wordSpacing_ ::  MisoString -> Attribute action
 wordSpacing_ = attr "word-spacing"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/writing-mode>
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/writing-mode>
 writingMode_ ::  MisoString -> Attribute action
 writingMode_ = attr "writing-mode"
 -----------------------------------------------------------------------------

--- a/src/Miso/Svg/Attribute.hs
+++ b/src/Miso/Svg/Attribute.hs
@@ -13,7 +13,7 @@
 --
 ----------------------------------------------------------------------------
 module Miso.Svg.Attribute
-  ( -- *** Attributes
+  ( -- *** Regular Attributes
     accumulate_
   , additive_
   , amplitude_
@@ -29,7 +29,7 @@ module Miso.Svg.Attribute
   , cx_
   , cy_
   , d_
-  -- TODO decoding
+  , decoding_
   , diffuseConstant_
   , divisor_
   , dur_
@@ -40,17 +40,14 @@ module Miso.Svg.Attribute
   , end_
   , exponent_
   , filterUnits_
-  -- TODO fr
-  -- TODO glyph-orientation-horizontal
-  -- TODO glyph-orientation-vertical
-  -- TODO href
-  -- TODO hreflang
+  , fr_
   , from_
   , fx_
   , fy_
   , gradientTransform_
   , gradientUnits_
   , height_
+  , href_
   , id_
   , in_'
   , in2_
@@ -80,19 +77,13 @@ module Miso.Svg.Attribute
   , operator_
   , order_
   , orient_
-  -- TODO paint-order
-  -- TODO ping
   , origin_
+  , paintOrder_
   , path_
   , pathLength_
   , patternContentUnits_
   , patternTransform_
   , patternUnits_
-  -- TODO referrerPolicy
-  -- TODO rel
-  -- TODO requiredExtensions
-  -- TODO requiredFeatures
-  -- TODO side
   , points_
   , pointsAtX_
   , pointsAtY_
@@ -113,6 +104,7 @@ module Miso.Svg.Attribute
   , ry_
   , scale_
   , seed_
+  , side_
   , slope_
   , spacing_
   , specularConstant_
@@ -124,6 +116,7 @@ module Miso.Svg.Attribute
   , style_
   , surfaceScale_
   , systemLanguage_
+  , tabindex_
   , tableValues_
   , target_
   , targetX_
@@ -131,13 +124,11 @@ module Miso.Svg.Attribute
   , textLength_
   , to_
   , transform_
-  -- TODO transform-origin
+  , transformOrigin_
   , type_'
   , values_
-  -- TODO vector-effect
-  -- TODO version
+  , vectorEffect_
   , viewBox_
-  -- TODO zoomAndPan
   , width_
   , x_
   , x1_
@@ -155,23 +146,23 @@ module Miso.Svg.Attribute
   , baselineShift_
   , clipPath_
   , clipRule_
-  , colorInterpolationFilters_
-  , colorInterpolation_
-  -- TODO crossorigin
   , color_
+  , colorInterpolation_
+  , colorInterpolationFilters_
+  , crossorigin_
   , cursor_
   , direction_
   , display_
   , dominantBaseline_
+  , fill_
   , fillOpacity_
   , fillRule_
-  , fill_
   , filter_
   , floodColor_
   , floodOpacity_
   , fontFamily_
-  , fontSizeAdjust_
   , fontSize_
+  , fontSizeAdjust_
   , fontStyle_
   , fontVariant_
   , fontWeight_
@@ -188,6 +179,7 @@ module Miso.Svg.Attribute
   , shapeRendering_
   , stopColor_
   , stopOpacity_
+  , stroke_
   , strokeDasharray_
   , strokeDashoffset_
   , strokeLinecap_
@@ -195,7 +187,6 @@ module Miso.Svg.Attribute
   , strokeMiterlimit_
   , strokeOpacity_
   , strokeWidth_
-  , stroke_
   , textAnchor_
   , textDecoration_
   , textRendering_
@@ -272,6 +263,10 @@ cy_ = attr "cy"
 d_ ::  MisoString -> Attribute action
 d_ = attr "d"
 -----------------------------------------------------------------------------
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/decoding>
+decoding_ ::  MisoString -> Attribute action
+decoding_ = attr "decoding"
+-----------------------------------------------------------------------------
 -- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/diffuseConstant>
 diffuseConstant_ ::  MisoString -> Attribute action
 diffuseConstant_ = attr "diffuseConstant"
@@ -312,6 +307,10 @@ exponent_ = attr "exponent"
 filterUnits_ ::  MisoString -> Attribute action
 filterUnits_ = attr "filterUnits"
 -----------------------------------------------------------------------------
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/fr>
+fr_ ::  MisoString -> Attribute action
+fr_ = attr "fr"
+-----------------------------------------------------------------------------
 -- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/from>
 from_ ::  MisoString -> Attribute action
 from_ = attr "from"
@@ -335,6 +334,10 @@ gradientUnits_ = attr "gradientUnits"
 -- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/height>
 height_ ::  MisoString -> Attribute action
 height_ = attr "height"
+-----------------------------------------------------------------------------
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/href>
+href_ ::  MisoString -> Attribute action
+href_ = attr "href"
 -----------------------------------------------------------------------------
 -- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/id>
 id_ ::  MisoString -> Attribute action
@@ -460,6 +463,10 @@ origin_ = attr "origin"
 path_ ::  MisoString -> Attribute action
 path_ = attr "path"
 -----------------------------------------------------------------------------
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/paint-order>
+paintOrder_ ::  MisoString -> Attribute action
+paintOrder_ = attr "paint-order"
+-----------------------------------------------------------------------------
 -- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/pathLength>
 pathLength_ ::  MisoString -> Attribute action
 pathLength_ = attr "pathLength"
@@ -556,6 +563,10 @@ scale_ = attr "scale"
 seed_ ::  MisoString -> Attribute action
 seed_ = attr "seed"
 -----------------------------------------------------------------------------
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/side>
+side_ ::  MisoString -> Attribute action
+side_ = attr "side"
+-----------------------------------------------------------------------------
 -- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/slope>
 slope_ ::  MisoString -> Attribute action
 slope_ = attr "slope"
@@ -600,6 +611,10 @@ surfaceScale_ = attr "surfaceScale"
 systemLanguage_ ::  MisoString -> Attribute action
 systemLanguage_ = attr "systemLanguage"
 -----------------------------------------------------------------------------
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/tabindex>
+tabindex_ ::  MisoString -> Attribute action
+tabindex_ = attr "tabindex"
+-----------------------------------------------------------------------------
 -- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/tableValues>
 tableValues_ ::  MisoString -> Attribute action
 tableValues_ = attr "tableValues"
@@ -628,6 +643,10 @@ to_ = attr "to"
 transform_ ::  MisoString -> Attribute action
 transform_ = attr "transform"
 -----------------------------------------------------------------------------
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/transform-origin>
+transformOrigin_ ::  MisoString -> Attribute action
+transformOrigin_ = attr "transform-origin"
+-----------------------------------------------------------------------------
 -- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/type>
 type_' ::  MisoString -> Attribute action
 type_' = attr "type"
@@ -635,6 +654,10 @@ type_' = attr "type"
 -- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/values>
 values_ ::  MisoString -> Attribute action
 values_ = attr "values"
+-----------------------------------------------------------------------------
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/vector-effect>
+vectorEffect_ ::  MisoString -> Attribute action
+vectorEffect_ = attr "vector-effect"
 -----------------------------------------------------------------------------
 -- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/viewBox>
 viewBox_ ::  MisoString -> Attribute action
@@ -696,13 +719,17 @@ clipPath_ = attr "clip-path"
 clipRule_ ::  MisoString -> Attribute action
 clipRule_ = attr "clip-rule"
 -----------------------------------------------------------------------------
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/color-interpolation>
+colorInterpolation_ ::  MisoString -> Attribute action
+colorInterpolation_ = attr "color-interpolation"
+-----------------------------------------------------------------------------
 -- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/color-interpolation-filters>
 colorInterpolationFilters_ ::  MisoString -> Attribute action
 colorInterpolationFilters_ = attr "color-interpolation-filters"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/color-interpolation>
-colorInterpolation_ ::  MisoString -> Attribute action
-colorInterpolation_ = attr "color-interpolation"
+-- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/crossorigin>
+crossorigin_ ::  MisoString -> Attribute action
+crossorigin_ = attr "crossorigin"
 -----------------------------------------------------------------------------
 -- | <https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/color>
 color_ ::  MisoString -> Attribute action


### PR DESCRIPTION
Followup on https://github.com/dmjio/miso/pull/914

I went through https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute and removed all the attributes for which the docs are no longer available or are explicitly marked as deprecated.