### PR TITLE
Attribute -> Property

### DIFF
--- a/miso.cabal
+++ b/miso.cabal
@@ -180,7 +180,7 @@ library
     Miso.Subscription.WebSocket
     Miso.Subscription.Window
     Miso.Subscription.SSE
-    Miso.Svg.Attribute
+    Miso.Svg.Property
     Miso.Svg.Element
     Miso.Svg.Event
     Miso.Types

--- a/src/Miso/Svg.hs
+++ b/src/Miso/Svg.hs
@@ -27,13 +27,13 @@
 module Miso.Svg
    ( -- ** Element
      module Miso.Svg.Element
-     -- ** Attribute
-   , module Miso.Svg.Attribute
+     -- ** Property
+   , module Miso.Svg.Property
      -- ** Event
    , module Miso.Svg.Event
    ) where
 -----------------------------------------------------------------------------
-import Miso.Svg.Attribute hiding (filter_, path_, mask_, clipPath_, cursor_, style_)
+import Miso.Svg.Property hiding (filter_, path_, mask_, clipPath_, cursor_, style_)
 import Miso.Svg.Element
 import Miso.Svg.Event
 -----------------------------------------------------------------------------

--- a/src/Miso/Svg/Property.hs
+++ b/src/Miso/Svg/Property.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 -----------------------------------------------------------------------------
 -- |
--- Module      :  Miso.Svg.Attribute
+-- Module      :  Miso.Svg.Property
 -- Copyright   :  (C) 2016-2025 David M. Johnson
 -- License     :  BSD3-style (see the file LICENSE)
 -- Maintainer  :  David M. Johnson <code@dmj.io>
@@ -12,7 +12,7 @@
 -- <https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute>
 --
 ----------------------------------------------------------------------------
-module Miso.Svg.Attribute
+module Miso.Svg.Property
   ( -- *** Regular Attributes
     accumulate_
   , additive_


### PR DESCRIPTION
In `miso` an `Attribute` is either an `Event`, `Property` or `Style`. In web nomenclature an Attribute lives as a key value pair on the HTML itself, and a Property lives on the DOM reference. `miso` normalises the two internally and exposes a unified `Property` abstraction. Therefore, the module names should reflect miso's abstraction. This change makes HTML and SVG modules consistently named and reflective of the `miso` `Attribute`.