### PR TITLE
Component refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ foreign export javascript "hs_start" main :: IO ()
 #endif
 ----------------------------------------------------------------------------
 -- | `defaultApp` takes as arguments the initial model, update function, view function
-app :: App Model Action
+app :: App name Model Action
 app = defaultApp emptyModel updateModel viewModel
 ----------------------------------------------------------------------------
 -- | Empty application state

--- a/examples/components/Main.hs
+++ b/examples/components/Main.hs
@@ -95,7 +95,7 @@ viewModel1 x =
         , button_ [onClick SampleChild] [text "Sample Child (unsafe)"]
         , if x
             then
-                componentWith_ component2 Nothing
+                componentWith "component-2" component2 Nothing
                   [ onMounted MountMain
                   , onUnmounted UnMountMain
                   ]
@@ -146,7 +146,7 @@ viewModel2 x =
         , button_ [onClick AddOne] [text "+"]
         , text (ms x)
         , button_ [onClick SubtractOne] [text "-"]
-        , componentWith_ component3 Nothing
+        , componentWith "component-3" component3 Nothing
           [ onMounted (Mount "3")
           , onUnmounted (UnMount "3")
           ]
@@ -189,12 +189,12 @@ viewModel3 (toggle, x) =
                -- If you are replacing an unnamed component (using 'component_') with anything else (e.g. 'vtext', 'vnode',
                -- 'vcomp', null), then you don't need to worry about this.
                then
-                 componentWith_ component4 Nothing
+                 componentWith "component-4" component4 Nothing
                    [ onMounted (Mount "4")
                    , onUnmounted (UnMount "4")
                    ]
                else
-                 componentWith_ component5 Nothing
+                 componentWith "component-5" component5 Nothing
                    [ onMounted (Mount "5")
                    , onUnmounted (UnMount "5")
                    ]

--- a/examples/components/Main.hs
+++ b/examples/components/Main.hs
@@ -54,20 +54,20 @@ loggerSub msg = \_ ->
 app :: App MainModel MainAction
 app = defaultApp False updateModel1 viewModel1
 
-component2 :: App Model Action
-component2 =
+app2 :: App Model Action
+app2 =
         counterApp2
             { subs = [loggerSub "component-2 sub"]
             }
 
-component3 :: App (Bool, Model) Action
-component3 =
+app3 :: App (Bool, Model) Action
+app3 =
         counterApp3
             { subs = [ loggerSub "component-3 sub"]
             }
 
-component4 :: App Model Action
-component4 =
+app4 :: App Model Action
+app4 =
         counterApp4
             { subs = [loggerSub "component-4 sub"]
             }
@@ -95,7 +95,7 @@ viewModel1 x =
         , button_ [onClick SampleChild] [text "Sample Child (unsafe)"]
         , if x
             then
-                componentWith "component-2" component2 Nothing
+                componentWith "component-2" app2 Nothing
                   [ onMounted MountMain
                   , onUnmounted UnMountMain
                   ]
@@ -146,7 +146,7 @@ viewModel2 x =
         , button_ [onClick AddOne] [text "+"]
         , text (ms x)
         , button_ [onClick SubtractOne] [text "-"]
-        , componentWith "component-3" component3 Nothing
+        , componentWith "component-3" app3 Nothing
           [ onMounted (Mount "3")
           , onUnmounted (UnMount "3")
           ]
@@ -189,12 +189,12 @@ viewModel3 (toggle, x) =
                -- If you are replacing an unnamed component (using 'component_') with anything else (e.g. 'vtext', 'vnode',
                -- 'vcomp', null), then you don't need to worry about this.
                then
-                 componentWith "component-4" component4 Nothing
+                 componentWith "component-4" app4 Nothing
                    [ onMounted (Mount "4")
                    , onUnmounted (UnMount "4")
                    ]
                else
-                 componentWith "component-5" component5 Nothing
+                 componentWith "component-5" app5 Nothing
                    [ onMounted (Mount "5")
                    , onUnmounted (UnMount "5")
                    ]
@@ -233,8 +233,8 @@ viewModel4 x =
         , button_ [onClick Sample] [text "Sample Component 3 state"]
         ]
 
-component5 :: App Model Action
-component5 =
+app5 :: App Model Action
+app5 =
         counterApp5
             { subs = [loggerSub "component-5 sub"]
             }

--- a/examples/fetch/Main.hs
+++ b/examples/fetch/Main.hs
@@ -59,7 +59,7 @@ data Action
   | ErrorHandler MisoString
   deriving (Show, Eq)
 ----------------------------------------------------------------------------
-app :: App Model Action
+app :: App name Model Action
 app = defaultApp emptyModel updateModel viewModel
 ----------------------------------------------------------------------------
 emptyModel :: Model

--- a/examples/file-reader/Main.hs
+++ b/examples/file-reader/Main.hs
@@ -78,7 +78,7 @@ css = unlines
   ]
 ----------------------------------------------------------------------------
 -- | Miso application
-app :: App Model Action
+app :: App name Model Action
 app = defaultApp (Model mempty) updateModel viewModel
 ----------------------------------------------------------------------------
 -- | Update function

--- a/examples/simple/Main.hs
+++ b/examples/simple/Main.hs
@@ -40,7 +40,7 @@ main = run $ startApp app
   }
 
 -- | Application definition (uses 'defaultApp' smart constructor)
-app :: App Model Action
+app :: App name Model Action
 app = defaultApp (Model 0) updateModel viewModel
 
 -- | UpdateModels model, optionally introduces side effects

--- a/examples/sse/server/Main.hs
+++ b/examples/sse/server/Main.hs
@@ -62,7 +62,7 @@ sendEvents chan =
         threadDelay (10 ^ (6 :: Int))
 
 -- | Page for setting HTML doctype and header
-newtype Page = Page (App Model Action)
+newtype Page = Page (App "app" Model Action)
 
 instance ToHtml Page where
     toHtml (Page x) =

--- a/examples/sse/shared/Common.hs
+++ b/examples/sse/shared/Common.hs
@@ -58,7 +58,7 @@ the404 =
 goHome :: URI
 goHome = allLinks' linkURI (Proxy :: Proxy ClientRoutes)
 
-sse :: URI -> App Model Action
+sse :: URI -> App name Model Action
 sse currentURI
   = app { subs =
           [ sseSub "/sse" handleSseMsg

--- a/examples/svg/Main.hs
+++ b/examples/svg/Main.hs
@@ -24,7 +24,7 @@ main = run $ startApp app
   }
 
 -- | Application definition (uses 'defaultApp' smart constructor)
-app :: App Model Action
+app :: App name Model Action
 app = defaultApp emptyModel updateModel viewModel
 
 emptyModel :: Model

--- a/examples/todo-mvc/Main.hs
+++ b/examples/todo-mvc/Main.hs
@@ -97,7 +97,7 @@ main = run $ startApp app
       ]
   }
 
-app :: App Model Msg
+app :: App name Model Msg
 app = defaultApp emptyModel updateModel viewModel
 
 updateModel :: Msg -> Effect Model Msg

--- a/examples/websocket/Main.hs
+++ b/examples/websocket/Main.hs
@@ -36,7 +36,7 @@ main = run $ startApp app
       url = URL "wss://echo.websocket.org"
       protocols = Protocols []
 
-app :: App Model Action
+app :: App name Model Action
 app = defaultApp emptyModel updateModel appView
 
 emptyModel :: Model

--- a/haskell-miso.org/shared/Common.hs
+++ b/haskell-miso.org/shared/Common.hs
@@ -61,7 +61,7 @@ type ClientRoutes = Routes (View Action)
 type ServerRoutes = Routes (Get '[HTML] Page)
 
 -- | Component synonym
-type HaskellMisoComponent = App Model Action
+type HaskellMisoComponent = App "app" Model Action
 
 -- | Links
 uriHome, uriExamples, uriDocs, uriCommunity, uri404 :: URI
@@ -100,7 +100,7 @@ haskellMisoComponent uri
   , logLevel = DebugAll
   }
   
-app :: URI -> App Model Action
+app :: URI -> App name Model Action
 app currentUri = defaultApp emptyModel updateModel viewModel
   where
     emptyModel = Model currentUri False

--- a/sample-app/Main.hs
+++ b/sample-app/Main.hs
@@ -35,7 +35,7 @@ foreign export javascript "hs_start" main :: IO ()
 #endif
 ----------------------------------------------------------------------------
 -- | `defaultApp` takes as arguments the initial model, update function, view function
-app :: App Model Action
+app :: App name Model Action
 app = defaultApp emptyModel updateModel viewModel
 ----------------------------------------------------------------------------
 -- | Empty application state

--- a/src/Miso.hs
+++ b/src/Miso.hs
@@ -23,8 +23,10 @@ module Miso
   , Sink
     -- ** Sampling
   , sample
+  , sample_
     -- ** Message Passing
   , notify
+  , notify_
     -- ** Subscription
   , start
   , start_

--- a/src/Miso.hs
+++ b/src/Miso.hs
@@ -109,7 +109,7 @@ import           Miso.Util
 -- Assumes the pre-rendered DOM is already present.
 -- Note: Uses 'mountPoint' as the 'Component' name.
 -- Always mounts to \<body\>. Copies page into the virtual DOM.
-miso :: Eq model => (URI -> App model action) -> JSM ()
+miso :: Eq model => (URI -> App name model action) -> JSM ()
 miso f = withJS $ do
   app@App {..} <- f <$> getURI
   initialize app $ \snk -> do
@@ -123,12 +123,12 @@ miso f = withJS $ do
     pure (name, mount, viewRef)
 -----------------------------------------------------------------------------
 -- | Alias for 'miso'.
-(🍜) :: Eq model => (URI -> App model action) -> JSM ()
+(🍜) :: Eq model => (URI -> App name model action) -> JSM ()
 (🍜) = miso
 ----------------------------------------------------------------------------
 -- | Runs a miso application
 -- Initializes application at 'mountPoint' (defaults to \<body\> when @Nothing@)
-startApp :: Eq model => App model action -> JSM ()
+startApp :: Eq model => App name model action -> JSM ()
 startApp app@App {..} = withJS $
   initialize app $ \snk -> do
     renderStyles styles

--- a/src/Miso/Internal.hs
+++ b/src/Miso/Internal.hs
@@ -308,7 +308,7 @@ runView
   -> LogLevel
   -> Events
   -> JSM VTree
-runView prerender (Component name attributes key (SomeApp app)) snk _ _ = do
+runView prerender (VComp name attributes key (Component app)) snk _ _ = do
   compName <-
     if null name
     then liftIO freshComponentId

--- a/src/Miso/Internal.hs
+++ b/src/Miso/Internal.hs
@@ -186,9 +186,11 @@ sample_ name = do
     Just ComponentState {..} -> readIORef componentModel)
 -----------------------------------------------------------------------------
 -- | Used for bidirectional communication between components.
--- Specify the mounted @App@ you'd like to target
+-- Specify the mounted @App@ you'd like to target.
+--
 -- This function is used to send messages to @App@ that are mounted on
 -- other parts of the DOM tree.
+--
 notify
   :: forall name model action . KnownSymbol name
   => App name model action
@@ -202,8 +204,11 @@ notify _ action = do
     name = ms $ symbolVal (Proxy @name)
 -----------------------------------------------------------------------------
 -- | Used for bidirectional communication between components.
--- Specify the mounted @App@ you'd like to target
--- This function is used to send messages to @Component@s on other parts of the application
+--
+-- Specify the mounted @App@ you'd like to target.
+-- This function is used to send messages to @App@ on other parts of the
+-- DOM tree.
+--
 notify_
   :: MisoString
   -> action

--- a/src/Miso/Render.hs
+++ b/src/Miso/Render.hs
@@ -93,7 +93,7 @@ renderBuilder (Node _ tag _ attrs children) =
     | tag `notElem` ["img", "input", "br", "hr", "meta", "link"]
     ]
   ]
-renderBuilder (Component mount attributes _ (SomeApp App {..})) =
+renderBuilder (VComp mount attributes _ (Component App {..})) =
   mconcat
   [ stringUtf8 "<div data-component-id=\""
   , fromMisoString mount

--- a/src/Miso/Render.hs
+++ b/src/Miso/Render.hs
@@ -46,10 +46,6 @@ instance Accept HTML where
 class ToHtml a where
   toHtml :: a -> L.ByteString
 ----------------------------------------------------------------------------
--- | Render a @Component@ to a @L.ByteString@
-instance ToHtml (Component model action) where
-  toHtml = renderComponent
-----------------------------------------------------------------------------
 -- | Render a @View@ to a @L.ByteString@
 instance ToHtml (View a) where
   toHtml = renderView
@@ -64,9 +60,6 @@ instance ToHtml a => MimeRender HTML a where
 ----------------------------------------------------------------------------
 renderView :: View a -> L.ByteString
 renderView = toLazyByteString . renderBuilder
-----------------------------------------------------------------------------
-renderComponent :: Component model action -> L.ByteString
-renderComponent (Component _ _ App {..}) = renderView (view model)
 ----------------------------------------------------------------------------
 intercalate :: Builder -> [Builder] -> Builder
 intercalate _ [] = ""
@@ -100,7 +93,7 @@ renderBuilder (Node _ tag _ attrs children) =
     | tag `notElem` ["img", "input", "br", "hr", "meta", "link"]
     ]
   ]
-renderBuilder (Embed attributes (SomeComponent (Component _ mount App {..}))) =
+renderBuilder (Component mount attributes _ (SomeApp App {..})) =
   mconcat
   [ stringUtf8 "<div data-component-id=\""
   , fromMisoString mount

--- a/src/Miso/Types.hs
+++ b/src/Miso/Types.hs
@@ -31,12 +31,14 @@ module Miso.Types
   -- ** Classes
   , ToView           (..)
   , ToKey            (..)
-  -- ** Functions
+  -- ** Smart Constructors
   , defaultApp
+  -- ** Components
   , component
   , component_
   , componentWith
   , componentWith_
+  -- ** Utils
   , getMountPoint
   ) where
 -----------------------------------------------------------------------------

--- a/src/Miso/Types.hs
+++ b/src/Miso/Types.hs
@@ -148,7 +148,8 @@ data SomeApp
   => SomeApp (App name model action)
 -----------------------------------------------------------------------------
 -- | Used in the @view@ function to embed an @App@ into another @App@
--- Since the name is omitted here
+-- Use this function if you'd like send messages to this @App@ at @name@ via
+-- @notify@ or to read the state of this @App@ via @sample@.
 component
   :: forall name model action a . (Eq model, KnownSymbol name)
   => App name model action
@@ -157,16 +158,18 @@ component app = Component (ms name) [] Nothing (SomeApp app)
   where
     name = symbolVal (Proxy @name)
 -----------------------------------------------------------------------------
--- | Like @component@, but it ignores the parameterized @name@, instead
--- the name is dynamically generated at runtime. This is for dynamic
--- component creation, where a mounted @App@ isn't necessarily statically known.
+-- | Like @component@, but uses a dynamically generated @name@ (enforced via @SomeApp@).
+-- The component name is dynamically generated at runtime and available via 'ask'.
+-- This is for dynamic component creation, where a mounted @App@ isn't necessarily
+-- statically known. Use this during circumstances where a parent would like
+-- to dynamically generate / destroy n-many children in response to user input.
 component_
-  :: Eq model
-  => App name model action
+  :: SomeApp
   -> View a
-component_ app = Component mempty [] Nothing (SomeApp app)
+component_ = Component mempty [] Nothing
 -----------------------------------------------------------------------------
--- | Used in the @view@ function to embed @App@ in @App@
+-- | Like @component@ except it allows the specification of @Key@
+-- and @Attribute action@.
 componentWith
   :: forall name model action a . (Eq model, KnownSymbol name)
   => App name model action
@@ -177,14 +180,14 @@ componentWith app key attrs = Component (ms name) attrs key (SomeApp app)
   where
     name = symbolVal (Proxy @name)
 -----------------------------------------------------------------------------
--- | Used in the @view@ function to embed @App@ in @App@
+-- | Like @component_@ except it allows the specification of @Key@
+-- and @Attribute action@. Note: the @name@ parameter is ignored here.
 componentWith_
-  :: Eq model
-  => App name model action
+  :: SomeApp
   -> Maybe Key
   -> [Attribute a]
   -> View a
-componentWith_ app key attrs = Component mempty attrs key (SomeApp app)
+componentWith_ someApp key attrs = Component mempty attrs key someApp
 -----------------------------------------------------------------------------
 -- | For constructing type-safe links
 instance HasLink (View a) where


### PR DESCRIPTION
This should crystallize / simplify the component feature.

- `App` is now parameterized by `name :: Symbol`, this allows `notify` and `sample` to be type safe during message passing and reading other component state. The `name` parameter is optional unless using the component feature (which means using `notify` / `sample`)

- `Component` is now used purely as an existential wrapper for `App`, when used w/ `notify_` / `sample_` its to indicate that the component is dynamically generated. The dynamically generated component can be communicated with now via its name, which is accessible via `ask` (per the `RWS` refactor).

- Introduces `notify_`, `sample_`,  