### PR TITLE
Add componentId, synonym for ask in RWS.

### DIFF
--- a/src/Miso.hs
+++ b/src/Miso.hs
@@ -39,6 +39,7 @@ module Miso
   , io
   , io_
   , for
+  , componentId
   , module Miso.Types
     -- * Effect
   , module Miso.Effect

--- a/src/Miso/Effect.hs
+++ b/src/Miso/Effect.hs
@@ -31,6 +31,7 @@ module Miso.Effect
   , issue
   , withSink
   , mapSub
+  , componentId
   -- * Internal
   , runEffect
   -- * Deprecated
@@ -48,7 +49,7 @@ import           Control.Monad.Fail (MonadFail, fail)
 import qualified Control.Monad.Fail as Fail
 #endif
 import           Data.Foldable (for_)
-import           Control.Monad.RWS ( RWS, put, tell, execRWS
+import           Control.Monad.RWS ( RWS, put, tell, execRWS, ask
                                    , MonadState, MonadReader, MonadWriter
                                    )
 -----------------------------------------------------------------------------
@@ -236,4 +237,8 @@ batchEff :: model -> [JSM action] -> Effect model action
 batchEff model actions = do
   put model
   batch actions
+-----------------------------------------------------------------------------
+-- | Retrieves the @name@ of the @App@
+componentId :: EffectCore action model MisoString
+componentId = ask
 -----------------------------------------------------------------------------


### PR DESCRIPTION
Now that 'Effect' is defined in terms of 'RWS', the component name is available via 'ask'. This PR exposes 'componentId' as a primitive function.

The intended use case is when dealing with dynamically generated components that are not statically known. componentId will retrieve the dynamically set component ID.