### PR TITLE
App -> Component

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ newtype Model = Model
 counter :: Lens Model Int
 counter = lens _counter $ \record field -> record { _counter = field }
 ----------------------------------------------------------------------------
--- | Sum type for App events
+-- | Sum type for Component events
 data Action
   = AddOne
   | SubtractOne
@@ -156,16 +156,16 @@ data Action
 ----------------------------------------------------------------------------
 -- | Entry point for a miso application
 main :: IO ()
-main = run (startApp app)
+main = run (startComponent component)
 ----------------------------------------------------------------------------
 -- | WASM export, required when compiling w/ the WASM backend.
 #ifdef WASM
 foreign export javascript "hs_start" main :: IO ()
 #endif
 ----------------------------------------------------------------------------
--- | `defaultApp` takes as arguments the initial model, update function, view function
-app :: App name Model Action
-app = defaultApp emptyModel updateModel viewModel
+-- | `defaultComponent` takes as arguments the initial model, update function, view function
+component :: Component name Model Action
+component = defaultComponent emptyModel updateModel viewModel
 ----------------------------------------------------------------------------
 -- | Empty application state
 emptyModel :: Model
@@ -176,7 +176,7 @@ updateModel :: Action -> Effect Model Action
 updateModel = \case
   AddOne        -> counter += 1
   SubtractOne   -> counter -= 1
-  SayHelloWorld -> io $ do
+  SayHelloWorld -> io_ $ do
     consoleLog "Hello World"
     alert "Hello World"
 ----------------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ import Miso
 import Miso.String
 import Miso.Lens
 ----------------------------------------------------------------------------
--- | Application model state
+-- | Component model state
 newtype Model = Model
   { _counter :: Int
   } deriving (Show, Eq)

--- a/examples/canvas2d/Main.hs
+++ b/examples/canvas2d/Main.hs
@@ -23,10 +23,10 @@ main = run $ do
     setSrc sun "https://7b40c187-5088-4a99-9118-37d20a2f875e.mdnplay.dev/en-US/docs/Web/API/Canvas_API/Tutorial/Basic_animations/canvas_sun.png"
     setSrc moon "https://7b40c187-5088-4a99-9118-37d20a2f875e.mdnplay.dev/en-US/docs/Web/API/Canvas_API/Tutorial/Basic_animations/canvas_moon.png"
     setSrc earth "https://7b40c187-5088-4a99-9118-37d20a2f875e.mdnplay.dev/en-US/docs/Web/API/Canvas_API/Tutorial/Basic_animations/canvas_earth.png"
-    startApp (app sun moon earth) { initialAction = Just GetTime }
+    startComponent (app sun moon earth) { initialAction = Just GetTime }
   where
     app sun moon earth =
-      defaultApp (0.0, 0.0) (updateModel (sun, moon, earth)) view
+      defaultComponent (0.0, 0.0) (updateModel (sun, moon, earth)) view
     view _ =
       canvas_
         [ id_ "canvas"

--- a/examples/components/Main.hs
+++ b/examples/components/Main.hs
@@ -39,7 +39,7 @@ data MainAction
 type MainModel = Bool
 
 main :: IO ()
-main = run $ startApp app
+main = run $ startComponent app
   { logLevel = DebugPrerender
   , subs = []
   }
@@ -53,21 +53,21 @@ loggerSub msg = \_ ->
     liftIO $ threadDelay (secs 1)
     consoleLog msg
 
-app :: App "app" MainModel MainAction
-app = defaultApp False updateModel1 viewModel1
+app :: Component "app" MainModel MainAction
+app = defaultComponent False updateModel1 viewModel1
 
-counterApp2 :: App "app-2" Model Action
-counterApp2 = (defaultApp 0 updateModel2 viewModel2)
+counterComponent2 :: Component "app-2" Model Action
+counterComponent2 = (defaultComponent 0 updateModel2 viewModel2)
   { subs = [loggerSub "component-2 sub"]
   }
 
-counterApp3 :: App "app-3" (Bool, Model) Action
-counterApp3 = (defaultApp (True, 0) updateModel3 viewModel3)
+counterComponent3 :: Component "app-3" (Bool, Model) Action
+counterComponent3 = (defaultComponent (True, 0) updateModel3 viewModel3)
   { subs = [ loggerSub "component-3 sub"]
   }
 
-counterApp4 :: App "app-4" Model Action
-counterApp4 = (defaultApp 0 updateModel4 viewModel4)
+counterComponent4 :: Component "app-4" Model Action
+counterComponent4 = (defaultComponent 0 updateModel4 viewModel4)
   { subs = [loggerSub "component-4 sub"]
   }
 
@@ -99,7 +99,7 @@ viewModel1 x =
         , button_ [onClick SampleChild] [text "Sample Child (unsafe)"]
         , if x
             then
-                componentWith counterApp2 Nothing
+                componentWith counterComponent2 Nothing
                   [ onMounted MountMain
                   , onUnmounted UnMountMain
                   ]
@@ -112,12 +112,12 @@ updateModel1 StartLogger = startSub "logger" (loggerSub "main-app")
 updateModel1 StopLogger  = stopSub "logger"
 updateModel1 Toggle = modify not
 updateModel1 UnMountMain =
-  io (consoleLog "Component 2 was unmounted!")
+  io_ (consoleLog "Component 2 was unmounted!")
 updateModel1 MountMain =
-  io (consoleLog "Component 2 was mounted!")
+  io_ (consoleLog "Component 2 was mounted!")
 updateModel1 SampleChild = do
-  io $ do
-    componentTwoModel <- sample counterApp2
+  io_ $ do
+    componentTwoModel <- sample counterComponent2
     consoleLog $
         "Sampling child component 2 from parent component main (unsafe): " <>
           ms (show componentTwoModel)
@@ -129,15 +129,15 @@ updateModel2 SubtractOne = modify (subtract 1)
 updateModel2 u@UnMount{} = unmountAction u
 updateModel2 m@Mount{} = mountAction m
 updateModel2 SayHelloWorld = do
-  io (consoleLog "Hello World from Component 2")
+  io_ (consoleLog "Hello World from Component 2")
 updateModel2 _ = pure ()
 
 unmountAction :: Action -> Effect model action
-unmountAction (UnMount name) = io $ consoleLog ("Component " <> name <> " was unmounted!")
+unmountAction (UnMount name) = io_ $ consoleLog ("Component " <> name <> " was unmounted!")
 unmountAction _ = pure ()
 
 mountAction :: Action -> Effect model action
-mountAction (Mount name) = io $ consoleLog ("Component " <> name <> " was mounted!")
+mountAction (Mount name) = io_ $ consoleLog ("Component " <> name <> " was mounted!")
 mountAction _ = pure ()
 
 -- | Constructs a virtual DOM from a model
@@ -149,7 +149,7 @@ viewModel2 x =
         , button_ [onClick AddOne] [text "+"]
         , text (ms x)
         , button_ [onClick SubtractOne] [text "-"]
-        , componentWith counterApp3 Nothing
+        , componentWith counterComponent3 Nothing
           [ onMounted (Mount "3")
           , onUnmounted (UnMount "3")
           ]
@@ -166,7 +166,7 @@ updateModel3 ToggleAction =
 updateModel3 x@UnMount{} = unmountAction x
 updateModel3 x@Mount{} = mountAction x
 updateModel3 SayHelloWorld = do
-  io (consoleLog "Hello World from Component 3")
+  io_ (consoleLog "Hello World from Component 3")
 updateModel3 _ = pure ()
 
 -- | Constructs a virtual DOM from a model
@@ -189,12 +189,12 @@ viewModel3 (toggle, x) =
                -- If you are replacing an unnamed component (using 'component_') with anything else (e.g. 'vtext', 'vnode',
                -- 'vcomp', null), then you don't need to worry about this.
                then
-                 componentWith counterApp4 Nothing
+                 componentWith counterComponent4 Nothing
                    [ onMounted (Mount "4")
                    , onUnmounted (UnMount "4")
                    ]
                else
-                 componentWith counterApp5 Nothing
+                 componentWith counterComponent5 Nothing
                    [ onMounted (Mount "5")
                    , onUnmounted (UnMount "5")
                    ]
@@ -204,18 +204,18 @@ viewModel3 (toggle, x) =
 updateModel4 :: Action -> Effect Model Action
 updateModel4 AddOne = do
   modify (+1)
-  io (notify counterApp3 AddOne)
+  io_ (notify counterComponent3 AddOne)
 updateModel4 SubtractOne = do
   modify (subtract 1)
-  io (notify counterApp3 SubtractOne)
+  io_ (notify counterComponent3 SubtractOne)
 updateModel4 Sample =
-  io $ do
-    componentTwoModel <- sample counterApp3
+  io_ $ do
+    componentTwoModel <- sample counterComponent3
     consoleLog $
       "Sampling parent component 3 from child component 4: " <>
          ms (show componentTwoModel)
 updateModel4 SayHelloWorld = do
-  io (consoleLog "Hello World from Component 4")
+  io_ (consoleLog "Hello World from Component 4")
 updateModel4 _ = pure ()
 
 -- | Constructs a virtual DOM from a model
@@ -230,31 +230,31 @@ viewModel4 x =
         , button_ [onClick Sample] [text "Sample Component 3 state"]
         ]
 
-app5 :: App "app-5" Model Action
+app5 :: Component "app-5" Model Action
 app5 =
-        counterApp5
+        counterComponent5
             { subs = [loggerSub "component-5 sub"]
             }
 
-counterApp5 :: App "app-5" Model Action
-counterApp5 = defaultApp 0 updateModel5 viewModel5
+counterComponent5 :: Component "app-5" Model Action
+counterComponent5 = defaultComponent 0 updateModel5 viewModel5
 
 -- | Updates model, optionally introduces side effects
 updateModel5 :: Action -> Effect Model Action
 updateModel5 AddOne = do
   modify (+1)
-  io (notify counterApp2 AddOne)
+  io_ (notify counterComponent2 AddOne)
 updateModel5 SubtractOne = do
   modify (subtract 1)
-  io (notify counterApp2 SubtractOne)
+  io_ (notify counterComponent2 SubtractOne)
 updateModel5 Sample =
-  io $ do
-    componentTwoModel <- sample counterApp2
+  io_ $ do
+    componentTwoModel <- sample counterComponent2
     consoleLog $
       "Sampling parent component 2 from child component 5: " <>
          ms (show componentTwoModel)
 updateModel5 SayHelloWorld = do
-  io (consoleLog "Hello World from Component 5")
+  io_ (consoleLog "Hello World from Component 5")
 updateModel5 _ = pure ()
 
 -- | Constructs a virtual DOM from a model

--- a/examples/fetch/Main.hs
+++ b/examples/fetch/Main.hs
@@ -36,7 +36,7 @@ foreign export javascript "hs_start" main :: IO ()
 ----------------------------------------------------------------------------
 -- | Main entry point
 main :: IO ()
-main = run $ startApp app
+main = run $ startComponent app
   { styles =
     [ Href "https://cdnjs.cloudflare.com/ajax/libs/bulma/0.4.3/css/bulma.min.css"
     , Href "https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css"
@@ -59,8 +59,8 @@ data Action
   | ErrorHandler MisoString
   deriving (Show, Eq)
 ----------------------------------------------------------------------------
-app :: App name Model Action
-app = defaultApp emptyModel updateModel viewModel
+app :: Component name Model Action
+app = defaultComponent emptyModel updateModel viewModel
 ----------------------------------------------------------------------------
 emptyModel :: Model
 emptyModel = Model Nothing
@@ -84,7 +84,7 @@ updateModel FetchGitHub = io_ $ getGithubAPI <&> \case
 updateModel (SetGitHub apiInfo) =
   info ?= apiInfo
 updateModel (ErrorHandler msg) =
-  io (consoleError msg)
+  io_ (consoleError msg)
 ----------------------------------------------------------------------------
 -- | View function, with routing
 viewModel :: Model -> View Action

--- a/examples/fetch/Main.hs
+++ b/examples/fetch/Main.hs
@@ -78,9 +78,9 @@ getGithubAPI = do
     c = Servant.Client.JS.client (Proxy @GithubAPI)
 ----------------------------------------------------------------------------
 updateModel :: Action -> Effect Model Action
-updateModel FetchGitHub = io_ $ getGithubAPI <&> \case
+updateModel FetchGitHub = io $ getGithubAPI <&> \case
   Right r -> SetGitHub r
-  Left e  -> ErrorHandler $ ms $ show e
+  Left e  -> ErrorHandler $ ms (show e)
 updateModel (SetGitHub apiInfo) =
   info ?= apiInfo
 updateModel (ErrorHandler msg) =

--- a/examples/file-reader/Main.hs
+++ b/examples/file-reader/Main.hs
@@ -20,7 +20,7 @@ import           Language.Javascript.JSaddle ((!), (!!), (#), JSVal, (<#))
 import qualified Language.Javascript.JSaddle as J
 import           Prelude hiding ((!!), null, unlines)
 ----------------------------------------------------------------------------
-import           Miso (App(styles), View,Effect, defaultApp, run, CSS(..), startApp, io, io_)
+import           Miso (Component(styles), View,Effect, defaultComponent, run, CSS(..), startComponent, io, io_)
 import qualified Miso as M
 import           Miso.Lens ((.=), Lens, lens)
 import           Miso.String (MisoString, unlines, null)
@@ -50,7 +50,7 @@ foreign export javascript "hs_start" main :: IO ()
 ----------------------------------------------------------------------------
 -- | Main entry point
 main :: IO ()
-main = run $ startApp app
+main = run $ startComponent app
   { styles =
     [ Href "https://cdn.jsdelivr.net/npm/bulma@1.0.2/css/bulma.min.css"
     , Style css
@@ -78,12 +78,12 @@ css = unlines
   ]
 ----------------------------------------------------------------------------
 -- | Miso application
-app :: App name Model Action
-app = defaultApp (Model mempty) updateModel viewModel
+app :: Component name Model Action
+app = defaultComponent (Model mempty) updateModel viewModel
 ----------------------------------------------------------------------------
 -- | Update function
 updateModel :: Action -> Effect Model Action
-updateModel ReadFile = io_ $ do
+updateModel ReadFile = io $ do
   fileReaderInput <- M.getElementById "fileReader"
   file <- fileReaderInput ! ("files" :: String) !! 0
   reader <- J.new (J.jsg ("FileReader" :: String)) ([] :: [JSVal])
@@ -95,7 +95,7 @@ updateModel ReadFile = io_ $ do
   void $ reader # ("readAsText" :: String) $ [file]
   SetContent <$> liftIO (readMVar mvar)
 updateModel (SetContent c) = info .= c
-updateModel ClickInput = io $ do
+updateModel ClickInput = io_ $ do
   fileReader <- M.getElementById "fileReader"
   void $ fileReader # ("click" :: String) $ ([] :: [JSVal])
 ----------------------------------------------------------------------------

--- a/examples/mario/Main.hs
+++ b/examples/mario/Main.hs
@@ -29,7 +29,7 @@ main :: IO ()
 main = run $ do
     time <- now
     let m = mario{time = time}
-    startApp (defaultApp m updateMario display)
+    startComponent (defaultComponent m updateMario display)
       { subs =
           [ arrowsSub GetArrows
           , windowCoordsSub WindowCoords

--- a/examples/mathml/Main.hs
+++ b/examples/mathml/Main.hs
@@ -10,7 +10,7 @@ foreign export javascript "hs_start" main :: IO ()
 
 -- | Entry point for a miso application
 main :: IO ()
-main = run $ startApp (defaultApp Main.Empty updateModel viewModel)
+main = run $ startComponent (defaultComponent Main.Empty updateModel viewModel)
 
 data Model = Empty
   deriving (Eq)

--- a/examples/router/Main.hs
+++ b/examples/router/Main.hs
@@ -33,14 +33,14 @@ data Action
 main :: IO ()
 main = run $
   miso $ \u ->
-    (defaultApp (Model u) updateModel viewModel)
+    (defaultComponent (Model u) updateModel viewModel)
        { subs = [uriSub HandleURI]
        }
 
 -- | Update your model
 updateModel :: Action -> Effect Model Action
 updateModel (HandleURI u) = modify $ \m -> m { uri = u }
-updateModel (ChangeURI u) = io (pushURI u)
+updateModel (ChangeURI u) = io_ (pushURI u)
 
 -- | View function, with routing
 viewModel :: Model -> View Action

--- a/examples/simple/Main.hs
+++ b/examples/simple/Main.hs
@@ -34,25 +34,25 @@ foreign export javascript "hs_start" main :: IO ()
 
 -- | Entry point for a miso application
 main :: IO ()
-main = run $ startApp app
+main = run $ startComponent app
   { events = pointerEvents
   , styles = [ Style css ]
   }
 
--- | Application definition (uses 'defaultApp' smart constructor)
-app :: App name Model Action
-app = defaultApp (Model 0) updateModel viewModel
+-- | Application definition (uses 'defaultComponent' smart constructor)
+app :: Component name Model Action
+app = defaultComponent (Model 0) updateModel viewModel
 
 -- | UpdateModels model, optionally introduces side effects
 updateModel :: Action -> Effect Model Action
 updateModel (AddOne event) = do
   value += 1
-  io $ consoleLog (ms (show event))
+  io_ $ consoleLog (ms (show event))
 updateModel (SubtractOne event) = do
   value -= 1
-  io $ consoleLog (ms (show event))
+  io_ $ consoleLog (ms (show event))
 updateModel SayHelloWorld =
-  io (consoleLog "Hello World!")
+  io_ (consoleLog "Hello World!")
 
 -- | Constructs a virtual DOM from a model
 viewModel :: Model -> View Action

--- a/examples/simple/Main.hs
+++ b/examples/simple/Main.hs
@@ -39,7 +39,7 @@ main = run $ startComponent app
   , styles = [ Style css ]
   }
 
--- | Application definition (uses 'defaultComponent' smart constructor)
+-- | Component definition (uses 'defaultComponent' smart constructor)
 app :: Component name Model Action
 app = defaultComponent (Model 0) updateModel viewModel
 

--- a/examples/sse/server/Main.hs
+++ b/examples/sse/server/Main.hs
@@ -62,7 +62,7 @@ sendEvents chan =
         threadDelay (10 ^ (6 :: Int))
 
 -- | Page for setting HTML doctype and header
-newtype Page = Page (App "app" Model Action)
+newtype Page = Page (Component "app" Model Action)
 
 instance ToHtml Page where
     toHtml (Page x) =

--- a/examples/sse/shared/Common.hs
+++ b/examples/sse/shared/Common.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 
 module Common (
-    -- * App
+    -- * Component
     sse,
     -- * Types
     Model,
@@ -58,7 +58,7 @@ the404 =
 goHome :: URI
 goHome = allLinks' linkURI (Proxy :: Proxy ClientRoutes)
 
-sse :: URI -> App name Model Action
+sse :: URI -> Component name Model Action
 sse currentURI
   = app { subs =
           [ sseSub "/sse" handleSseMsg
@@ -66,7 +66,7 @@ sse currentURI
           ]
         }
   where
-    app = defaultApp (Model currentURI "No event received") updateModel viewModel
+    app = defaultComponent (Model currentURI "No event received") updateModel viewModel
     viewModel m
         | Right r <- route (Proxy :: Proxy ClientRoutes) home modelUri m =
             r
@@ -83,4 +83,4 @@ updateModel (ServerMsg msg) =
 updateModel (HandleURI u) =
     modify $ \m -> m { modelUri = u }
 updateModel (ChangeURI u) =
-    io (pushURI u)
+    io_ (pushURI u)

--- a/examples/svg/Main.hs
+++ b/examples/svg/Main.hs
@@ -23,7 +23,7 @@ main = run $ startComponent app
   , subs = [ mouseSub HandlePointer ]
   }
 
--- | Application definition (uses 'defaultComponent' smart constructor)
+-- | Component definition (uses 'defaultComponent' smart constructor)
 app :: Component name Model Action
 app = defaultComponent emptyModel updateModel viewModel
 

--- a/examples/svg/Main.hs
+++ b/examples/svg/Main.hs
@@ -18,14 +18,14 @@ foreign export javascript "hs_start" main :: IO ()
 #endif
 
 main :: IO ()
-main = run $ startApp app
+main = run $ startComponent app
   { events = M.insert "pointermove" False pointerEvents
   , subs = [ mouseSub HandlePointer ]
   }
 
--- | Application definition (uses 'defaultApp' smart constructor)
-app :: App name Model Action
-app = defaultApp emptyModel updateModel viewModel
+-- | Application definition (uses 'defaultComponent' smart constructor)
+app :: Component name Model Action
+app = defaultComponent emptyModel updateModel viewModel
 
 emptyModel :: Model
 emptyModel = Model (0, 0)

--- a/examples/three/Main.hs
+++ b/examples/three/Main.hs
@@ -62,7 +62,7 @@ main = run $ do
     stats <- newStats
     ref <- newIORef $ Context (pure ()) (pure ()) stats
     m <- now
-    startApp (defaultApp m (updateModel ref) viewModel)
+    startComponent (defaultComponent m (updateModel ref) viewModel)
       { initialAction = Just Init
       }
 
@@ -88,18 +88,18 @@ updateModel ::
     Action ->
     Effect Double Action
 updateModel ref Init = do
-  io (initContext ref)
-  issue GetTime
+  io $ do
+    initContext ref
+    pure GetTime
 updateModel ref GetTime = do
   io $ do
     Context{..} <- liftIO (readIORef ref)
     withStats stats $ do
       rotateCube
       renderScene
-  io_ (SetTime <$> now)
-updateModel _ (SetTime m) = do
-  put m
-  issue GetTime
+    SetTime <$> now
+updateModel _ (SetTime m) =
+  m <# pure GetTime
 
 #ifdef GHCJS_NEW
 foreign import javascript unsafe "(() => { return new Stats(); })"

--- a/examples/todo-mvc/Main.hs
+++ b/examples/todo-mvc/Main.hs
@@ -88,7 +88,7 @@ data Msg
     deriving (Show)
 
 main :: IO ()
-main = run $ startApp app
+main = run $ startComponent app
   { events = defaultEvents <> keyboardEvents
   , initialAction = Just FocusOnInput
   , styles =
@@ -97,14 +97,14 @@ main = run $ startApp app
       ]
   }
 
-app :: App name Model Msg
-app = defaultApp emptyModel updateModel viewModel
+app :: Component name Model Msg
+app = defaultComponent emptyModel updateModel viewModel
 
 updateModel :: Msg -> Effect Model Msg
 updateModel NoOp = pure ()
 updateModel FocusOnInput =
-  io (focus "input-box")
-updateModel (CurrentTime time) = io $ consoleLog $ S.ms (show time)
+  io_ (focus "input-box")
+updateModel (CurrentTime time) = io_ $ consoleLog $ S.ms (show time)
 updateModel Add = do
     model@Model{..} <- get
     put

--- a/examples/websocket/Main.hs
+++ b/examples/websocket/Main.hs
@@ -27,7 +27,7 @@ foreign export javascript "hs_start" main :: IO ()
 #endif
 
 main :: IO ()
-main = run $ startApp app
+main = run $ startComponent app
   { events = defaultEvents <> keyboardEvents
   , subs =
     [ websocketSub url protocols HandleWebSocket
@@ -36,8 +36,8 @@ main = run $ startApp app
       url = URL "wss://echo.websocket.org"
       protocols = Protocols []
 
-app :: App name Model Action
-app = defaultApp emptyModel updateModel appView
+app :: Component name Model Action
+app = defaultComponent emptyModel updateModel appView
 
 emptyModel :: Model
 emptyModel = Model (Message "") mempty
@@ -46,7 +46,7 @@ updateModel :: Action -> Effect Model Action
 updateModel (HandleWebSocket (WebSocketMessage (Message m))) =
   modify $ \model -> model { received = m }
 updateModel (SendMessage msg) =
-  io (send msg)
+  io_ (send msg)
 updateModel (UpdateMessage m) = do
   modify $ \model -> model { msg = Message m }
 updateModel _ = pure ()

--- a/haskell-miso.org/client/DevelMain.hs
+++ b/haskell-miso.org/client/DevelMain.hs
@@ -2,7 +2,7 @@
 module DevelMain (update) where
 
 import Common (haskellMisoComponent, uriHome)
-import Miso (startApp, run)
+import Miso (startComponent, run)
 import Miso.String (MisoString)
 
 import Rapid
@@ -11,4 +11,4 @@ update :: IO ()
 update =
   rapid 0 $ \r ->
     restart r ("miso-client" :: MisoString) $
-      run (startApp (haskellMisoComponent uriHome))
+      run (startComponent (haskellMisoComponent uriHome))

--- a/haskell-miso.org/shared/Common.hs
+++ b/haskell-miso.org/shared/Common.hs
@@ -61,7 +61,7 @@ type ClientRoutes = Routes (View Action)
 type ServerRoutes = Routes (Get '[HTML] Page)
 
 -- | Component synonym
-type HaskellMisoComponent = App "app" Model Action
+type HaskellMisoComponent = Component "app" Model Action
 
 -- | Links
 uriHome, uriExamples, uriDocs, uriCommunity, uri404 :: URI
@@ -100,8 +100,8 @@ haskellMisoComponent uri
   , logLevel = DebugAll
   }
   
-app :: URI -> App name Model Action
-app currentUri = defaultApp emptyModel updateModel viewModel
+app :: URI -> Component name Model Action
+app currentUri = defaultComponent emptyModel updateModel viewModel
   where
     emptyModel = Model currentUri False
     viewModel m =

--- a/haskell-miso.org/shared/Common.hs
+++ b/haskell-miso.org/shared/Common.hs
@@ -115,7 +115,7 @@ updateModel = \case
     modify $ \m -> m { uri = u }
   ChangeURI u -> do
     modify $ \m -> m { navMenuOpen = False }
-    io (pushURI u)
+    io_ (pushURI u)
   ToggleNavMenu -> do
     m@Model{..} <- get
     put m { navMenuOpen = not navMenuOpen }

--- a/nix/source.nix
+++ b/nix/source.nix
@@ -46,25 +46,25 @@ in
   flatris = fetchFromGitHub {
     owner = "dmjio";
     repo = "hs-flatris";
-    rev = "36454332d2a2b289bb892279a354851d68c566b3";
-    hash = "sha256-daNn2I6BlDxYTzkULyUiOcsQRF1Jn9Ub+VFdYJPCA2A=";
+    rev = "aa7a2e00cf87832de660718c15f1d85093ded103";
+    hash = "sha256-RLBfjIGeoSTsAuxh8Pa8kcQkupVtFZEYewDE783lZFg=";
   };
   miso-plane = fetchFromGitHub {
     owner = "dmjio";
     repo = "miso-plane";
-    rev = "0b7153a0174e2df456188a38084ba5cbbbdd7243";
-    hash = "sha256-WThKRb1k1kpVlcdkNtIDHneko1Mt0KEecq8x4sV944g=";
+    rev = "f143eb9";
+    hash = "sha256-S5urxw4eHrxsrZ9ivHeW5Nwec5eqpeat6GusNrxS+08=";
   };
   hs2048 = fetchFromGitHub {
     owner = "dmjio";
     repo = "hs2048";
-    rev = "eb6e1b6f85546607d3f0f150ec480ceee69668ba";
-    hash = "sha256-DelAE0ArLXan1Gx52qsKO9umfvJAW2xtY2UuNZkJQUY=";
+    rev = "65d7b3d";
+    hash = "sha256-46dhEMVutlPheLyw3/11WxF0STr9O3kR5w8xXMs9mCw=";
   };
   snake = fetchFromGitHub {
     owner = "dmjio";
     repo = "miso-snake";
-    rev = "4a1c7701973682d0df227185273ddbcbb2459e54";
-    hash = "sha256-hqEWoOvvraYUPFN71ofGpwXQLNRgZV5OCiMkdHNYF2A=";
+    rev = "1da7afa";
+    hash = "sha256-bAfIlnd3PRn9wqGn38R3+6ok1dxRR3Jeb+UUIYJZ7/M=";
   };
 }

--- a/sample-app/Main.hs
+++ b/sample-app/Main.hs
@@ -27,7 +27,7 @@ data Action
 ----------------------------------------------------------------------------
 -- | Entry point for a miso application
 main :: IO ()
-main = run (startApp app)
+main = run (startComponent app)
 ----------------------------------------------------------------------------
 -- | WASM export, required when compiling w/ the WASM backend.
 #ifdef WASM
@@ -35,8 +35,8 @@ foreign export javascript "hs_start" main :: IO ()
 #endif
 ----------------------------------------------------------------------------
 -- | `defaultApp` takes as arguments the initial model, update function, view function
-app :: App name Model Action
-app = defaultApp emptyModel updateModel viewModel
+app :: Component name Model Action
+app = defaultComponent emptyModel updateModel viewModel
 ----------------------------------------------------------------------------
 -- | Empty application state
 emptyModel :: Model
@@ -47,7 +47,7 @@ updateModel :: Action -> Effect Model Action
 updateModel = \case
   AddOne        -> counter += 1
   SubtractOne   -> counter -= 1
-  SayHelloWorld -> io $ do
+  SayHelloWorld -> io_ $ do
     alert "Hello World"
     consoleLog "Hello World"
 ----------------------------------------------------------------------------

--- a/sample-app/Main.hs
+++ b/sample-app/Main.hs
@@ -9,7 +9,7 @@ import Miso
 import Miso.String
 import Miso.Lens
 ----------------------------------------------------------------------------
--- | Application model state
+-- | Component model state
 data Model
   = Model
   { _counter :: Int

--- a/src/Miso.hs
+++ b/src/Miso.hs
@@ -17,16 +17,16 @@ module Miso
     -- ** Entry
     miso
   , (🍜)
-  , startApp
+  , startComponent
     -- ** Sink
   , withSink
   , Sink
     -- ** Sampling
   , sample
-  , sample_
+  , sample'
     -- ** Message Passing
   , notify
-  , notify_
+  , notify'
     -- ** Subscription
   , startSub
   , stopSub
@@ -38,7 +38,6 @@ module Miso
   , io
   , io_
   , for
-  , componentId
   , module Miso.Types
     -- * Effect
   , module Miso.Effect
@@ -111,9 +110,9 @@ import           Miso.Util
 -- Assumes the pre-rendered DOM is already present.
 -- Note: Uses 'mountPoint' as the 'Component' name.
 -- Always mounts to \<body\>. Copies page into the virtual DOM.
-miso :: Eq model => (URI -> App name model action) -> JSM ()
+miso :: Eq model => (URI -> Component name model action) -> JSM ()
 miso f = withJS $ do
-  app@App {..} <- f <$> getURI
+  app@Component {..} <- f <$> getURI
   initialize app $ \snk -> do
     renderStyles styles
     VTree (Object vtree) <- runView Prerender (view model) snk logLevel events
@@ -125,13 +124,13 @@ miso f = withJS $ do
     pure (name, mount, viewRef)
 -----------------------------------------------------------------------------
 -- | Alias for 'miso'.
-(🍜) :: Eq model => (URI -> App name model action) -> JSM ()
+(🍜) :: Eq model => (URI -> Component name model action) -> JSM ()
 (🍜) = miso
 ----------------------------------------------------------------------------
 -- | Runs a miso application
 -- Initializes application at 'mountPoint' (defaults to \<body\> when @Nothing@)
-startApp :: Eq model => App name model action -> JSM ()
-startApp app@App {..} = withJS $
+startComponent :: Eq model => Component name model action -> JSM ()
+startComponent app@Component {..} = withJS $
   initialize app $ \snk -> do
     renderStyles styles
     vtree <- runView DontPrerender (view model) snk logLevel events

--- a/src/Miso.hs
+++ b/src/Miso.hs
@@ -106,7 +106,7 @@ import           Miso.Subscription
 import           Miso.Types
 import           Miso.Util
 ----------------------------------------------------------------------------
--- | Runs an isomorphic miso application.
+-- | Runs an isomorphic @miso@ application.
 -- Assumes the pre-rendered DOM is already present.
 -- Note: Uses 'mountPoint' as the 'Component' name.
 -- Always mounts to \<body\>. Copies page into the virtual DOM.

--- a/src/Miso/Effect.hs
+++ b/src/Miso/Effect.hs
@@ -11,7 +11,7 @@
 -- Portability :  non-portable
 --
 -- This module defines `Effect`, `Sub` and `Sink` types, which are used to define
--- `Miso.Types.update` function and `Miso.Types.subs` field of the `Miso.Types.App`.
+-- `Miso.Types.update` function and `Miso.Types.subs` field of the `Miso.Types.Component`.
 --
 ----------------------------------------------------------------------------
 module Miso.Effect
@@ -114,7 +114,7 @@ batch_ actions = sequence_
 -- @LambdaCase@ language extension is enabled:
 --
 -- @
--- myApp = App
+-- myComponent = Component
 --   { update = \\case
 --       MyAction1 -> do
 --         field1 .= value1
@@ -191,7 +191,7 @@ for :: Foldable f => JSM (f action) -> Effect model action
 for actions = withSink $ \sink -> actions >>= flip for_ sink
 -----------------------------------------------------------------------------
 -- | @withSink@ allows users to access the sink of the 'Component' or top-level
--- 'App' in their application. This is useful for introducing 'IO' into the system.
+-- 'Component' in their application. This is useful for introducing 'IO' into the system.
 -- A synonym for 'Control.Monad.Writer.tell', specialized to 'Effect'.
 --
 -- A use-case is scheduling an 'IO' computation which creates a 3rd-party JS

--- a/src/Miso/Html/Event.hs
+++ b/src/Miso/Html/Event.hs
@@ -114,7 +114,7 @@ onWithOptions options eventName Decoder{..} toAction =
             [ "Event \""
             , eventName
             , "\" is not being listened on. To use this event, "
-            , "add to the 'events' Map in 'App'"
+            , "add to the 'events' @Map@ in @Component@"
             ]
       Just _ -> do
         eventObj <- getProp "events" n

--- a/src/Miso/Html/Types.hs
+++ b/src/Miso/Html/Types.hs
@@ -42,7 +42,7 @@ import           Miso.Types
 rawHtml
   :: MisoString
   -> View action
-rawHtml = TextRaw
+rawHtml = VTextRaw
 -----------------------------------------------------------------------------
 -- | Create a new @Miso.Html.Types.Node@.
 --
@@ -55,15 +55,15 @@ node :: NS
      -> [Attribute action]
      -> [View action]
      -> View action
-node = Node
+node = VNode
 -----------------------------------------------------------------------------
 -- | Create a new @Text@ with the given content.
 text :: MisoString -> View action
-text = Text
+text = VText
 -----------------------------------------------------------------------------
 -- | `TextRaw` creation. Don't use directly
 textRaw :: MisoString -> View action
-textRaw = TextRaw
+textRaw = VTextRaw
 -----------------------------------------------------------------------------
 -- | Virtual DOM implemented as a JavaScript `Object`.
 --   Used for diffing, patching and event delegation.

--- a/src/Miso/Internal.hs
+++ b/src/Miso/Internal.hs
@@ -66,7 +66,7 @@ import           Miso.Types
 import           Miso.Event (Events)
 import           Miso.Effect (Sub, SubName, Sink, Effect, runEffect, io_)
 -----------------------------------------------------------------------------
--- | Helper function to abstract out initialization of @App@ between top-level API functions.
+-- | Helper function to abstract out initialization of @Component@ between top-level API functions.
 initialize
   :: Eq model
   => Component name model action

--- a/src/Miso/Internal.hs
+++ b/src/Miso/Internal.hs
@@ -22,10 +22,10 @@ module Miso.Internal
     initialize
   , componentMap
   , notify
-  , notify_
+  , notify'
   , runView
   , sample
-  , sample_
+  , sample'
   , renderStyles
   , Prerender(..)
   -- * Subscription
@@ -64,16 +64,16 @@ import           Miso.Html hiding (on)
 import           Miso.String hiding (reverse)
 import           Miso.Types
 import           Miso.Event (Events)
-import           Miso.Effect (Sub, SubName, Sink, Effect, runEffect, io)
+import           Miso.Effect (Sub, SubName, Sink, Effect, runEffect, io_)
 -----------------------------------------------------------------------------
 -- | Helper function to abstract out initialization of @App@ between top-level API functions.
 initialize
   :: Eq model
-  => App name model action
+  => Component name model action
   -> (Sink action -> JSM (MisoString, JSVal, IORef VTree))
   -- ^ Callback function is used to perform the creation of VTree
   -> JSM (IORef VTree)
-initialize App {..} getView = do
+initialize Component {..} getView = do
   Waiter {..} <- liftIO waiter
   componentActions <- liftIO (newIORef S.empty)
   let
@@ -165,7 +165,7 @@ componentMap = unsafePerformIO (newIORef mempty)
 -- @Component@ being accessed is not available.
 sample
   :: forall name model action . KnownSymbol name
-  => App name model action
+  => Component name model action
   -> JSM model
 sample _ = do
   componentStateMap <- liftIO (readIORef componentMap)
@@ -175,24 +175,26 @@ sample _ = do
   where
     name = ms $ symbolVal (Proxy @name)
 -----------------------------------------------------------------------------
-sample_
+-- | Like @sample@ except used for dynamic @Component@ where the component-id
+-- has been retrieved via @ask@.
+sample'
   :: MisoString
   -> JSM model
-sample_ name = do
+sample' name = do
   componentStateMap <- liftIO (readIORef componentMap)
   liftIO (case M.lookup name componentStateMap of
     Nothing -> throwIO (NotMountedException name)
     Just ComponentState {..} -> readIORef componentModel)
 -----------------------------------------------------------------------------
 -- | Used for bidirectional communication between components.
--- Specify the mounted @App@ you'd like to target.
+-- Specify the mounted @Component@ you'd like to target.
 --
--- This function is used to send messages to @App@ that are mounted on
+-- This function is used to send messages to @Component@ that are mounted on
 -- other parts of the DOM tree.
 --
 notify
   :: forall name model action . KnownSymbol name
-  => App name model action
+  => Component name model action
   -> action
   -> JSM ()
 notify _ action = do
@@ -202,17 +204,14 @@ notify _ action = do
   where
     name = ms $ symbolVal (Proxy @name)
 -----------------------------------------------------------------------------
--- | Used for bidirectional communication between components.
+-- | Like @notify@ except used for dynamic @Component@ where the component-id
+-- has been retrieved via @ask@.
 --
--- Specify the mounted @App@ you'd like to target.
--- This function is used to send messages to @App@ on other parts of the
--- DOM tree.
---
-notify_
+notify'
   :: MisoString
   -> action
   -> JSM ()
-notify_ name action = do
+notify' name action = do
   componentStateMap <- liftIO (readIORef componentMap)
   forM_ (M.lookup name componentStateMap) $ \ComponentState {..} ->
     componentSink action
@@ -249,16 +248,16 @@ foldEffects update synchronicity name snk (e:es) o =
           sub snk `catch` (void . exception)
       foldEffects update synchronicity name snk es n
 --------------------------------------------------
--- | Internally used for runView and startApp
+-- | Internally used for runView and startComponent
 -- Initial draw helper
 -- If prerendering, bypass diff and continue copying
 drawComponent
   :: Prerender
   -> MisoString
-  -> App name model action
+  -> Component name model action
   -> Sink action
   -> JSM (MisoString, JSVal, IORef VTree)
-drawComponent prerender name App {..} snk = do
+drawComponent prerender name Component {..} snk = do
   vtree <- runView prerender (view model) snk logLevel events
   mountElement <- FFI.getComponent name
   when (prerender == DontPrerender) (diff Nothing (Just vtree) mountElement)
@@ -267,10 +266,10 @@ drawComponent prerender name App {..} snk = do
 -----------------------------------------------------------------------------
 -- | Drains the event queue before unmounting, executed synchronously
 drain
-  :: App name model action
+  :: Component name model action
   -> ComponentState model action
   -> JSM ()
-drain app@App{..} cs@ComponentState {..} = do
+drain app@Component{..} cs@ComponentState {..} = do
   actions <- liftIO $ atomicModifyIORef' componentActions $ \actions -> (S.empty, actions)
   if S.null actions then pure () else go actions
     where
@@ -283,10 +282,10 @@ drain app@App{..} cs@ComponentState {..} = do
 -- | Helper function for cleanly destroying a @Component@
 unmount
   :: Function
-  -> App name model action
+  -> Component name model action
   -> ComponentState model action
   -> JSM ()
-unmount mountCallback app@App {..} cs@ComponentState {..} = do
+unmount mountCallback app@Component {..} cs@ComponentState {..} = do
   undelegator componentMount componentVTree events (logLevel `elem` [DebugEvents, DebugAll])
   freeFunction mountCallback
   liftIO (mapM_ killThread =<< readIORef componentSubThreads)
@@ -307,7 +306,7 @@ runView
   -> LogLevel
   -> Events
   -> JSM VTree
-runView prerender (VComp name attributes key (Component app)) snk _ _ = do
+runView prerender (VComp name attributes key (SomeComponent app)) snk _ _ = do
   compName <-
     if null name
     then liftIO freshComponentId
@@ -443,8 +442,8 @@ renderStyles styles =
 startSub :: SubName -> Sub action -> Effect action model
 startSub subName sub = do
   compName <- ask
-  io $ do
-    M.lookup compName <$> liftIO (readIORef componentMap) >>= \case
+  io_
+    (M.lookup compName <$> liftIO (readIORef componentMap) >>= \case
       Nothing -> pure ()
       Just compState@ComponentState {..} -> do
         mtid <- liftIO (M.lookup subName <$> readIORef componentSubThreads)
@@ -456,7 +455,7 @@ startSub subName sub = do
             case status of
               ThreadFinished -> startThread compState
               ThreadDied -> startThread compState
-              _ -> pure ()
+              _ -> pure ())
   where
     startThread ComponentState {..} = do
       tid <- FFI.forkJSM (sub componentSink)
@@ -469,8 +468,8 @@ startSub subName sub = do
 stopSub :: SubName -> Effect action model
 stopSub subName = do
   compName <- ask
-  io $ do
-    M.lookup compName <$> liftIO (readIORef componentMap) >>= \case
+  io_
+    (M.lookup compName <$> liftIO (readIORef componentMap) >>= \case
       Nothing -> do
         pure ()
       Just ComponentState {..} -> do
@@ -478,5 +477,5 @@ stopSub subName = do
         forM_ mtid $ \tid -> do
           liftIO $ do
             atomicModifyIORef' componentSubThreads $ \m -> (M.delete subName m, ())
-            killThread tid
+            killThread tid)
 -----------------------------------------------------------------------------

--- a/src/Miso/Render.hs
+++ b/src/Miso/Render.hs
@@ -72,12 +72,12 @@ intercalate sep (x:xs) =
   ]
 ----------------------------------------------------------------------------
 renderBuilder :: View a -> Builder
-renderBuilder (Text "")    = fromMisoString " "
-renderBuilder (Text s)     = fromMisoString s
-renderBuilder (TextRaw "") = fromMisoString " "
-renderBuilder (TextRaw s)  = fromMisoString s
-renderBuilder (Node _ "doctype" _ [] []) = "<!doctype html>"
-renderBuilder (Node _ tag _ attrs children) =
+renderBuilder (VText "")    = fromMisoString " "
+renderBuilder (VText s)     = fromMisoString s
+renderBuilder (VTextRaw "") = fromMisoString " "
+renderBuilder (VTextRaw s)  = fromMisoString s
+renderBuilder (VNode _ "doctype" _ [] []) = "<!doctype html>"
+renderBuilder (VNode _ tag _ attrs children) =
   mconcat
   [ "<"
   , fromMisoString tag
@@ -134,8 +134,8 @@ renderAttrs (Styles styles) =
 -- this means we must collapse adjacent text nodes during hydration.
 collapseSiblingTextNodes :: [View a] -> [View a]
 collapseSiblingTextNodes [] = []
-collapseSiblingTextNodes (Text x : Text y : xs) =
-  collapseSiblingTextNodes (Text (x <> y) : xs)
+collapseSiblingTextNodes (VText x : VText y : xs) =
+  collapseSiblingTextNodes (VText (x <> y) : xs)
 collapseSiblingTextNodes (x:xs) =
   x : collapseSiblingTextNodes xs
 ----------------------------------------------------------------------------

--- a/src/Miso/Render.hs
+++ b/src/Miso/Render.hs
@@ -93,7 +93,7 @@ renderBuilder (Node _ tag _ attrs children) =
     | tag `notElem` ["img", "input", "br", "hr", "meta", "link"]
     ]
   ]
-renderBuilder (VComp mount attributes _ (Component App {..})) =
+renderBuilder (VComp mount attributes _ (SomeComponent Component {..})) =
   mconcat
   [ stringUtf8 "<div data-component-id=\""
   , fromMisoString mount

--- a/src/Miso/Types.hs
+++ b/src/Miso/Types.hs
@@ -1,10 +1,10 @@
-{-# LANGUAGE TypeApplications #-}
 -----------------------------------------------------------------------------
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE ExistentialQuantification  #-}
 {-# LANGUAGE ScopedTypeVariables        #-}
 {-# LANGUAGE OverloadedStrings          #-}
 {-# LANGUAGE FlexibleInstances          #-}
+{-# LANGUAGE TypeApplications           #-}
 {-# LANGUAGE RecordWildCards            #-}
 {-# LANGUAGE DeriveFunctor              #-}
 {-# LANGUAGE TypeFamilies               #-}
@@ -148,9 +148,9 @@ data SomeComponent
    = forall name model action . Eq model
   => SomeComponent (Component name model action)
 -----------------------------------------------------------------------------
--- | Used in the @view@ function to embed an @App@ into another @App@
--- Use this function if you'd like send messages to this @App@ at @name@ via
--- @notify@ or to read the state of this @App@ via @sample@.
+-- | Used in the @view@ function to embed an @Component@ into another @Component@
+-- Use this function if you'd like send messages to this @Component@ at @name@ via
+-- @notify@ or to read the state of this @Component@ via @sample@.
 component
   :: forall name model action a . (Eq model, KnownSymbol name)
   => Component name model action

--- a/src/Miso/Types.hs
+++ b/src/Miso/Types.hs
@@ -137,9 +137,9 @@ data LogLevel
 -----------------------------------------------------------------------------
 -- | Core type for constructing a virtual DOM in Haskell
 data View action
-  = Node NS MisoString (Maybe Key) [Attribute action] [View action]
-  | Text MisoString
-  | TextRaw MisoString
+  = VNode NS MisoString (Maybe Key) [Attribute action] [View action]
+  | VText MisoString
+  | VTextRaw MisoString
   | VComp MisoString [Attribute action] (Maybe Key) SomeComponent
   deriving Functor
 -----------------------------------------------------------------------------
@@ -280,5 +280,5 @@ data Attribute action
 -----------------------------------------------------------------------------
 -- | @IsString@ instance
 instance IsString (View a) where
-  fromString = Text . fromString
+  fromString = VText . fromString
 -----------------------------------------------------------------------------


### PR DESCRIPTION
Now that `Component` has been added, and `Component` can be nested recursively, `App` is now subsumed by `Component`. This PR replaces `App` with `Component`.

- `App` ->`Component`
- `defaultApp` -> `defaultComponent`
- `startApp` -> `startComponent`
- `Component` -> `SomeComponent`
- `io`-> `io_`, `io_` -> `io`
- Update examples (third-party too)
- `notify_` -> `notify'`
- `sample_` -> `sample'`
- Add `batch_`
- `Text` -> `VText`
- `Node` -> `VNode`
- `TextRaw` -> `VTextRaw`