### PR TITLE
Add dynamic Component example

### DIFF
--- a/examples/components/Main.hs
+++ b/examples/components/Main.hs
@@ -271,7 +271,9 @@ viewModel5 x =
         , component_ counterComponent6
         ]
 
-counterComponent6 :: Component name Model Action
+-- | "" here means the component is given a dynamically generated name, can also leave generic
+-- the component_ or componentWith_
+counterComponent6 :: Component "" Model Action
 counterComponent6 = defaultComponent 0 updateModel6 viewModel6
 
 -- | Updates model, optionally introduces side effects

--- a/examples/components/Main.hs
+++ b/examples/components/Main.hs
@@ -1,6 +1,6 @@
-{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module Main where
@@ -263,6 +263,41 @@ viewModel5 x =
     div_
         []
         [ "This is the view for Component 5"
+        , button_ [onClick AddOne] [text "+"]
+        , text (ms x)
+        , button_ [onClick SubtractOne] [text "-"]
+        , button_ [onClick Sample] [text "Sample Component 2 state"]
+        , "here is dynamic component 6..."
+        , component_ counterComponent6
+        ]
+
+counterComponent6 :: Component name Model Action
+counterComponent6 = defaultComponent 0 updateModel6 viewModel6
+
+-- | Updates model, optionally introduces side effects
+updateModel6 :: Action -> Effect Model Action
+updateModel6 AddOne = do
+  modify (+1)
+  io_ (notify counterComponent2 AddOne)
+updateModel6 SubtractOne = do
+  modify (subtract 1)
+  io_ (notify counterComponent2 SubtractOne)
+updateModel6 Sample =
+  io_ $ do
+    componentTwoModel <- sample counterComponent2
+    consoleLog $
+      "Sampling parent component 2 from child component 6: " <>
+         ms (show componentTwoModel)
+updateModel6 SayHelloWorld = do
+  io_ (consoleLog "Hello World from Component 6")
+updateModel6 _ = pure ()
+
+-- | Constructs a virtual DOM from a model
+viewModel6 :: Model -> View Action
+viewModel6 x =
+    div_
+        []
+        [ "This is the view for Component 6"
         , button_ [onClick AddOne] [text "+"]
         , text (ms x)
         , button_ [onClick SubtractOne] [text "-"]

--- a/examples/sse/server/Main.hs
+++ b/examples/sse/server/Main.hs
@@ -19,7 +19,7 @@ import Network.Wai.EventSource
 import Network.Wai.Handler.Warp
 import Network.Wai.Middleware.Gzip
 import Network.Wai.Middleware.RequestLogger
-import Servant hiding (respond)
+import Servant
 import qualified System.IO as IO
 
 import Miso hiding (SSE, run)

--- a/haskell-miso.org/server/Main.hs
+++ b/haskell-miso.org/server/Main.hs
@@ -29,7 +29,7 @@ import Network.Wai.Application.Static (defaultWebAppSettings)
 import Network.Wai.Handler.Warp (run)
 import Network.Wai.Middleware.Gzip (GzipFiles (..), def, gzip, gzipFiles)
 import Network.Wai.Middleware.RequestLogger (logStdout)
-import Servant hiding (respond)
+import Servant
 import qualified System.IO as IO
 
 import Miso hiding (run)

--- a/src/Miso/Internal.hs
+++ b/src/Miso/Internal.hs
@@ -1,7 +1,6 @@
 -----------------------------------------------------------------------------
 {-# LANGUAGE CPP                 #-}
 {-# LANGUAGE DataKinds           #-}
-{-# LANGUAGE PolyKinds           #-}
 {-# LANGUAGE LambdaCase          #-}
 {-# LANGUAGE BangPatterns        #-}
 {-# LANGUAGE KindSignatures      #-}

--- a/src/Miso/Internal.hs
+++ b/src/Miso/Internal.hs
@@ -46,7 +46,11 @@ import qualified Data.Map.Strict as M
 import qualified Data.Sequence as S
 import           Data.Sequence (Seq)
 import qualified JavaScript.Array as JSArray
+#ifndef GHCJS_BOTH
 import           Language.Javascript.JSaddle hiding (Sync)
+#else
+import           Language.Javascript.JSaddle
+#endif
 import           GHC.TypeLits (KnownSymbol, symbolVal)
 import           GHC.Conc (ThreadStatus(ThreadDied, ThreadFinished), ThreadId, killThread, threadStatus)
 import           Data.Proxy (Proxy(..))

--- a/src/Miso/Internal.hs
+++ b/src/Miso/Internal.hs
@@ -1,6 +1,7 @@
 -----------------------------------------------------------------------------
 {-# LANGUAGE CPP                 #-}
 {-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE PolyKinds           #-}
 {-# LANGUAGE LambdaCase          #-}
 {-# LANGUAGE BangPatterns        #-}
 {-# LANGUAGE KindSignatures      #-}
@@ -204,7 +205,7 @@ notify _ action = do
   where
     name = ms $ symbolVal (Proxy @name)
 -----------------------------------------------------------------------------
--- | Like @notify@ except used for dynamic @Component@ where the component-id
+-- | Like @notify@ except used for dynamic @Component@ where the /component-id/
 -- has been retrieved via @ask@.
 --
 notify'

--- a/src/Miso/Types.hs
+++ b/src/Miso/Types.hs
@@ -9,7 +9,6 @@
 {-# LANGUAGE DeriveFunctor              #-}
 {-# LANGUAGE TypeFamilies               #-}
 {-# LANGUAGE DataKinds                  #-}
-{-# LANGUAGE PolyKinds                  #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Miso.Types
@@ -54,7 +53,7 @@ import qualified Data.Text as T
 import           Data.Proxy (Proxy(Proxy))
 import           Language.Javascript.JSaddle (ToJSVal(toJSVal), Object, JSM)
 import           Prelude hiding (null)
-import           GHC.TypeLits (KnownSymbol, symbolVal)
+import           GHC.TypeLits (KnownSymbol, symbolVal, Symbol)
 import           Servant.API (HasLink(MkLink, toLink))
 -----------------------------------------------------------------------------
 import           Miso.Effect (Effect, Sub, Sink)
@@ -62,7 +61,7 @@ import           Miso.Event.Types
 import           Miso.String (MisoString, toMisoString, ms)
 -----------------------------------------------------------------------------
 -- | Application entry point
-data Component (name :: k) model action = Component
+data Component (name :: Symbol) model action = Component
   { model :: model
   -- ^ initial model
   , update :: action -> Effect model action
@@ -176,7 +175,7 @@ component app = VComp (ms name) [] Nothing (SomeComponent app)
 --
 component_
   :: Eq model
-  => Component () model action
+  => Component "" model action
   -> View a
 component_ vcomp = VComp mempty [] Nothing (SomeComponent vcomp)
 -----------------------------------------------------------------------------
@@ -198,7 +197,7 @@ componentWith app key attrs = VComp (ms name) attrs key (SomeComponent app)
 -- and it's /component-id/ can only be known at runtime.
 componentWith_
   :: Eq model
-  => Component () model action
+  => Component "" model action
   -> Maybe Key
   -> [Attribute a]
   -> View a


### PR DESCRIPTION
- [x] Makes `name` in `Component` be a type-level null `Symbol` for `component_` and `componentWith_`
- [x] Removes `SomeComponent` from external API (`component` and `component_` now both take `Component`).
- [x] Adds a dynamically generated `Component` example to `examples/component/Main.hs`

Instead of using `SomeComponent` to indicate dynamic `Component` creation, it will be more user-friendly to use unit (`()`).