### PR TITLE
Add key_, drop componentWith* variants.

### DIFF
--- a/examples/components/Main.hs
+++ b/examples/components/Main.hs
@@ -100,7 +100,7 @@ viewModel1 x =
         , button_ [onClick SampleChild] [text "Sample Child (unsafe)"]
         , if x
             then
-                componentWith counterComponent2 Nothing
+                component counterComponent2
                   [ onMounted MountMain
                   , onUnmounted UnMountMain
                   ]
@@ -150,7 +150,7 @@ viewModel2 x =
         , button_ [onClick AddOne] [text "+"]
         , text (ms x)
         , button_ [onClick SubtractOne] [text "-"]
-        , componentWith counterComponent3 Nothing
+        , component counterComponent3
           [ onMounted (Mount "3")
           , onUnmounted (UnMount "3")
           ]
@@ -190,12 +190,12 @@ viewModel3 (toggle, x) =
                -- If you are replacing an unnamed component (using 'component_') with anything else (e.g. 'vtext', 'vnode',
                -- 'vcomp', null), then you don't need to worry about this.
                then
-                 componentWith counterComponent4 Nothing
+                 component counterComponent4
                    [ onMounted (Mount "4")
                    , onUnmounted (UnMount "4")
                    ]
                else
-                 componentWith counterComponent5 Nothing
+                 component counterComponent5
                    [ onMounted (Mount "5")
                    , onUnmounted (UnMount "5")
                    ]
@@ -276,7 +276,7 @@ viewModel5 (x, _) =
         , button_ [onClick Sample] [text "Sample Component 2 state"]
         , "Here is dynamic component 6..."
         , br_ []
-        , componentWith_ counterComponent6 Nothing
+        , component_ counterComponent6
           [ onMountedWith Mount
           ]
         ]

--- a/examples/todo-mvc/Main.hs
+++ b/examples/todo-mvc/Main.hs
@@ -209,11 +209,11 @@ viewKeyedEntry = viewEntry
 
 viewEntry :: Entry -> View Msg
 viewEntry Entry{..} =
-    liKeyed_
-        (toKey eid)
+    li_
         [ class_ $
             S.intercalate " " $
                 ["completed" | completed] <> ["editing" | editing]
+        , key_ eid
         ]
         [ div_
             [class_ "view"]

--- a/src/Miso/Canvas.hs
+++ b/src/Miso/Canvas.hs
@@ -174,7 +174,7 @@ canvas
    . [ Attribute action ]
   -> JSM JSVal
   -> View action
-canvas attributes callback = node HTML "canvas" Nothing attrs []
+canvas attributes callback = node HTML "canvas" attrs []
   where
     attrs :: [ Attribute action ]
     attrs = flip (:) attributes $ Event $ \_ obj _ _ ->

--- a/src/Miso/Html/Element.hs
+++ b/src/Miso/Html/Element.hs
@@ -12,7 +12,6 @@
 module Miso.Html.Element
   ( -- ** Smart constructors
       nodeHtml
-    , nodeHtmlKeyed
     -- ** Document metadata
     , html_
     , doctype_
@@ -51,7 +50,6 @@ module Miso.Html.Element
     , figure_
     , hr_
     , li_
-    , liKeyed_
     , menu_
     , ol_
     , p_
@@ -119,7 +117,6 @@ module Miso.Html.Element
     , th_
     , thead_
     , tr_
-    , trKeyed_
     -- ** Forms
     , button_
     , datalist_
@@ -146,16 +143,11 @@ module Miso.Html.Element
 -----------------------------------------------------------------------------
 import           Miso.Html.Types
 import           Miso.String (MisoString)
-import           Miso.Property (keyProp)
 -----------------------------------------------------------------------------
 -- | Low-level helper used to construct 'HTML' 'node' in 'View'.
 -- Almost all functions in this module, like 'div_', 'table_' etc. are defined in terms of it.
 nodeHtml :: MisoString -> [Attribute action] -> [View action] -> View action
 nodeHtml nodeName = node HTML nodeName
------------------------------------------------------------------------------
--- | Construct a node with a 'Key'
-nodeHtmlKeyed :: MisoString -> Key -> [Attribute action] -> [View action] -> View action
-nodeHtmlKeyed name key attrs = node HTML name (keyProp key : attrs)
 -----------------------------------------------------------------------------
 -- | [\<div\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/div)
 div_ :: [Attribute action] -> [View action] -> View action
@@ -176,13 +168,6 @@ tbody_ = nodeHtml "tbody"
 -- | [\<tr\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/tr)
 tr_ :: [Attribute action] -> [View action] -> View action
 tr_ = nodeHtml "tr"
------------------------------------------------------------------------------
--- | Contains `Key`, inteded to be used for child replacement patch
---
--- [\<tr\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/tr)
------------------------------------------------------------------------------
-trKeyed_ :: Key -> [Attribute action] -> [View action] -> View action
-trKeyed_ key attrs = node HTML "tr" (keyProp key : attrs)
 -----------------------------------------------------------------------------
 -- | [\<th\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/th)
 th_ :: [Attribute action] -> [View action] -> View action
@@ -248,12 +233,6 @@ strong_ = nodeHtml "strong"
 -- | [\<li\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/li)
 li_ :: [Attribute action] -> [View action] -> View action
 li_ = nodeHtml "li"
------------------------------------------------------------------------------
--- | Contains `Key`, inteded to be used for child replacement patch
---
--- [\<li\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/li)
-liKeyed_ :: Key -> [Attribute action] -> [View action] -> View action
-liKeyed_ key attrs = node HTML "li" (keyProp key : attrs)
 -----------------------------------------------------------------------------
 -- | [\<h1\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/Heading_Elements)
 h1_ :: [Attribute action] -> [View action] -> View action

--- a/src/Miso/Html/Element.hs
+++ b/src/Miso/Html/Element.hs
@@ -146,15 +146,16 @@ module Miso.Html.Element
 -----------------------------------------------------------------------------
 import           Miso.Html.Types
 import           Miso.String (MisoString)
+import           Miso.Property (keyProp)
 -----------------------------------------------------------------------------
 -- | Low-level helper used to construct 'HTML' 'node' in 'View'.
 -- Almost all functions in this module, like 'div_', 'table_' etc. are defined in terms of it.
 nodeHtml :: MisoString -> [Attribute action] -> [View action] -> View action
-nodeHtml nodeName = node HTML nodeName Nothing
+nodeHtml nodeName = node HTML nodeName
 -----------------------------------------------------------------------------
 -- | Construct a node with a 'Key'
 nodeHtmlKeyed :: MisoString -> Key -> [Attribute action] -> [View action] -> View action
-nodeHtmlKeyed name key = node HTML name (Just key)
+nodeHtmlKeyed name key attrs = node HTML name (keyProp key : attrs)
 -----------------------------------------------------------------------------
 -- | [\<div\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/div)
 div_ :: [Attribute action] -> [View action] -> View action
@@ -181,7 +182,7 @@ tr_ = nodeHtml "tr"
 -- [\<tr\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/tr)
 -----------------------------------------------------------------------------
 trKeyed_ :: Key -> [Attribute action] -> [View action] -> View action
-trKeyed_ = node HTML "tr" . pure
+trKeyed_ key attrs = node HTML "tr" (keyProp key : attrs)
 -----------------------------------------------------------------------------
 -- | [\<th\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/th)
 th_ :: [Attribute action] -> [View action] -> View action
@@ -252,7 +253,7 @@ li_ = nodeHtml "li"
 --
 -- [\<li\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/li)
 liKeyed_ :: Key -> [Attribute action] -> [View action] -> View action
-liKeyed_ = node HTML "li" . pure
+liKeyed_ key attrs = node HTML "li" (keyProp key : attrs)
 -----------------------------------------------------------------------------
 -- | [\<h1\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/Heading_Elements)
 h1_ :: [Attribute action] -> [View action] -> View action
@@ -570,7 +571,7 @@ link_ = flip (nodeHtml "link") []
 --
 -- @'style_' [] "\</style\>"@
 style_ :: [Attribute action] -> MisoString -> View action
-style_ attrs rawText = node HTML "style" Nothing attrs [textRaw rawText]
+style_ attrs rawText = node HTML "style" attrs [textRaw rawText]
 -----------------------------------------------------------------------------
 -- | [\<script\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/script)
 --
@@ -584,7 +585,7 @@ style_ attrs rawText = node HTML "style" Nothing attrs [textRaw rawText]
 --
 -- @'script_' [] "\</script\>"@
 script_ :: [Attribute action] -> MisoString -> View action
-script_ attrs rawText = node HTML "script" Nothing attrs [textRaw rawText]
+script_ attrs rawText = node HTML "script" attrs [textRaw rawText]
 -----------------------------------------------------------------------------
 -- | [\<doctype\>](https://developer.mozilla.org/en-US/docs/Glossary/Doctype)
 doctype_ :: View action

--- a/src/Miso/Html/Types.hs
+++ b/src/Miso/Html/Types.hs
@@ -51,7 +51,6 @@ rawHtml = VTextRaw
 -- the node is created and its children are initialized to @children@.
 node :: NS
      -> MisoString
-     -> Maybe Key
      -> [Attribute action]
      -> [View action]
      -> View action

--- a/src/Miso/Mathml/Element.hs
+++ b/src/Miso/Mathml/Element.hs
@@ -50,7 +50,7 @@ import           Miso.String (MisoString)
 -- | Low-level helper used to construct 'MATHML' 'node' in 'View'.
 -- Most View helpers in this module are defined in terms of it.
 nodeMathml :: MisoString -> [Attribute action] -> [View action] -> View action
-nodeMathml nodeName = node MATHML nodeName Nothing
+nodeMathml nodeName = node MATHML nodeName
 -----------------------------------------------------------------------------
 -- | [\<annotation-xml\>](https://developer.mozilla.org/en-US/docs/Web/MathML/Reference/Element/annotation-xml)
 --

--- a/src/Miso/Property.hs
+++ b/src/Miso/Property.hs
@@ -23,6 +23,8 @@ module Miso.Property
   , integerProp
   , doubleProp
   , prop
+  , keyProp
+  , key_
   ) where
 -----------------------------------------------------------------------------
 import           Data.Aeson (ToJSON(..))
@@ -58,4 +60,13 @@ integerProp = prop
 -- | Set field to `Double` value
 doubleProp ::  MisoString -> Double -> Attribute action
 doubleProp = prop
+-----------------------------------------------------------------------------
+-- | Set `Key` on 'VNode'.
+keyProp :: ToKey key => key -> Attribute action
+keyProp key = prop "key" (toKey key)
+-----------------------------------------------------------------------------
+-- | Synonym for 'keyProp'
+-- Allows a user to specify a 'Key' inside of an @[Attribute action]@
+key_ :: ToKey key => key -> Attribute action
+key_ = keyProp
 -----------------------------------------------------------------------------

--- a/src/Miso/Render.hs
+++ b/src/Miso/Render.hs
@@ -76,8 +76,8 @@ renderBuilder (VText "")    = fromMisoString " "
 renderBuilder (VText s)     = fromMisoString s
 renderBuilder (VTextRaw "") = fromMisoString " "
 renderBuilder (VTextRaw s)  = fromMisoString s
-renderBuilder (VNode _ "doctype" _ [] []) = "<!doctype html>"
-renderBuilder (VNode _ tag _ attrs children) =
+renderBuilder (VNode _ "doctype" [] []) = "<!doctype html>"
+renderBuilder (VNode _ tag attrs children) =
   mconcat
   [ "<"
   , fromMisoString tag
@@ -93,7 +93,7 @@ renderBuilder (VNode _ tag _ attrs children) =
     | tag `notElem` ["img", "input", "br", "hr", "meta", "link"]
     ]
   ]
-renderBuilder (VComp mount attributes _ (SomeComponent Component {..})) =
+renderBuilder (VComp mount attributes (SomeComponent Component {..})) =
   mconcat
   [ stringUtf8 "<div data-component-id=\""
   , fromMisoString mount

--- a/src/Miso/Svg/Element.hs
+++ b/src/Miso/Svg/Element.hs
@@ -93,7 +93,7 @@ import           Miso.String        (MisoString)
 -- > document.createElementNS('http://www.w3.org/2000/svg', 'circle');
 --
 nodeSvg :: MisoString -> [Attribute action] -> [View action] -> View action
-nodeSvg nodeName = node SVG nodeName Nothing
+nodeSvg nodeName = node SVG nodeName
 -----------------------------------------------------------------------------
 -- | [\<svg\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/svg)
 svg_ :: [Attribute action] -> [View action] -> View action


### PR DESCRIPTION
`Key` has always existed as an explicit identifier internally, this change makes` Key` no different than any other 'Attribute'. User's can now set a `Key` inside of an `Attribute` list using 'key_'. This change is purely cosmetic for the Haskell interface, no TypeScript changes required. ~This preserves existing `trKeyed_`, `liKeyed_` combinators as well~

```haskell
-- example
keyedDiv = div_ [ key_ 1 ] []
```

- [x] Introduce `key_`
- [x] Drop `Key` parameter internally
- [x] Set `"key"` inside of `'setAttrs'` internally (in `runView`)
- [x] Use `textProp` in `parseView`
- [x] `ToJSON` on `Key`
- [x] Drop `with*` variants of `component`.
- [x] Drop `trKeyed`, `liKeyed` variants