### PR TITLE
Remove prompt symbol from ghcjs commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,7 +429,7 @@ Using [GHCup](https://www.haskell.org/ghcup/) you should be able to acquire the 
 > Use [cachix](https://cachix.org) to ensure you're not building dependencies unnecessarily `cachix use haskell-miso-cachix`
 
 ```bash
-❯ nix-shell -p pkgs.pkgsCross.ghcjs.haskell.packages.ghc9122.ghc -I nixpkgs=https://github.com/NixOS/nixpkgs/archive/65f179f903e8bbeff3215cd613bdc570940c0eab.tar.gz
+nix-shell -p pkgs.pkgsCross.ghcjs.haskell.packages.ghc9122.ghc -I nixpkgs=https://github.com/NixOS/nixpkgs/archive/65f179f903e8bbeff3215cd613bdc570940c0eab.tar.gz
 ```
 
 > [!NOTE]
@@ -439,7 +439,7 @@ Using [GHCup](https://www.haskell.org/ghcup/) you should be able to acquire the 
 > Alternatively, if you'd like to install the compiler into your global environment (so you don't need to develop inside a `bash` shell) you can use the following command.
 >
 > ```bash
-> ❯ nix-env -iA pkgs.pkgsCross.ghcjs.haskell.packages.ghc9122.ghc -f https://github.com/NixOS/nixpkgs/archive/65f179f903e8bbeff3215cd613bdc570940c0eab.tar.gz
+> nix-env -iA pkgs.pkgsCross.ghcjs.haskell.packages.ghc9122.ghc -f https://github.com/NixOS/nixpkgs/archive/65f179f903e8bbeff3215cd613bdc570940c0eab.tar.gz
 > ```
 
 - `cabal.project`


### PR DESCRIPTION
`❯` gets in the way when using the clipboard button to paste into the terminal