### PR TITLE
Miso.Media 🔊 🎥

### DIFF
--- a/README.md
+++ b/README.md
@@ -545,6 +545,7 @@ For real-world examples of Haskell `miso` applications, see below.
 | **Router**      | A client-side routing example          | [Source](https://github.com/dmjio/miso/blob/master/examples/router/Main.hs)      | [Demo](https://router.haskell-miso.org/)      | [@dmjio](https://github.com/dmjio)   |
 | **Canvas 2D**   | A 2D Canvas rendering example          | [Source](https://github.com/dmjio/miso/blob/master/examples/canvas2d/Main.hs)    | [Demo](https://canvas.haskell-miso.org/)      | [@dmjio](https://github.com/dmjio)   |
 | **Space Invaders**   | A Space-Invaders-like game       | [Source](https://gitlab.com/juliendehos/miso-invaders)    | [Demo](https://juliendehos.gitlab.io/miso-invaders/)      | [@juliendehos](https://github.com/juliendehos)   |
+| **Audio**   | Audio examples       | [Source](https://github.com/juliendehos/miso-audio-test)    | [Demo](https://juliendehos.github.io/miso-audio-test/)      | [@juliendehos](https://github.com/juliendehos)   |
 
 ## Building examples
 

--- a/miso.cabal
+++ b/miso.cabal
@@ -142,6 +142,7 @@ library
     Miso.Mathml
     Miso.Mathml.Element
     Miso.Mathml.Property
+    Miso.Media
     Miso.Property
     Miso.Render
     Miso.Router

--- a/src/Miso.hs
+++ b/src/Miso.hs
@@ -59,6 +59,8 @@ module Miso
   , module Miso.Storage
     -- * Fetch
   , module Miso.Fetch
+    -- * Media
+  , module Miso.Media
     -- * Util
   , module Miso.Util
     -- * FFI
@@ -101,6 +103,7 @@ import           Miso.Storage
 import           Miso.Subscription
 import           Miso.Types
 import           Miso.Util
+import           Miso.Media
 ----------------------------------------------------------------------------
 -- | Runs an isomorphic @miso@ application.
 -- Assumes the pre-rendered DOM is already present.

--- a/src/Miso.hs
+++ b/src/Miso.hs
@@ -59,8 +59,6 @@ module Miso
   , module Miso.Storage
     -- * Fetch
   , module Miso.Fetch
-    -- * Media
-  , module Miso.Media
     -- * Util
   , module Miso.Util
     -- * FFI
@@ -103,7 +101,6 @@ import           Miso.Storage
 import           Miso.Subscription
 import           Miso.Types
 import           Miso.Util
-import           Miso.Media
 ----------------------------------------------------------------------------
 -- | Runs an isomorphic @miso@ application.
 -- Assumes the pre-rendered DOM is already present.

--- a/src/Miso/Event/Types.hs
+++ b/src/Miso/Event/Types.hs
@@ -35,7 +35,7 @@ module Miso.Event.Types
   , mouseEvents
   , dragEvents
   , pointerEvents
-  , audioVideoEvents
+  , mediaEvents
   ) where
 -----------------------------------------------------------------------------
 import           Data.Aeson (FromJSON(..), withText)
@@ -187,8 +187,8 @@ pointerEvents = M.fromList
 -----------------------------------------------------------------------------
 -- | Audio video events
 -- For use with the /<audio/> and /<video/> tags.
-audioVideoEvents :: Events
-audioVideoEvents = M.fromList
+mediaEvents :: Events
+mediaEvents = M.fromList
   [ ("abort", True)
   , ("canplay", True)
   , ("canplaythrough", True)

--- a/src/Miso/FFI.hs
+++ b/src/Miso/FFI.hs
@@ -28,13 +28,6 @@ module Miso.FFI
   -- ** Image
   , Image (..)
   , newImage
-  -- ** Audio
-  , Audio (..)
-  , newAudio
-  , play
-  , volume
-  , pause
-  , paused
   ) where
 -----------------------------------------------------------------------------
 import           Miso.FFI.Internal

--- a/src/Miso/FFI/Internal.hs
+++ b/src/Miso/FFI/Internal.hs
@@ -61,12 +61,6 @@ module Miso.FFI.Internal
    , setComponent
    , Image (..)
    , newImage
-   , Audio (..)
-   , newAudio
-   , play
-   , volume
-   , pause
-   , paused
    ) where
 -----------------------------------------------------------------------------
 import           Control.Concurrent (ThreadId, forkIO)
@@ -74,7 +68,7 @@ import           Control.Monad (void, forM_)
 import           Control.Monad.IO.Class (liftIO)
 import           Data.Aeson hiding (Object)
 import qualified Data.Aeson as A
-import           Data.Maybe (isJust, fromMaybe)
+import           Data.Maybe (isJust)
 import qualified Data.JSString as JSS
 #ifdef GHCJS_BOTH
 import           Language.Javascript.JSaddle
@@ -504,28 +498,4 @@ newImage url = do
   img <- new (jsg "Image") ([] :: [MisoString])
   img <# "src" $ url
   pure (Image img)
------------------------------------------------------------------------------
-newtype Audio = Audio JSVal
-  deriving (ToJSVal)
------------------------------------------------------------------------------
-newAudio :: MisoString -> JSM Audio
-newAudio url = do
-  a <- new (jsg "Audio") ([] :: [MisoString])
-  o <- makeObject a
-  set (ms "src") url o
-  pure (Audio a)
------------------------a------------------------------------------------------
-play :: Audio -> JSM ()
-play (Audio a) = void $ a # "play" $ ()
------------------------------------------------------------------------------
-volume :: Audio -> Double -> JSM ()
-volume (Audio a) = a <# "volume"
------------------------------------------------------------------------------
-paused :: Audio -> JSM Bool
-paused (Audio a) = do
-  value <- a ! "paused"
-  fromMaybe False <$> fromJSVal value
------------------------------------------------------------------------------
-pause :: Audio -> JSM ()
-pause (Audio a) = void $ a # "pause" $ ()
 -----------------------------------------------------------------------------

--- a/src/Miso/Html/Event.hs
+++ b/src/Miso/Html/Event.hs
@@ -58,32 +58,55 @@ module Miso.Html.Event
   , onPointerMove
   -- *** Media
   , onAbort
+  , onAbortWith
   , onCanPlay
+  , onCanPlayWith
   , onCanPlayThrough
+  , onCanPlayThroughWith
   , onDurationChange
+  , onDurationChangeWith
   , onEmptied
+  , onEmptiedWith
   , onEnded
+  , onEndedWith
   , onError
+  , onErrorWith
   , onLoadedData
+  , onLoadedDataWith
   , onLoadedMetadata
+  , onLoadedMetadataWith
   , onLoadStart
+  , onLoadStartWith
   , onPause
+  , onPauseWith
   , onPlay
+  , onPlayWith
   , onPlaying
+  , onPlayingWith
   , onProgress
+  , onProgressWith
   , onRateChange
+  , onRateChangeWith
   , onSeeked
+  , onSeekedWith
   , onSeeking
+  , onSeekingWith
   , onStalled
+  , onStalledWith
   , onSuspend
+  , onSuspendWith
   , onTimeUpdate
+  , onTimeUpdateWith
   , onVolumeChange
+  , onVolumeChangeWith
   , onWaiting
+  , onWaitingWith
   ) where
 -----------------------------------------------------------------------------
 import           Language.Javascript.JSaddle
 -----------------------------------------------------------------------------
 import           Miso.Event
+import           Miso.Media (Media(..))
 import           Miso.String (MisoString)
 import           Miso.Types (Attribute)
 -----------------------------------------------------------------------------
@@ -243,87 +266,175 @@ onPointerMove f = on "pointermove" pointerDecoder (\action _ -> f action)
 onAbort :: action -> Attribute action
 onAbort action = on "abort" emptyDecoder $ \() _ -> action
 -----------------------------------------------------------------------------
+-- | https://www.w3schools.com/tags/av_event_abort.asp
+onAbortWith :: (Media -> action) -> Attribute action
+onAbortWith action = on "abort" emptyDecoder $ \() -> action . Media
+-----------------------------------------------------------------------------
 -- | https://www.w3schools.com/tags/av_event_canplay.asp
 onCanPlay :: action -> Attribute action
 onCanPlay action = on "canplay" emptyDecoder $ \() _ -> action
+-----------------------------------------------------------------------------
+-- | https://www.w3schools.com/tags/av_event_canplay.asp
+onCanPlayWith :: (Media -> action) -> Attribute action
+onCanPlayWith action = on "canplay" emptyDecoder $ \() -> action . Media
 -----------------------------------------------------------------------------
 -- | https://www.w3schools.com/tags/av_event_canplaythrough.asp
 onCanPlayThrough :: action -> Attribute action
 onCanPlayThrough action = on "canplaythrough" emptyDecoder $ \() _ -> action
 -----------------------------------------------------------------------------
+-- | https://www.w3schools.com/tags/av_event_canplaythrough.asp
+onCanPlayThroughWith :: (Media -> action) -> Attribute action
+onCanPlayThroughWith action = on "canplaythrough" emptyDecoder $ \() -> action . Media
+-----------------------------------------------------------------------------
 -- | https://www.w3schools.com/tags/av_event_duractionchange.asp
 onDurationChange :: action -> Attribute action
 onDurationChange action = on "durationchange" emptyDecoder $ \() _ -> action
+-----------------------------------------------------------------------------
+-- | https://www.w3schools.com/tags/av_event_duractionchange.asp
+onDurationChangeWith :: (Media -> action) -> Attribute action
+onDurationChangeWith action = on "durationchange" emptyDecoder $ \() -> action . Media
 -----------------------------------------------------------------------------
 -- | https://www.w3schools.com/tags/av_event_emptied.asp
 onEmptied :: action -> Attribute action
 onEmptied action = on "emptied" emptyDecoder $ \() _ -> action
 -----------------------------------------------------------------------------
+-- | https://www.w3schools.com/tags/av_event_emptied.asp
+onEmptiedWith :: (Media -> action) -> Attribute action
+onEmptiedWith action = on "emptied" emptyDecoder $ \() -> action . Media
+-----------------------------------------------------------------------------
 -- | https://www.w3schools.com/tags/av_event_ended.asp
 onEnded :: action -> Attribute action
 onEnded action = on "ended" emptyDecoder $ \() _ -> action
+-----------------------------------------------------------------------------
+-- | https://www.w3schools.com/tags/av_event_ended.asp
+onEndedWith :: (Media -> action) -> Attribute action
+onEndedWith action = on "ended" emptyDecoder $ \() -> action . Media
 -----------------------------------------------------------------------------
 -- | https://www.w3schools.com/tags/av_event_error.asp
 onError :: action -> Attribute action
 onError action = on "error" emptyDecoder $ \() _ -> action
 -----------------------------------------------------------------------------
+-- | https://www.w3schools.com/tags/av_event_error.asp
+onErrorWith :: (Media -> action) -> Attribute action
+onErrorWith action = on "error" emptyDecoder $ \() -> action . Media
+-----------------------------------------------------------------------------
 -- | https://www.w3schools.com/tags/av_event_loaddeddata.asp
 onLoadedData :: action -> Attribute action
 onLoadedData action = on "loadeddata" emptyDecoder $ \() _ -> action
+-----------------------------------------------------------------------------
+-- | https://www.w3schools.com/tags/av_event_loaddeddata.asp
+onLoadedDataWith :: (Media -> action) -> Attribute action
+onLoadedDataWith action = on "loadeddata" emptyDecoder $ \() -> action . Media
 -----------------------------------------------------------------------------
 -- | https://www.w3schools.com/tags/av_event_loadedmetadata.asp
 onLoadedMetadata :: action -> Attribute action
 onLoadedMetadata action = on "loadedmetadata" emptyDecoder $ \() _ -> action
 -----------------------------------------------------------------------------
+-- | https://www.w3schools.com/tags/av_event_loadedmetadata.asp
+onLoadedMetadataWith :: (Media -> action) -> Attribute action
+onLoadedMetadataWith action = on "loadedmetadata" emptyDecoder $ \() -> action . Media
+-----------------------------------------------------------------------------
 -- | https://www.w3schools.com/tags/av_event_loadstart.asp
 onLoadStart :: action -> Attribute action
 onLoadStart action = on "loadstart" emptyDecoder $ \() _ -> action
+-----------------------------------------------------------------------------
+-- | https://www.w3schools.com/tags/av_event_loadstart.asp
+onLoadStartWith :: (Media -> action) -> Attribute action
+onLoadStartWith action = on "loadstart" emptyDecoder $ \() -> action . Media
 -----------------------------------------------------------------------------
 -- | https://www.w3schools.com/tags/av_event_pause.asp
 onPause :: action -> Attribute action
 onPause action = on "pause" emptyDecoder $ \() _ -> action
 -----------------------------------------------------------------------------
+-- | https://www.w3schools.com/tags/av_event_pause.asp
+onPauseWith :: (Media -> action) -> Attribute action
+onPauseWith action = on "pause" emptyDecoder $ \() -> action . Media
+-----------------------------------------------------------------------------
 -- | https://www.w3schools.com/tags/av_event_play.asp
 onPlay :: action -> Attribute action
 onPlay action = on "play" emptyDecoder $ \() _ -> action
+-----------------------------------------------------------------------------
+-- | https://www.w3schools.com/tags/av_event_play.asp
+onPlayWith :: (Media -> action) -> Attribute action
+onPlayWith action = on "play" emptyDecoder $ \() -> action . Media
 -----------------------------------------------------------------------------
 -- | https://www.w3schools.com/tags/av_event_playing.asp
 onPlaying :: action -> Attribute action
 onPlaying action = on "playing" emptyDecoder $ \() _ -> action
 -----------------------------------------------------------------------------
+-- | https://www.w3schools.com/tags/av_event_playing.asp
+onPlayingWith :: (Media -> action) -> Attribute action
+onPlayingWith action = on "playing" emptyDecoder $ \() -> action . Media
+-----------------------------------------------------------------------------
 -- | https://www.w3schools.com/tags/av_event_progress.asp
 onProgress :: action -> Attribute action
 onProgress action = on "progress" emptyDecoder $ \() _ -> action
+-----------------------------------------------------------------------------
+-- | https://www.w3schools.com/tags/av_event_progress.asp
+onProgressWith :: (Media -> action) -> Attribute action
+onProgressWith action = on "progress" emptyDecoder $ \() -> action . Media
 -----------------------------------------------------------------------------
 -- | https://www.w3schools.com/tags/av_event_ratechange.asp
 onRateChange :: action -> Attribute action
 onRateChange action = on "ratechange" emptyDecoder $ \() _ -> action
 -----------------------------------------------------------------------------
+-- | https://www.w3schools.com/tags/av_event_ratechange.asp
+onRateChangeWith :: (Media -> action) -> Attribute action
+onRateChangeWith action = on "ratechange" emptyDecoder $ \() -> action . Media
+-----------------------------------------------------------------------------
 -- | https://www.w3schools.com/tags/av_event_seeked.asp
 onSeeked :: action -> Attribute action
 onSeeked action = on "seeked" emptyDecoder $ \() _ -> action
+-----------------------------------------------------------------------------
+-- | https://www.w3schools.com/tags/av_event_seeked.asp
+onSeekedWith :: (Media -> action) -> Attribute action
+onSeekedWith action = on "seeked" emptyDecoder $ \() -> action . Media
 -----------------------------------------------------------------------------
 -- | https://www.w3schools.com/tags/av_event_seeking.asp
 onSeeking :: action -> Attribute action
 onSeeking action = on "seeking" emptyDecoder $ \() _ -> action
 -----------------------------------------------------------------------------
+-- | https://www.w3schools.com/tags/av_event_seeking.asp
+onSeekingWith :: (Media -> action) -> Attribute action
+onSeekingWith action = on "seeking" emptyDecoder $ \() -> action . Media
+-----------------------------------------------------------------------------
 -- | https://www.w3schools.com/tags/av_event_stalled.asp
 onStalled :: action -> Attribute action
 onStalled action = on "stalled" emptyDecoder $ \() _ -> action
+-----------------------------------------------------------------------------
+-- | https://www.w3schools.com/tags/av_event_stalled.asp
+onStalledWith :: (Media -> action) -> Attribute action
+onStalledWith action = on "stalled" emptyDecoder $ \() -> action . Media
 -----------------------------------------------------------------------------
 -- | https://www.w3schools.com/tags/av_event_suspend.asp
 onSuspend :: action -> Attribute action
 onSuspend action = on "suspend" emptyDecoder $ \() _ -> action
 -----------------------------------------------------------------------------
+-- | https://www.w3schools.com/tags/av_event_suspend.asp
+onSuspendWith :: (Media -> action) -> Attribute action
+onSuspendWith action = on "suspend" emptyDecoder $ \() -> action . Media
+-----------------------------------------------------------------------------
 -- | https://www.w3schools.com/tags/av_event_timeupdate.asp
 onTimeUpdate :: action -> Attribute action
 onTimeUpdate action = on "timeupdate" emptyDecoder $ \() _ -> action
+-----------------------------------------------------------------------------
+-- | https://www.w3schools.com/tags/av_event_timeupdate.asp
+onTimeUpdateWith :: (Media -> action) -> Attribute action
+onTimeUpdateWith action = on "timeupdate" emptyDecoder $ \() -> action . Media
 -----------------------------------------------------------------------------
 -- | https://www.w3schools.com/tags/av_event_volumechange.asp
 onVolumeChange :: action -> Attribute action
 onVolumeChange action = on "volumechange" emptyDecoder $ \() _ -> action
 -----------------------------------------------------------------------------
+-- | https://www.w3schools.com/tags/av_event_volumechange.asp
+onVolumeChangeWith :: (Media -> action) -> Attribute action
+onVolumeChangeWith action = on "volumechange" emptyDecoder $ \() -> action . Media
+-----------------------------------------------------------------------------
 -- | https://www.w3schools.com/tags/av_event_waiting.asp
 onWaiting :: action -> Attribute action
 onWaiting action = on "waiting" emptyDecoder $ \() _ -> action
+-----------------------------------------------------------------------------
+-- | https://www.w3schools.com/tags/av_event_waiting.asp
+onWaitingWith :: (Media -> action) -> Attribute action
+onWaitingWith action = on "waiting" emptyDecoder $ \() -> action . Media
 -----------------------------------------------------------------------------

--- a/src/Miso/Html/Event.hs
+++ b/src/Miso/Html/Event.hs
@@ -240,90 +240,90 @@ onPointerMove :: (PointerEvent -> action) -> Attribute action
 onPointerMove f = on "pointermove" pointerDecoder (\action _ -> f action)
 -----------------------------------------------------------------------------
 -- | https://www.w3schools.com/tags/av_event_abort.asp
-onAbort ::action -> Attribute action
+onAbort :: action -> Attribute action
 onAbort action = on "abort" emptyDecoder $ \() _ -> action
 -----------------------------------------------------------------------------
 -- | https://www.w3schools.com/tags/av_event_canplay.asp
-onCanplay ::action -> Attribute action
+onCanplay :: action -> Attribute action
 onCanplay action = on "canplay" emptyDecoder $ \() _ -> action
 -----------------------------------------------------------------------------
 -- | https://www.w3schools.com/tags/av_event_canplaythrough.asp
-onCanPlayThrough ::action -> Attribute action
+onCanPlayThrough :: action -> Attribute action
 onCanPlayThrough action = on "canplaythrough" emptyDecoder $ \() _ -> action
 -----------------------------------------------------------------------------
 -- | https://www.w3schools.com/tags/av_event_duractionchange.asp
-onDurationChange ::action -> Attribute action
+onDurationChange :: action -> Attribute action
 onDurationChange action = on "durationchange" emptyDecoder $ \() _ -> action
 -----------------------------------------------------------------------------
 -- | https://www.w3schools.com/tags/av_event_emptied.asp
-onEmptied ::action -> Attribute action
+onEmptied :: action -> Attribute action
 onEmptied action = on "emptied" emptyDecoder $ \() _ -> action
 -----------------------------------------------------------------------------
 -- | https://www.w3schools.com/tags/av_event_ended.asp
-onEnded ::action -> Attribute action
+onEnded :: action -> Attribute action
 onEnded action = on "ended" emptyDecoder $ \() _ -> action
 -----------------------------------------------------------------------------
 -- | https://www.w3schools.com/tags/av_event_error.asp
-onError ::action -> Attribute action
+onError :: action -> Attribute action
 onError action = on "error" emptyDecoder $ \() _ -> action
 -----------------------------------------------------------------------------
 -- | https://www.w3schools.com/tags/av_event_loaddeddata.asp
-onLoadedData ::action -> Attribute action
+onLoadedData :: action -> Attribute action
 onLoadedData action = on "loadeddata" emptyDecoder $ \() _ -> action
 -----------------------------------------------------------------------------
 -- | https://www.w3schools.com/tags/av_event_loadedmetadata.asp
-onLoadedMetadata ::action -> Attribute action
+onLoadedMetadata :: action -> Attribute action
 onLoadedMetadata action = on "loadedmetadata" emptyDecoder $ \() _ -> action
 -----------------------------------------------------------------------------
 -- | https://www.w3schools.com/tags/av_event_loadstart.asp
-onLoadStart ::action -> Attribute action
+onLoadStart :: action -> Attribute action
 onLoadStart action = on "loadstart" emptyDecoder $ \() _ -> action
 -----------------------------------------------------------------------------
 -- | https://www.w3schools.com/tags/av_event_pause.asp
-onPause ::action -> Attribute action
+onPause :: action -> Attribute action
 onPause action = on "pause" emptyDecoder $ \() _ -> action
 -----------------------------------------------------------------------------
 -- | https://www.w3schools.com/tags/av_event_play.asp
-onPlay ::action -> Attribute action
+onPlay :: action -> Attribute action
 onPlay action = on "play" emptyDecoder $ \() _ -> action
 -----------------------------------------------------------------------------
 -- | https://www.w3schools.com/tags/av_event_playing.asp
-onPlaying ::action -> Attribute action
+onPlaying :: action -> Attribute action
 onPlaying action = on "playing" emptyDecoder $ \() _ -> action
 -----------------------------------------------------------------------------
 -- | https://www.w3schools.com/tags/av_event_progress.asp
-onProgress ::action -> Attribute action
+onProgress :: action -> Attribute action
 onProgress action = on "progress" emptyDecoder $ \() _ -> action
 -----------------------------------------------------------------------------
 -- | https://www.w3schools.com/tags/av_event_ratechange.asp
-onRateChange ::action -> Attribute action
+onRateChange :: action -> Attribute action
 onRateChange action = on "ratechange" emptyDecoder $ \() _ -> action
 -----------------------------------------------------------------------------
 -- | https://www.w3schools.com/tags/av_event_seeked.asp
-onSeeked ::action -> Attribute action
+onSeeked :: action -> Attribute action
 onSeeked action = on "seeked" emptyDecoder $ \() _ -> action
 -----------------------------------------------------------------------------
 -- | https://www.w3schools.com/tags/av_event_seeking.asp
-onSeeking ::action -> Attribute action
+onSeeking :: action -> Attribute action
 onSeeking action = on "seeking" emptyDecoder $ \() _ -> action
 -----------------------------------------------------------------------------
 -- | https://www.w3schools.com/tags/av_event_stalled.asp
-onStalled ::action -> Attribute action
+onStalled :: action -> Attribute action
 onStalled action = on "stalled" emptyDecoder $ \() _ -> action
 -----------------------------------------------------------------------------
 -- | https://www.w3schools.com/tags/av_event_suspend.asp
-onSuspend ::action -> Attribute action
+onSuspend :: action -> Attribute action
 onSuspend action = on "suspend" emptyDecoder $ \() _ -> action
 -----------------------------------------------------------------------------
 -- | https://www.w3schools.com/tags/av_event_timeupdate.asp
-onTimeUpdate ::action -> Attribute action
+onTimeUpdate :: action -> Attribute action
 onTimeUpdate action = on "timeupdate" emptyDecoder $ \() _ -> action
 -----------------------------------------------------------------------------
 -- | https://www.w3schools.com/tags/av_event_volumechange.asp
-onVolumeChange ::action -> Attribute action
+onVolumeChange :: action -> Attribute action
 onVolumeChange action = on "volumechange" emptyDecoder $ \() _ -> action
 -----------------------------------------------------------------------------
 -- | https://www.w3schools.com/tags/av_event_waiting.asp
-onWaiting ::action -> Attribute action
+onWaiting :: action -> Attribute action
 onWaiting action = on "waiting" emptyDecoder $ \() _ -> action
 -----------------------------------------------------------------------------

--- a/src/Miso/Html/Event.hs
+++ b/src/Miso/Html/Event.hs
@@ -58,7 +58,7 @@ module Miso.Html.Event
   , onPointerMove
   -- *** Media
   , onAbort
-  , onCanplay
+  , onCanPlay
   , onCanPlayThrough
   , onDurationChange
   , onEmptied
@@ -244,8 +244,8 @@ onAbort :: action -> Attribute action
 onAbort action = on "abort" emptyDecoder $ \() _ -> action
 -----------------------------------------------------------------------------
 -- | https://www.w3schools.com/tags/av_event_canplay.asp
-onCanplay :: action -> Attribute action
-onCanplay action = on "canplay" emptyDecoder $ \() _ -> action
+onCanPlay :: action -> Attribute action
+onCanPlay action = on "canplay" emptyDecoder $ \() _ -> action
 -----------------------------------------------------------------------------
 -- | https://www.w3schools.com/tags/av_event_canplaythrough.asp
 onCanPlayThrough :: action -> Attribute action

--- a/src/Miso/Html/Event.hs
+++ b/src/Miso/Html/Event.hs
@@ -56,6 +56,29 @@ module Miso.Html.Event
   , onPointerOut
   , onPointerCancel
   , onPointerMove
+  -- *** Media
+  , onAbort
+  , onCanplay
+  , onCanPlayThrough
+  , onDurationChange
+  , onEmptied
+  , onEnded
+  , onError
+  , onLoadedData
+  , onLoadedMetadata
+  , onLoadStart
+  , onPause
+  , onPlay
+  , onPlaying
+  , onProgress
+  , onRateChange
+  , onSeeked
+  , onSeeking
+  , onStalled
+  , onSuspend
+  , onTimeUpdate
+  , onVolumeChange
+  , onWaiting
   ) where
 -----------------------------------------------------------------------------
 import           Language.Javascript.JSaddle
@@ -215,4 +238,92 @@ onPointerCancel f = on "pointercancel" pointerDecoder (\action _ -> f action)
 -- | https://developer.mozilla.org/en-US/docs/Web/Events/pointermove
 onPointerMove :: (PointerEvent -> action) -> Attribute action
 onPointerMove f = on "pointermove" pointerDecoder (\action _ -> f action)
+-----------------------------------------------------------------------------
+-- | https://www.w3schools.com/tags/av_event_abort.asp
+onAbort ::action -> Attribute action
+onAbort action = on "abort" emptyDecoder $ \() _ -> action
+-----------------------------------------------------------------------------
+-- | https://www.w3schools.com/tags/av_event_canplay.asp
+onCanplay ::action -> Attribute action
+onCanplay action = on "canplay" emptyDecoder $ \() _ -> action
+-----------------------------------------------------------------------------
+-- | https://www.w3schools.com/tags/av_event_canplaythrough.asp
+onCanPlayThrough ::action -> Attribute action
+onCanPlayThrough action = on "canplaythrough" emptyDecoder $ \() _ -> action
+-----------------------------------------------------------------------------
+-- | https://www.w3schools.com/tags/av_event_duractionchange.asp
+onDurationChange ::action -> Attribute action
+onDurationChange action = on "durationchange" emptyDecoder $ \() _ -> action
+-----------------------------------------------------------------------------
+-- | https://www.w3schools.com/tags/av_event_emptied.asp
+onEmptied ::action -> Attribute action
+onEmptied action = on "emptied" emptyDecoder $ \() _ -> action
+-----------------------------------------------------------------------------
+-- | https://www.w3schools.com/tags/av_event_ended.asp
+onEnded ::action -> Attribute action
+onEnded action = on "ended" emptyDecoder $ \() _ -> action
+-----------------------------------------------------------------------------
+-- | https://www.w3schools.com/tags/av_event_error.asp
+onError ::action -> Attribute action
+onError action = on "error" emptyDecoder $ \() _ -> action
+-----------------------------------------------------------------------------
+-- | https://www.w3schools.com/tags/av_event_loaddeddata.asp
+onLoadedData ::action -> Attribute action
+onLoadedData action = on "loadeddata" emptyDecoder $ \() _ -> action
+-----------------------------------------------------------------------------
+-- | https://www.w3schools.com/tags/av_event_loadedmetadata.asp
+onLoadedMetadata ::action -> Attribute action
+onLoadedMetadata action = on "loadedmetadata" emptyDecoder $ \() _ -> action
+-----------------------------------------------------------------------------
+-- | https://www.w3schools.com/tags/av_event_loadstart.asp
+onLoadStart ::action -> Attribute action
+onLoadStart action = on "loadstart" emptyDecoder $ \() _ -> action
+-----------------------------------------------------------------------------
+-- | https://www.w3schools.com/tags/av_event_pause.asp
+onPause ::action -> Attribute action
+onPause action = on "pause" emptyDecoder $ \() _ -> action
+-----------------------------------------------------------------------------
+-- | https://www.w3schools.com/tags/av_event_play.asp
+onPlay ::action -> Attribute action
+onPlay action = on "play" emptyDecoder $ \() _ -> action
+-----------------------------------------------------------------------------
+-- | https://www.w3schools.com/tags/av_event_playing.asp
+onPlaying ::action -> Attribute action
+onPlaying action = on "playing" emptyDecoder $ \() _ -> action
+-----------------------------------------------------------------------------
+-- | https://www.w3schools.com/tags/av_event_progress.asp
+onProgress ::action -> Attribute action
+onProgress action = on "progress" emptyDecoder $ \() _ -> action
+-----------------------------------------------------------------------------
+-- | https://www.w3schools.com/tags/av_event_ratechange.asp
+onRateChange ::action -> Attribute action
+onRateChange action = on "ratechange" emptyDecoder $ \() _ -> action
+-----------------------------------------------------------------------------
+-- | https://www.w3schools.com/tags/av_event_seeked.asp
+onSeeked ::action -> Attribute action
+onSeeked action = on "seeked" emptyDecoder $ \() _ -> action
+-----------------------------------------------------------------------------
+-- | https://www.w3schools.com/tags/av_event_seeking.asp
+onSeeking ::action -> Attribute action
+onSeeking action = on "seeking" emptyDecoder $ \() _ -> action
+-----------------------------------------------------------------------------
+-- | https://www.w3schools.com/tags/av_event_stalled.asp
+onStalled ::action -> Attribute action
+onStalled action = on "stalled" emptyDecoder $ \() _ -> action
+-----------------------------------------------------------------------------
+-- | https://www.w3schools.com/tags/av_event_suspend.asp
+onSuspend ::action -> Attribute action
+onSuspend action = on "suspend" emptyDecoder $ \() _ -> action
+-----------------------------------------------------------------------------
+-- | https://www.w3schools.com/tags/av_event_timeupdate.asp
+onTimeUpdate ::action -> Attribute action
+onTimeUpdate action = on "timeupdate" emptyDecoder $ \() _ -> action
+-----------------------------------------------------------------------------
+-- | https://www.w3schools.com/tags/av_event_volumechange.asp
+onVolumeChange ::action -> Attribute action
+onVolumeChange action = on "volumechange" emptyDecoder $ \() _ -> action
+-----------------------------------------------------------------------------
+-- | https://www.w3schools.com/tags/av_event_waiting.asp
+onWaiting ::action -> Attribute action
+onWaiting action = on "waiting" emptyDecoder $ \() _ -> action
 -----------------------------------------------------------------------------

--- a/src/Miso/Html/Property.hs
+++ b/src/Miso/Html/Property.hs
@@ -75,8 +75,22 @@ module Miso.Html.Property
    , alt_
    , loading_
    , autoplay_
+   , buffered_
+   , currentTime_
+   , defaultMuted_
+   , volume_
    , controls_
    , loop_
+   , defaultPlaybackRate_
+   , mediaGroup_
+   , muted_
+   , networkState_
+   , paused_
+   , playbackRate_
+   , played_
+   , readyState_
+   , seekable_
+   , seeking_
    , preload_
    , poster_
    , default_
@@ -309,6 +323,66 @@ loading_           = textProp "loading"
 autoplay_ ::  Bool -> Attribute action
 autoplay_          = boolProp "autoplay"
 -----------------------------------------------------------------------------
+-- | <https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/buffered>
+buffered_ ::  Bool -> Attribute action
+buffered_          = boolProp "buffered"
+-----------------------------------------------------------------------------
+-- | <https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/currentTime>
+currentTime_ ::  Double -> Attribute action
+currentTime_          = doubleProp "currentTime"
+-----------------------------------------------------------------------------
+-- | <https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/defaultMuted>
+defaultMuted_ ::  Bool -> Attribute action
+defaultMuted_          = boolProp "defaultMuted"
+-----------------------------------------------------------------------------
+-- | <https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/defaultPlaybackRate>
+defaultPlaybackRate_ ::  Double -> Attribute action
+defaultPlaybackRate_          = doubleProp "defaultPlaybackRate"
+-----------------------------------------------------------------------------
+-- | <https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/mediaGroup>
+mediaGroup_ :: MisoString -> Attribute action
+mediaGroup_ = textProp "mediaGroup"
+-----------------------------------------------------------------------------
+-- | <https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/muted>
+muted_ :: Bool -> Attribute action
+muted_ = boolProp "muted"
+-----------------------------------------------------------------------------
+-- | <https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/networkState>
+networkState_ :: Bool -> Attribute action
+networkState_ = boolProp "networkState"
+-----------------------------------------------------------------------------
+-- | <https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/paused>
+paused_ :: Bool -> Attribute action
+paused_ = boolProp "paused"
+-----------------------------------------------------------------------------
+-- | <https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/playbackRate>
+playbackRate_ :: Bool -> Attribute action
+playbackRate_ = boolProp "playbackRate"
+-----------------------------------------------------------------------------
+-- | <https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/played>
+played_ :: Bool -> Attribute action
+played_ = boolProp "played"
+-----------------------------------------------------------------------------
+-- | <https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/preload>
+preload_ :: Bool -> Attribute action
+preload_ = boolProp "preload"
+-----------------------------------------------------------------------------
+-- | <https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/readyState>
+readyState_ :: Bool -> Attribute action
+readyState_ = boolProp "readyState"
+-----------------------------------------------------------------------------
+-- | <https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/seekable>
+seekable_ :: Bool -> Attribute action
+seekable_ = boolProp "seekable"
+-----------------------------------------------------------------------------
+-- | <https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/seeking>
+seeking_ :: Bool -> Attribute action
+seeking_ = boolProp "seeking"
+-----------------------------------------------------------------------------
+-- | <https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/volume>
+volume_ :: Double -> Attribute action
+volume_ = doubleProp "volume"
+-----------------------------------------------------------------------------
 -- | <https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/controls>
 controls_ ::  Bool -> Attribute action
 controls_          = boolProp "controls"
@@ -316,10 +390,6 @@ controls_          = boolProp "controls"
 -- | <https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/loop>
 loop_ ::  Bool -> Attribute action
 loop_              = boolProp "loop"
------------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/preload>
-preload_ ::  MisoString -> Attribute action
-preload_           = textProp "preload"
 -----------------------------------------------------------------------------
 -- | <https://developer.mozilla.org/en-US/docs/Web/API/HTMLVideoElement/poster>
 poster_ ::  MisoString -> Attribute action

--- a/src/Miso/Html/Property.hs
+++ b/src/Miso/Html/Property.hs
@@ -75,7 +75,6 @@ module Miso.Html.Property
    , alt_
    , loading_
    , autoplay_
-   , buffered_
    , currentTime_
    , defaultMuted_
    , volume_
@@ -318,10 +317,6 @@ loading_           = textProp "loading"
 -- | <https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/autoplay>
 autoplay_ ::  Bool -> Attribute action
 autoplay_          = boolProp "autoplay"
------------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/buffered>
-buffered_ ::  Bool -> Attribute action
-buffered_          = boolProp "buffered"
 -----------------------------------------------------------------------------
 -- | <https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/currentTime>
 currentTime_ ::  Double -> Attribute action

--- a/src/Miso/Html/Property.hs
+++ b/src/Miso/Html/Property.hs
@@ -84,10 +84,7 @@ module Miso.Html.Property
    , defaultPlaybackRate_
    , mediaGroup_
    , muted_
-   , paused_
    , playbackRate_
-   , played_
-   , readyState_
    , seekable_
    , seeking_
    , preload_
@@ -346,13 +343,9 @@ mediaGroup_ = textProp "mediaGroup"
 muted_ :: Bool -> Attribute action
 muted_ = boolProp "muted"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/paused>
-paused_ :: Bool -> Attribute action
-paused_ = boolProp "paused"
------------------------------------------------------------------------------
 -- | <https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/playbackRate>
-playbackRate_ :: Bool -> Attribute action
-playbackRate_ = boolProp "playbackRate"
+playbackRate_ :: Double -> Attribute action
+playbackRate_ = doubleProp "playbackRate"
 -----------------------------------------------------------------------------
 -- | <https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/played>
 played_ :: Bool -> Attribute action
@@ -361,10 +354,6 @@ played_ = boolProp "played"
 -- | <https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/preload>
 preload_ :: Bool -> Attribute action
 preload_ = boolProp "preload"
------------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/readyState>
-readyState_ :: Bool -> Attribute action
-readyState_ = boolProp "readyState"
 -----------------------------------------------------------------------------
 -- | <https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/seekable>
 seekable_ :: Bool -> Attribute action

--- a/src/Miso/Html/Property.hs
+++ b/src/Miso/Html/Property.hs
@@ -84,7 +84,6 @@ module Miso.Html.Property
    , defaultPlaybackRate_
    , mediaGroup_
    , muted_
-   , networkState_
    , paused_
    , playbackRate_
    , played_
@@ -346,10 +345,6 @@ mediaGroup_ = textProp "mediaGroup"
 -- | <https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/muted>
 muted_ :: Bool -> Attribute action
 muted_ = boolProp "muted"
------------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/networkState>
-networkState_ :: Bool -> Attribute action
-networkState_ = boolProp "networkState"
 -----------------------------------------------------------------------------
 -- | <https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/paused>
 paused_ :: Bool -> Attribute action

--- a/src/Miso/Html/Property.hs
+++ b/src/Miso/Html/Property.hs
@@ -347,10 +347,6 @@ muted_ = boolProp "muted"
 playbackRate_ :: Double -> Attribute action
 playbackRate_ = doubleProp "playbackRate"
 -----------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/played>
-played_ :: Bool -> Attribute action
-played_ = boolProp "played"
------------------------------------------------------------------------------
 -- | <https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/preload>
 preload_ :: MisoString -> Attribute action
 preload_ = textProp "preload"

--- a/src/Miso/Html/Property.hs
+++ b/src/Miso/Html/Property.hs
@@ -352,8 +352,8 @@ played_ :: Bool -> Attribute action
 played_ = boolProp "played"
 -----------------------------------------------------------------------------
 -- | <https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/preload>
-preload_ :: Bool -> Attribute action
-preload_ = boolProp "preload"
+preload_ :: MisoString -> Attribute action
+preload_ = stringProp "preload"
 -----------------------------------------------------------------------------
 -- | <https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/seekable>
 seekable_ :: Bool -> Attribute action

--- a/src/Miso/Html/Property.hs
+++ b/src/Miso/Html/Property.hs
@@ -84,7 +84,6 @@ module Miso.Html.Property
    , mediaGroup_
    , muted_
    , playbackRate_
-   , seekable_
    , seeking_
    , preload_
    , poster_
@@ -345,10 +344,6 @@ playbackRate_ = doubleProp "playbackRate"
 -- | <https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/preload>
 preload_ :: MisoString -> Attribute action
 preload_ = textProp "preload"
------------------------------------------------------------------------------
--- | <https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/seekable>
-seekable_ :: Bool -> Attribute action
-seekable_ = boolProp "seekable"
 -----------------------------------------------------------------------------
 -- | <https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/seeking>
 seeking_ :: Bool -> Attribute action

--- a/src/Miso/Html/Property.hs
+++ b/src/Miso/Html/Property.hs
@@ -353,7 +353,7 @@ played_ = boolProp "played"
 -----------------------------------------------------------------------------
 -- | <https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/preload>
 preload_ :: MisoString -> Attribute action
-preload_ = stringProp "preload"
+preload_ = textProp "preload"
 -----------------------------------------------------------------------------
 -- | <https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/seekable>
 seekable_ :: Bool -> Attribute action

--- a/src/Miso/Media.hs
+++ b/src/Miso/Media.hs
@@ -14,6 +14,7 @@ module Miso.Media
   ( -- *** Types
     Media        (..)
   , NetworkState (..)
+  , ReadyState   (..)
   -- *** Constructors
   , new
   -- *** Methods
@@ -37,7 +38,6 @@ module Miso.Media
   , networkState
   , paused
   , playbackRate
-  , played
   , preload
   , readyState
   , seekable
@@ -58,11 +58,21 @@ import           Miso.String
 newtype Media = Media JSVal
   deriving (ToJSVal)
 -----------------------------------------------------------------------------
+-- | https://www.w3schools.com/tags/av_prop_networkstate.asp
 data NetworkState
   = NETWORK_EMPTY
   | NETWORK_IDLE
   | NETWORK_LOADING
   | NETWORK_NO_SOURCE
+  deriving (Show, Eq, Enum)
+-----------------------------------------------------------------------------
+-- | https://www.w3schools.com/tags/av_prop_readystate.asp
+data ReadyState
+  = HAVE_NOTHING
+  | HAVE_METADATA
+  | HAVE_CURRENT_DATA
+  | HAVE_FUTURE_DATA
+  | HAVE_ENOUGH_DATA
   deriving (Show, Eq, Enum)
 -----------------------------------------------------------------------------
 -- | Smart constructor for @Media@ with 'src' element
@@ -153,24 +163,22 @@ paused (Media a) = fromJSValUnchecked =<< a ! ("paused" :: MisoString)
 playbackRate :: Media -> JSM Double
 playbackRate (Media a) = fromJSValUnchecked =<< a ! ("playbackRate" :: MisoString)
 -----------------------------------------------------------------------------
--- | https://www.w3schools.com/tags/av_prop_played.asp
-played :: Media -> JSM Double
-played (Media a) = fromJSValUnchecked =<< a ! ("played" :: MisoString)
------------------------------------------------------------------------------
 -- | https://www.w3schools.com/tags/av_prop_preload.asp
 preload :: Media -> JSM Double
 preload (Media a) = fromJSValUnchecked =<< a ! ("preload" :: MisoString)
 -----------------------------------------------------------------------------
 -- | https://www.w3schools.com/tags/av_prop_readyState.asp
-readyState :: Media -> JSM Double
-readyState (Media a) = fromJSValUnchecked =<< a ! ("readyState" :: MisoString)
+readyState :: Media -> JSM ReadyState
+readyState (Media a) = do
+  number <- fromJSValUnchecked =<< a ! ("readyState" :: MisoString)
+  pure (toEnum number)
 -----------------------------------------------------------------------------
 -- | https://www.w3schools.com/tags/av_prop_seekable.asp
-seekable :: Media -> JSM Double
+seekable :: Media -> JSM Bool
 seekable (Media a) = fromJSValUnchecked =<< a ! ("seekable" :: MisoString)
 -----------------------------------------------------------------------------
 -- | https://www.w3schools.com/tags/av_prop_seeking.asp
-seeking :: Media -> JSM Double
+seeking :: Media -> JSM Bool
 seeking (Media a) = fromJSValUnchecked =<< a ! ("seeking" :: MisoString)
 -----------------------------------------------------------------------------
 -- | https://www.w3schools.com/tags/av_met_volume.asp

--- a/src/Miso/Media.hs
+++ b/src/Miso/Media.hs
@@ -164,7 +164,7 @@ playbackRate :: Media -> JSM Double
 playbackRate (Media a) = fromJSValUnchecked =<< a ! ("playbackRate" :: MisoString)
 -----------------------------------------------------------------------------
 -- | https://www.w3schools.com/tags/av_prop_preload.asp
-preload :: Media -> JSM Double
+preload :: Media -> JSM MisoString
 preload (Media a) = fromJSValUnchecked =<< a ! ("preload" :: MisoString)
 -----------------------------------------------------------------------------
 -- | https://www.w3schools.com/tags/av_prop_readyState.asp

--- a/src/Miso/Media.hs
+++ b/src/Miso/Media.hs
@@ -109,7 +109,7 @@ controls :: Media -> JSM Bool
 controls (Media m) = fromJSValUnchecked =<< m ! ("controls" :: MisoString)
 -----------------------------------------------------------------------------
 -- | https://www.w3schools.com/tags/av_prop_currentsrc.asp
-currentSrc :: Media -> JSM Bool
+currentSrc :: Media -> JSM MisoString
 currentSrc (Media m) = fromJSValUnchecked =<< m ! ("currentSrc" :: MisoString)
 -----------------------------------------------------------------------------
 -- | https://www.w3schools.com/tags/av_prop_currenttime.asp

--- a/src/Miso/Media.hs
+++ b/src/Miso/Media.hs
@@ -121,7 +121,7 @@ defaultMuted :: Media -> JSM Bool
 defaultMuted (Media m) = fromJSValUnchecked =<< m ! ("defaultMuted" :: MisoString)
 -----------------------------------------------------------------------------
 -- | https://www.w3schools.com/tags/av_prop_defaultplaybackrate.asp
-defaultPlaybackRate :: Media -> JSM Bool
+defaultPlaybackRate :: Media -> JSM Double
 defaultPlaybackRate (Media m) = fromJSValUnchecked =<< m ! ("defaultPlaybackRate" :: MisoString)
 -----------------------------------------------------------------------------
 -- | https://www.w3schools.com/tags/av_prop_duration.asp

--- a/src/Miso/Media.hs
+++ b/src/Miso/Media.hs
@@ -39,7 +39,6 @@ module Miso.Media
   , playbackRate
   , preload
   , readyState
-  , seekable
   , seeking
   , volume
   -- *** Event Map
@@ -167,10 +166,6 @@ readyState :: Media -> JSM ReadyState
 readyState (Media a) = do
   number <- fromJSValUnchecked =<< a ! ("readyState" :: MisoString)
   pure (toEnum number)
------------------------------------------------------------------------------
--- | https://www.w3schools.com/tags/av_prop_seekable.asp
-seekable :: Media -> JSM Bool
-seekable (Media a) = fromJSValUnchecked =<< a ! ("seekable" :: MisoString)
 -----------------------------------------------------------------------------
 -- | https://www.w3schools.com/tags/av_prop_seeking.asp
 seeking :: Media -> JSM Bool

--- a/src/Miso/Media.hs
+++ b/src/Miso/Media.hs
@@ -132,7 +132,7 @@ ended :: Media -> JSM Double
 ended (Media m) = fromJSValUnchecked =<< m ! ("ended" :: MisoString)
 -----------------------------------------------------------------------------
 -- | https://www.w3schools.com/tags/av_prop_loop.asp
-loop :: Media -> JSM Double
+loop :: Media -> JSM Bool
 loop (Media m) = fromJSValUnchecked =<< m ! ("loop" :: MisoString)
 -----------------------------------------------------------------------------
 -- | https://www.w3schools.com/tags/av_prop_mediagroup.asp

--- a/src/Miso/Media.hs
+++ b/src/Miso/Media.hs
@@ -1,0 +1,179 @@
+-----------------------------------------------------------------------------
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Miso.Media
+-- Copyright   :  (C) 2016-2025 David M. Johnson
+-- License     :  BSD3-style (see the file LICENSE)
+-- Maintainer  :  David M. Johnson <code@dmj.io>
+-- Stability   :  experimental
+-- Portability :  non-portable
+----------------------------------------------------------------------------
+module Miso.Media
+  ( -- *** Types
+    Media        (..)
+  , NetworkState (..)
+  -- *** Constructors
+  , new
+  -- *** Methods
+  , canPlayType
+  , load
+  , play
+  , pause
+  -- *** Properties
+  , autoplay
+  , buffered
+  , controls
+  , currentSrc
+  , currentTime
+  , defaultMuted
+  , defaultPlaybackRate
+  , duration
+  , ended
+  , loop
+  , mediaGroup
+  , muted
+  , networkState
+  , paused
+  , playbackRate
+  , played
+  , preload
+  , readyState
+  , seekable
+  , seeking
+  , volume
+  -- *** Event Map
+  , mediaEvents
+  ) where
+-----------------------------------------------------------------------------
+import           Control.Monad
+import           Language.Javascript.JSaddle hiding (new)
+import qualified Language.Javascript.JSaddle as JS 
+-----------------------------------------------------------------------------
+import           Miso.FFI
+import           Miso.Event
+import           Miso.String
+-----------------------------------------------------------------------------
+newtype Media = Media JSVal
+  deriving (ToJSVal)
+-----------------------------------------------------------------------------
+data NetworkState
+  = NETWORK_EMPTY
+  | NETWORK_IDLE
+  | NETWORK_LOADING
+  | NETWORK_NO_SOURCE
+  deriving (Show, Eq, Enum)
+-----------------------------------------------------------------------------
+-- | Smart constructor for @Media@ with 'src' element
+new :: MisoString -> JSM Media
+new url = do
+  a <- JS.new (jsg ("Media" :: MisoString)) ([] :: [MisoString])
+  o <- makeObject a
+  set ("src" :: MisoString) url o
+  pure (Media a)
+-----------------------------------------------------------------------------
+-- | https://www.w3schools.com/tags/av_met_load.asp
+load :: Media -> JSM ()
+load (Media m) = void $ m <# ("load" :: MisoString) $ ()
+-----------------------------------------------------------------------------
+-- | https://www.w3schools.com/tags/av_met_play.asp
+play :: Media -> JSM ()
+play (Media m) = void $ m # ("play" :: MisoString) $ ()
+-----------------------------------------------------------------------------
+-- | https://www.w3schools.com/tags/av_met_pause.asp
+pause :: Media -> JSM ()
+pause (Media a) = void $ a # ("pause" :: MisoString) $ ()
+-----------------------------------------------------------------------------
+-- | https://www.w3schools.com/tags/av_met_canplaytype.asp
+canPlayType :: Media -> JSM MisoString
+canPlayType (Media m) = do
+  fromJSValUnchecked =<< do
+    m # ("canPlayType" :: MisoString) $ ()
+-----------------------------------------------------------------------------
+-- | https://www.w3schools.com/tags/av_met_buffered.asp
+buffered :: Media -> JSM Bool
+buffered (Media m) = fromJSValUnchecked =<< m ! ("buffered" :: MisoString)
+-----------------------------------------------------------------------------
+-- | https://www.w3schools.com/tags/av_met_autoplay.asp
+autoplay :: Media -> JSM Bool
+autoplay (Media m) = fromJSValUnchecked =<< m ! ("autoplay" :: MisoString)
+-----------------------------------------------------------------------------
+-- | https://www.w3schools.com/tags/av_met_controls.asp
+controls :: Media -> JSM Bool
+controls (Media m) = fromJSValUnchecked =<< m ! ("controls" :: MisoString)
+-----------------------------------------------------------------------------
+-- | https://www.w3schools.com/tags/av_prop_currentsrc.asp
+currentSrc :: Media -> JSM Bool
+currentSrc (Media m) = fromJSValUnchecked =<< m ! ("currentSrc" :: MisoString)
+-----------------------------------------------------------------------------
+-- | https://www.w3schools.com/tags/av_prop_currenttime.asp
+currentTime :: Media -> JSM Double
+currentTime (Media m) = fromJSValUnchecked =<< m ! ("currentTime" :: MisoString)
+-----------------------------------------------------------------------------
+-- | https://www.w3schools.com/tags/av_prop_defaultmuted.asp
+defaultMuted :: Media -> JSM Bool
+defaultMuted (Media m) = fromJSValUnchecked =<< m ! ("defaultMuted" :: MisoString)
+-----------------------------------------------------------------------------
+-- | https://www.w3schools.com/tags/av_prop_defaultplaybackrate.asp
+defaultPlaybackRate :: Media -> JSM Bool
+defaultPlaybackRate (Media m) = fromJSValUnchecked =<< m ! ("defaultPlaybackRate" :: MisoString)
+-----------------------------------------------------------------------------
+-- | https://www.w3schools.com/tags/av_prop_duration.asp
+duration :: Media -> JSM Double
+duration (Media m) = fromJSValUnchecked =<< m ! ("duration" :: MisoString)
+-----------------------------------------------------------------------------
+-- | https://www.w3schools.com/tags/av_prop_ended.asp
+ended :: Media -> JSM Double
+ended (Media m) = fromJSValUnchecked =<< m ! ("ended" :: MisoString)
+-----------------------------------------------------------------------------
+-- | https://www.w3schools.com/tags/av_prop_loop.asp
+loop :: Media -> JSM Double
+loop (Media m) = fromJSValUnchecked =<< m ! ("loop" :: MisoString)
+-----------------------------------------------------------------------------
+-- | https://www.w3schools.com/tags/av_prop_mediagroup.asp
+mediaGroup :: Media -> JSM MisoString
+mediaGroup (Media m) = fromJSValUnchecked =<< m ! ("mediaGroup" :: MisoString)
+-----------------------------------------------------------------------------
+-- | https://www.w3schools.com/tags/av_prop_muted.asp
+muted :: Media -> JSM Bool
+muted (Media m) = fromJSValUnchecked =<< m ! ("muted" :: MisoString)
+-----------------------------------------------------------------------------
+-- | https://www.w3schools.com/tags/av_prop_networkstate.asp
+networkState :: Media -> JSM NetworkState
+networkState (Media m) = do
+  number <- fromJSValUnchecked =<< m ! ("networkState" :: MisoString)
+  pure (toEnum number)
+-----------------------------------------------------------------------------
+-- | https://www.w3schools.com/tags/av_prop_paused.asp
+paused :: Media -> JSM Bool
+paused (Media a) = fromJSValUnchecked =<< a ! ("paused" :: MisoString)
+-----------------------------------------------------------------------------
+-- | https://www.w3schools.com/tags/av_prop_playbackRate.asp
+playbackRate :: Media -> JSM Double
+playbackRate (Media a) = fromJSValUnchecked =<< a ! ("playbackRate" :: MisoString)
+-----------------------------------------------------------------------------
+-- | https://www.w3schools.com/tags/av_prop_played.asp
+played :: Media -> JSM Double
+played (Media a) = fromJSValUnchecked =<< a ! ("played" :: MisoString)
+-----------------------------------------------------------------------------
+-- | https://www.w3schools.com/tags/av_prop_preload.asp
+preload :: Media -> JSM Double
+preload (Media a) = fromJSValUnchecked =<< a ! ("preload" :: MisoString)
+-----------------------------------------------------------------------------
+-- | https://www.w3schools.com/tags/av_prop_readyState.asp
+readyState :: Media -> JSM Double
+readyState (Media a) = fromJSValUnchecked =<< a ! ("readyState" :: MisoString)
+-----------------------------------------------------------------------------
+-- | https://www.w3schools.com/tags/av_prop_seekable.asp
+seekable :: Media -> JSM Double
+seekable (Media a) = fromJSValUnchecked =<< a ! ("seekable" :: MisoString)
+-----------------------------------------------------------------------------
+-- | https://www.w3schools.com/tags/av_prop_seeking.asp
+seeking :: Media -> JSM Double
+seeking (Media a) = fromJSValUnchecked =<< a ! ("seeking" :: MisoString)
+-----------------------------------------------------------------------------
+-- | https://www.w3schools.com/tags/av_met_volume.asp
+volume :: Media -> JSM Double
+volume (Media m) = fromJSValUnchecked =<< m ! ("volume" :: MisoString)
+-----------------------------------------------------------------------------

--- a/src/Miso/Media.hs
+++ b/src/Miso/Media.hs
@@ -24,7 +24,6 @@ module Miso.Media
   , pause
   -- *** Properties
   , autoplay
-  , buffered
   , controls
   , currentSrc
   , currentTime
@@ -100,10 +99,6 @@ canPlayType :: Media -> JSM MisoString
 canPlayType (Media m) = do
   fromJSValUnchecked =<< do
     m # ("canPlayType" :: MisoString) $ ()
------------------------------------------------------------------------------
--- | https://www.w3schools.com/tags/av_met_buffered.asp
-buffered :: Media -> JSM Bool
-buffered (Media m) = fromJSValUnchecked =<< m ! ("buffered" :: MisoString)
 -----------------------------------------------------------------------------
 -- | https://www.w3schools.com/tags/av_met_autoplay.asp
 autoplay :: Media -> JSM Bool


### PR DESCRIPTION
- [x] Adds `Miso.Media` module
- [x] Adds `miso-audio` example to README.md (@juliendehos)
- [x] `audioVideoEvents` -> `mediaEvents`
- [x] Moves `Audio` from `src/Miso/FFI.hs` into `Miso.Media`
- [x] `Audio` -> `Media`
- [x] Adds `Media` events to `src/Miso/Html/Event.hs`
- [x] Adds `Media` property getters to `src/Miso/Html/Property.hs`
- [x] Add `*with` variants that pass along `Media` object

Fleshes out media API, generalizes to support video as well.

cc @juliendehos 