### PR TITLE
Media: fix `load` and some broken links

### DIFF
--- a/src/Miso/Html/Event.hs
+++ b/src/Miso/Html/Event.hs
@@ -286,19 +286,17 @@ onCanPlayThrough action = on "canplaythrough" emptyDecoder $ \() _ -> action
 onCanPlayThroughWith :: (Media -> action) -> Attribute action
 onCanPlayThroughWith action = on "canplaythrough" emptyDecoder $ \() -> action . Media
 -----------------------------------------------------------------------------
--- | https://www.w3schools.com/tags/av_event_duractionchange.asp
+-- | https://www.w3schools.com/tags/av_event_durationchange.asp
 onDurationChange :: action -> Attribute action
 onDurationChange action = on "durationchange" emptyDecoder $ \() _ -> action
 -----------------------------------------------------------------------------
--- | https://www.w3schools.com/tags/av_event_duractionchange.asp
+-- | https://www.w3schools.com/tags/av_event_durationchange.asp
 onDurationChangeWith :: (Media -> action) -> Attribute action
 onDurationChangeWith action = on "durationchange" emptyDecoder $ \() -> action . Media
 -----------------------------------------------------------------------------
--- | https://www.w3schools.com/tags/av_event_emptied.asp
 onEmptied :: action -> Attribute action
 onEmptied action = on "emptied" emptyDecoder $ \() _ -> action
 -----------------------------------------------------------------------------
--- | https://www.w3schools.com/tags/av_event_emptied.asp
 onEmptiedWith :: (Media -> action) -> Attribute action
 onEmptiedWith action = on "emptied" emptyDecoder $ \() -> action . Media
 -----------------------------------------------------------------------------
@@ -318,11 +316,11 @@ onError action = on "error" emptyDecoder $ \() _ -> action
 onErrorWith :: (Media -> action) -> Attribute action
 onErrorWith action = on "error" emptyDecoder $ \() -> action . Media
 -----------------------------------------------------------------------------
--- | https://www.w3schools.com/tags/av_event_loaddeddata.asp
+-- | https://www.w3schools.com/tags/av_event_loadeddata.asp
 onLoadedData :: action -> Attribute action
 onLoadedData action = on "loadeddata" emptyDecoder $ \() _ -> action
 -----------------------------------------------------------------------------
--- | https://www.w3schools.com/tags/av_event_loaddeddata.asp
+-- | https://www.w3schools.com/tags/av_event_loadeddata.asp
 onLoadedDataWith :: (Media -> action) -> Attribute action
 onLoadedDataWith action = on "loadeddata" emptyDecoder $ \() -> action . Media
 -----------------------------------------------------------------------------

--- a/src/Miso/Media.hs
+++ b/src/Miso/Media.hs
@@ -83,7 +83,7 @@ new url = do
 -----------------------------------------------------------------------------
 -- | https://www.w3schools.com/tags/av_met_load.asp
 load :: Media -> JSM ()
-load (Media m) = void $ m <# ("load" :: MisoString) $ ()
+load (Media m) = void $ m # ("load" :: MisoString) $ ()
 -----------------------------------------------------------------------------
 -- | https://www.w3schools.com/tags/av_met_play.asp
 play :: Media -> JSM ()
@@ -99,11 +99,11 @@ canPlayType (Media m) = do
   fromJSValUnchecked =<< do
     m # ("canPlayType" :: MisoString) $ ()
 -----------------------------------------------------------------------------
--- | https://www.w3schools.com/tags/av_met_autoplay.asp
+-- | https://www.w3schools.com/tags/av_prop_autoplay.asp
 autoplay :: Media -> JSM Bool
 autoplay (Media m) = fromJSValUnchecked =<< m ! ("autoplay" :: MisoString)
 -----------------------------------------------------------------------------
--- | https://www.w3schools.com/tags/av_met_controls.asp
+-- | https://www.w3schools.com/tags/av_prop_controls.asp
 controls :: Media -> JSM Bool
 controls (Media m) = fromJSValUnchecked =<< m ! ("controls" :: MisoString)
 -----------------------------------------------------------------------------
@@ -171,7 +171,7 @@ readyState (Media a) = do
 seeking :: Media -> JSM Bool
 seeking (Media a) = fromJSValUnchecked =<< a ! ("seeking" :: MisoString)
 -----------------------------------------------------------------------------
--- | https://www.w3schools.com/tags/av_met_volume.asp
+-- | https://www.w3schools.com/tags/av_prop_volume.asp
 volume :: Media -> JSM Double
 volume (Media m) = fromJSValUnchecked =<< m ! ("volume" :: MisoString)
 -----------------------------------------------------------------------------


### PR DESCRIPTION
- fix a bug in the `Miso.Media.load` function
- fix some broken links in `Miso.Media` and `Miso.Html.Event` docs
- remove links for the `emptied` event since the page is missing