### PR TITLE
Revert `subKey` polymorphism.

### DIFF
--- a/examples/components/Main.hs
+++ b/examples/components/Main.hs
@@ -110,6 +110,9 @@ viewModel1 x =
 data LoggerSub = LoggerSub
   deriving (Eq, Ord)
 
+instance ToMisoString LoggerSub where
+  toMisoString LoggerSub = "LoggerSub"
+
 -- | Updates model, optionally introduces side effects
 updateModel1 :: MainAction -> Effect MainModel MainAction
 updateModel1 StartLogger = startSub LoggerSub (loggerSub "main-app")


### PR DESCRIPTION
- [x] `Ord key => key` -> `ToMisoString s => s`
- [x] Uses `MisoString` internally for `componentSubThreads`

This avoids unnecessary polymorphism when using the global variable trick.