### PR TITLE
Add `@keyframes` animation and `@media` query support to `Miso.Style`

### DIFF
--- a/examples/simple/Main.hs
+++ b/examples/simple/Main.hs
@@ -4,11 +4,12 @@
 -----------------------------------------------------------------------------
 module Main where
 -----------------------------------------------------------------------------
-import           Prelude hiding (unlines)
+import           Prelude hiding (unlines, rem)
 -----------------------------------------------------------------------------
-import           Miso
+import           Miso hiding (media_)
 import           Miso.Lens
 import           Miso.String
+import           Miso.Style hiding (ms)
 -----------------------------------------------------------------------------
 newtype Model = Model { _value :: Int }
   deriving (Show, Eq)
@@ -32,7 +33,7 @@ foreign export javascript "hs_start" main :: IO ()
 main :: IO ()
 main = run $ startComponent app
   { events = pointerEvents
-  , styles = [ Style css ]
+  , styles = [ Sheet sheet ]
   }
 -----------------------------------------------------------------------------
 app :: Component name Model Action
@@ -75,94 +76,101 @@ viewModel x = div_
     ]
   ]
 -----------------------------------------------------------------------------
-css :: MisoString
-css = unlines
-  [ ":root {"
-  , "--primary-color: #4a6bff;"
-  , "--primary-hover: #3451d1;"
-  , "--secondary-color: #ff4a6b;"
-  , "--secondary-hover: #d13451;"
-  , "--background: #f7f9fc;"
-  , "--text-color: #333;"
-  , "--shadow: 0 4px 10px rgba(0, 0, 0, 0.1);"
-  , "--transition: all 0.3s ease;"
-  , "}"
-  , "body {"
-  , "  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;"
-  , "  display: flex;"
-  , "  justify-content: center;"
-  , "  align-items: center;"
-  , "  height: 100vh;"
-  , "  margin: 0;"
-  , "  background-color: var(--background);"
-  , "  color: var(--text-color);"
-  , "}"
-  , ".counter-container {"
-  , "  background-color: white;"
-  , "  padding: 2rem;"
-  , "  border-radius: 12px;"
-  , "  box-shadow: var(--shadow);"
-  , "  text-align: center;"
-  , "}"
-  , ".counter-display {"
-  , "  font-size: 5rem;"
-  , "  font-weight: bold;"
-  , "  margin: 1rem 0;"
-  , "  transition: var(--transition);"
-  , "}"
-  , ".buttons-container {"
-  , "  display: flex;"
-  , "  gap: 1rem;"
-  , "  justify-content: center;"
-  , "  margin-top: 1.5rem;"
-  , "}"
-  , "button {"
-  , "  font-size: 1.5rem;"
-  , "  width: 3rem;"
-  , "  height: 3rem;"
-  , "  border: none;"
-  , "  border-radius: 50%;"
-  , "  cursor: pointer;"
-  , "  transition: var(--transition);"
-  , "  color: white;"
-  , "  display: flex;"
-  , "  align-items: center;"
-  , "  justify-content: center;"
-  , "}"
-  , ".increment-btn {"
-  , "  background-color: var(--primary-color);"
-  , "}"
-  , ".increment-btn:hover {"
-  , "  background-color: var(--primary-hover);"
-  , "  transform: translateY(-2px);"
-  , "}"
-  , ".decrement-btn {"
-  , "  background-color: var(--secondary-color);"
-  , "}"
-  , ".decrement-btn:hover {"
-  , "  background-color: var(--secondary-hover);"
-  , "  transform: translateY(-2px);"
-  , "}"
-  , "@keyframes pulse {"
-  , "  0% { transform: scale(1); }"
-  , "  50% { transform: scale(1.1); }"
-  , "  100% { transform: scale(1); }"
-  , "}"
-  , ".counter-display.animate {"
-  , "  animation: pulse 0.3s ease;"
-  , "}"
-  , "@media (max-width: 480px) {"
-  , "  .counter-container {"
-  , "    padding: 1.5rem;"
-  , "  }"
-  , "  .counter-display {"
-  , "    font-size: 3rem;"
-  , "  }"
-  , "  button {"
-  , "    font-size: 1.2rem;"
-  , "    width: 2.5rem;"
-  , "    height: 2.5rem;"
-  , "  }"
-  , "}"
+sheet :: StyleSheet
+sheet =
+  sheet_
+  [ selector_ ":root"
+    [ "--primary-color" =: "#4a6bff"
+    , "--primary-hover" =: "#3451d1"
+    , "--secondary-color" =: "#ff4a6b"
+    , "--secondary-hover" =: "#d13451"
+    , "--background" =: "#f7f9fc"
+    , "--text-color" =: "#333"
+    , "--shadow" =: "0 4px 10px rgba(0, 0, 0, 0.1);"
+    , "--transition" =: "all 0.3s ease;"
+    ]
+  , selector_ "body"
+    [ fontFamily "'Segoe UI', Tahoma, Geneva, Verdana, sans-serif"
+    , display "flex"
+    , justifyContent "center"
+    , alignItems "center"
+    , height "100vh"
+    , margin "0"
+    , backgroundColor (var "background")
+    , color (var "text-color")
+    ]
+  , selector_ ".counter-container"
+    [ backgroundColor white
+    , padding (rem 2)
+    , borderRadius (px 12)
+    , boxShadow "shadow"
+    , textAlign "center"
+    ]
+  , selector_ ".counter-display"
+    [ fontSize "5rem"
+    , fontWeight "bold"
+    , margin "1rem 0"
+    , transition "var(--transition)"
+    ]
+  , selector_ ".buttons-container"
+    [ display "flex"
+    , gap "1rem"
+    , justifyContent "center"
+    , marginTop "1.5rem"
+    ]
+  , selector_ "button"
+    [ fontSize "1.5rem"
+    , width "3rem"
+    , height "3rem"
+    , border "none"
+    , borderRadius "50%"
+    , cursor "pointer"
+    , transition "var(--transition)"
+    , color white
+    , display "flex"
+    , alignItems "center"
+    , justifyContent "center"
+    ]
+  , selector_ ".increment-btn"
+    [ backgroundColor (var "primary-color")
+    ]
+  , selector_ ".increment-btn:hover"
+    [ backgroundColor (var "primary-hover")
+    , transform "translateY(-2px)"
+    ]
+  , selector_ ".decrement-btn"
+    [ backgroundColor (var "secondary-color")
+    ]
+  , selector_ ".decrement-btn:hover"
+    [ backgroundColor (var "secondary-hover")
+    , transform "translateY(-2px)"
+    ]
+  , keyframes_ "pulse"
+    [ pct 0 =:
+      [ transform "scale(1)"
+      ]
+    , pct 50 =:
+      [ transform "scale(1.1)"
+      ]
+    , pct 100 =:
+      [ transform "scale(1)"
+      ]
+    ]
+  , selector_ ".counter-display.animate"
+    [ animation "pulse 0.3s ease"
+    ]
+  , media_ "(max-width: 480px)"
+    [ ".counter-container" =:
+      [ padding (rem 1.5)
+      ]
+    , ".counter-display" =:
+      [ fontSize (rem 3)
+      ]
+    , "button" =:
+      [ fontSize (rem 1.2)
+      , width (rem 2.5)
+      , width (rem 2.5)
+      ]
+    ]
   ]
 -----------------------------------------------------------------------------

--- a/miso.cabal
+++ b/miso.cabal
@@ -161,6 +161,7 @@ library
     Miso.String
     Miso.Style
     Miso.Style.Color
+    Miso.Style.Types
     Miso.Types
     Miso.Util
     Miso.Util.Lexer

--- a/src/Miso/Internal.hs
+++ b/src/Miso/Internal.hs
@@ -65,6 +65,7 @@ import           Miso.Exception (MisoException(..), exception)
 import qualified Miso.FFI.Internal as FFI
 import           Miso.String hiding (reverse)
 import           Miso.Types
+import           Miso.Style (renderStyleSheet)
 import           Miso.Event (Events)
 import           Miso.Property (textProp)
 import           Miso.Effect (Sub, Sink, Effect, runEffect, io_)
@@ -455,6 +456,7 @@ renderStyles styles =
   forM_ styles $ \case
     Href url -> FFI.addStyleSheet url
     Style css -> FFI.addStyle css
+    Sheet sheet -> FFI.addStyle (renderStyleSheet sheet)
 -----------------------------------------------------------------------------
 -- | Starts a named 'Sub' dynamically, during the life of a 'Component'.
 -- The 'Sub' can be stopped by calling @Ord subKey => stop subKey@ from the 'update' function.

--- a/src/Miso/Style.hs
+++ b/src/Miso/Style.hs
@@ -18,6 +18,7 @@ module Miso.Style
   , style_
   , styleInline_
   , sheet_
+  , selector_
   , (=:)
     -- *** Render
   , renderStyleSheet
@@ -214,9 +215,10 @@ module Miso.Style
   , em
   , s
   , ms
+  -- *** Animations
+  , keyframes
   ) where
 -----------------------------------------------------------------------------
-import           Data.Map (Map)
 import qualified Data.Map as M
 import           Miso.String (MisoString)
 import qualified Miso.String as MS
@@ -228,46 +230,46 @@ import qualified Miso.Types as MT
 import           Prelude hiding (filter, rem)
 -----------------------------------------------------------------------------
 pt :: Double -> MisoString
-pt x = ms x <> "pt"
+pt x = MS.ms x <> "pt"
 -----------------------------------------------------------------------------
 px :: Double -> MisoString
-px x = ms x <> "px"
+px x = MS.ms x <> "px"
 -----------------------------------------------------------------------------
 deg :: Double -> MisoString
-deg x = ms x <> "deg"
+deg x = MS.ms x <> "deg"
 -----------------------------------------------------------------------------
 turn :: Double -> MisoString
-turn x = ms x <> "turn"
+turn x = MS.ms x <> "turn"
 -----------------------------------------------------------------------------
 rad :: Double -> MisoString
-rad x = ms x <> "rad"
+rad x = MS.ms x <> "rad"
 -----------------------------------------------------------------------------
 rpx :: Double -> MisoString
-rpx x = ms x <> "rpx"
+rpx x = MS.ms x <> "rpx"
 -----------------------------------------------------------------------------
 rem :: Double -> MisoString
-rem x = ms x <> "rem"
+rem x = MS.ms x <> "rem"
 -----------------------------------------------------------------------------
 em :: Double -> MisoString
-em x = ms x <> "em"
+em x = MS.ms x <> "em"
 -----------------------------------------------------------------------------
 vh :: Double -> MisoString
-vh x = ms x <> "vh"
+vh x = MS.ms x <> "vh"
 -----------------------------------------------------------------------------
 vw :: Double -> MisoString
-vw x = ms x <> "vw"
+vw x = MS.ms x <> "vw"
 -----------------------------------------------------------------------------
 s :: Double -> MisoString
-s x = ms x <> "s"
+s x = MS.ms x <> "s"
 -----------------------------------------------------------------------------
 ms :: Double -> MisoString
-ms x = ms x <> "ms"
+ms x = MS.ms x <> "ms"
 -----------------------------------------------------------------------------
 pct :: Double -> MisoString
-pct x = ms x <> "%"
+pct x = MS.ms x <> "%"
 -----------------------------------------------------------------------------
 ppx :: Double -> MisoString
-ppx x = ms x <> "ppx"
+ppx x = MS.ms x <> "ppx"
 -----------------------------------------------------------------------------
 -- | Smart constructor for Attributes. This function is helpful when
 -- constructing 'Style'.
@@ -287,7 +289,21 @@ type Style = (MisoString, MisoString)
 -----------------------------------------------------------------------------
 -- | Type for a @Map@ of CSS 'Style'. Used with @StyleSheet@.
 -- It maps CSS properties to their values.
-type Styles = Map MisoString MisoString
+data Styles
+  = Styles (MisoString, [Style])
+  | KeyFrame MisoString [(MisoString, [Style])]
+-----------------------------------------------------------------------------
+-- | Used when constructing a 'StyleSheet'
+-- @
+-- sheet_
+--   [ selector_ ".name"
+--     [ backgroundColor red
+--     , alignContent "top"
+--     ]
+--   ]
+-- @
+selector_ :: MisoString -> [Style] -> Styles
+selector_ k v = Styles (k,v)
 -----------------------------------------------------------------------------
 -- | Type for a CSS style on native.
 -- Internally it maps From CSS selectors to 'Styles'.
@@ -296,23 +312,35 @@ type Styles = Map MisoString MisoString
 -- testSheet :: StyleSheet
 -- testSheet =
 --   sheet_
---   [ ".name" =:
---       style_
---       [ backgroundColor "red"
+--   [ selector ".name"
+--       [ backgroundColor red
 --       , alignContent "top"
 --       ]
---   , "#container" =:
---       style_
---       [ backgroundColor "blue"
+--   , selector "#container"
+--       [ backgroundColor blue
 --       , alignContent "center"
 --       ]
+--   , keyframes "slide-in"
+--     [ "from" =:
+--       [ transform "translateX(0%)"
+--       ]
+--     , "to" =:
+--       [ transform "translateX(100%)"
+--       , backgroundColor red
+--       , backgroundSize "10px"
+--       , backgroundRepeat "true"
+--       ]
+--     , pct 10 =:
+--       [ "foo" =: "bar"
+--       ]
+--     ]
 --   ]
 -- @
 --
-newtype StyleSheet = StyleSheet { getStyleSheet :: Map MisoString Styles }
+newtype StyleSheet = StyleSheet { getStyleSheet :: [Styles] }
 -----------------------------------------------------------------------------
-sheet_ :: [(MisoString, Styles)] -> StyleSheet
-sheet_ = StyleSheet . M.fromList
+sheet_ :: [Styles] -> StyleSheet
+sheet_ = StyleSheet
 -----------------------------------------------------------------------------
 -- | @style_@ is an attribute that will set the @style@
 -- attribute of the associated DOM node to @attrs@.
@@ -336,22 +364,57 @@ styleInline_ ::  MisoString -> Attribute action
 styleInline_ = textProp "style"
 -----------------------------------------------------------------------------
 -- | Renders a 'Styles' to a 'MisoString'
-renderStyles :: Styles -> MisoString
-renderStyles m = MS.unlines
-  [ mconcat [ indent, k, ":", v, ";" ]
-  | let indent = "  "
-  , (k,v) <- M.toList m
+renderStyles :: Int -> Styles -> MisoString
+renderStyles indent (Styles (sel,styles)) = MS.unlines
+  [ sel <> " {" <> MS.replicate indent " "
+  , MS.intercalate "\n"
+        [ mconcat
+          [ MS.replicate (indent + 2) " " <> k
+          , " : "
+          , v
+          , ";"
+          ]
+        | (k,v) <- styles
+        ]
+  , MS.replicate indent " " <> "}"
+  ]
+renderStyles indent (KeyFrame name frames) = MS.intercalate " "
+  [ "@keyframes"
+  , name
+  , "{\n"
+  , MS.intercalate "\n  "
+    [ renderStyles (indent + 2) (Styles frame)
+    | frame <- frames
+    ]
   ]
 -----------------------------------------------------------------------------
 renderStyleSheet :: StyleSheet -> MisoString
-renderStyleSheet styleSheet = mconcat
-  [ MS.unlines
-    [ selector
-    , "{"
-    , renderStyles styles <> "}"
-    ]
-  | (selector, styles) <- M.toList (getStyleSheet styleSheet)
+renderStyleSheet styleSheet = MS.intercalate "\n"
+  [ renderStyles 0 styles
+  | styles <- getStyleSheet styleSheet
   ]
+-----------------------------------------------------------------------------
+-- | https://developer.mozilla.org/en-US/docs/Web/CSS/@keyframes
+-- @
+-- testKeyFrame :: Styles
+-- testKeyFrame = keyframes "slide-in"
+--   [ "from" =:
+--       [ transform "translateX(0%)"
+--       ]
+--   , "to" =:
+--       [ transform "translateX(100%)"
+--       , backgroundColor red
+--       , backgroundSize "10px"
+--       , backgroundRepeat "true"
+--       ]
+--   , pct 10 =:
+--     [ "foo" =: "bar"
+--     ]
+--  ]
+-- @
+--
+keyframes :: MisoString -> [(MisoString, [Style])] -> Styles
+keyframes = KeyFrame
 -----------------------------------------------------------------------------
 --
 -- > style_ [ alignContent =: "value" ]

--- a/src/Miso/Style.hs
+++ b/src/Miso/Style.hs
@@ -295,6 +295,7 @@ data Styles
   = Styles (MisoString, [Style])
   | KeyFrame MisoString [(MisoString, [Style])]
   | Media MisoString [(MisoString, [Style])]
+  deriving (Eq, Show)
 -----------------------------------------------------------------------------
 -- | Used when constructing a 'StyleSheet'
 -- @
@@ -347,6 +348,7 @@ selector_ k v = Styles (k,v)
 --    ]
 -- @
 newtype StyleSheet = StyleSheet { getStyleSheet :: [Styles] }
+  deriving (Eq, Show)
 -----------------------------------------------------------------------------
 sheet_ :: [Styles] -> StyleSheet
 sheet_ = StyleSheet

--- a/src/Miso/Style.hs
+++ b/src/Miso/Style.hs
@@ -11,10 +11,8 @@
 -----------------------------------------------------------------------------
 module Miso.Style
   ( -- *** Types
-    Style
-  , Styles
-  , StyleSheet
-    -- *** Smart Constructor
+    module Miso.Style.Types
+  -- *** Smart Constructor
   , style_
   , styleInline_
   , sheet_
@@ -226,6 +224,7 @@ import qualified Data.Map as M
 import           Miso.String (MisoString)
 import qualified Miso.String as MS
 import           Miso.Style.Color
+import           Miso.Style.Types
 import           Miso.Property
 import           Miso.Types (Attribute)
 import qualified Miso.Types as MT
@@ -286,18 +285,6 @@ ppx x = MS.ms x <> "ppx"
 (=:) :: k -> v -> (k, v)
 k =: v = (k,v)
 -----------------------------------------------------------------------------
--- | Type for a CSS 'Style'
---
-type Style = (MisoString, MisoString)
------------------------------------------------------------------------------
--- | Type for a @Map@ of CSS 'Style'. Used with @StyleSheet@.
--- It maps CSS properties to their values.
-data Styles
-  = Styles (MisoString, [Style])
-  | KeyFrame MisoString [(MisoString, [Style])]
-  | Media MisoString [(MisoString, [Style])]
-  deriving (Eq, Show)
------------------------------------------------------------------------------
 -- | Used when constructing a 'StyleSheet'
 -- @
 -- sheet_
@@ -309,47 +296,6 @@ data Styles
 -- @
 selector_ :: MisoString -> [Style] -> Styles
 selector_ k v = Styles (k,v)
------------------------------------------------------------------------------
--- | Type for a CSS style on native.
--- Internally it maps From CSS selectors to 'Styles'.
--- @
--- testSheet :: StyleSheet
--- testSheet =
---    sheet_
---    [ selector_ ".name"
---        [ backgroundColor red
---        , alignContent "top"
---        ]
---    , selector_ "#container"
---        [ backgroundColor blue
---        , alignContent "center"
---        ]
---    , keyframes_ "slide-in"
---      [ "from" =:
---        [ transform "translateX(0%)"
---        ]
---      , "to" =:
---        [ transform "translateX(100%)"
---        , backgroundColor red
---        , backgroundSize "10px"
---        , backgroundRepeat "true"
---        ]
---      , pct 10 =:
---        [ "foo" =: "bar"
---        ]
---      ]
---    , media_ "screen and (min-width: 480px)"
---      [ "header" =:
---        [ height "auto"
---        ]
---      , "ul" =:
---        [ display "block"
---        ]
---      ]
---    ]
--- @
-newtype StyleSheet = StyleSheet { getStyleSheet :: [Styles] }
-  deriving (Eq, Show)
 -----------------------------------------------------------------------------
 sheet_ :: [Styles] -> StyleSheet
 sheet_ = StyleSheet

--- a/src/Miso/Style.hs
+++ b/src/Miso/Style.hs
@@ -86,6 +86,7 @@ module Miso.Style
   , color
   , columnGap
   , cssVariable
+  , cursor
   , direction
   , display
   , filter
@@ -914,6 +915,12 @@ fontStyle x = "font-style" =: x
 --
 fontWeight :: MisoString -> Style
 fontWeight x = "font-weight" =: x
+-----------------------------------------------------------------------------
+--
+-- > style_ [ cursor =: "pointer" ]
+--
+cursor :: MisoString -> Style
+cursor x = "cursor" =: x
 -----------------------------------------------------------------------------
 --
 -- > style_ [ gap =: "value" ]

--- a/src/Miso/Style/Color.hs
+++ b/src/Miso/Style/Color.hs
@@ -16,6 +16,7 @@ module Miso.Style.Color
   , rgba
   , hsl
   , hex
+  , var
     -- *** Render
   , renderColor
     -- *** Colors
@@ -178,6 +179,7 @@ data Color
   = RGBA Int Int Int Double
   | HSL Int Int Int
   | Hex MisoString
+  | VarColor MisoString
   deriving (Show, Eq)
 -----------------------------------------------------------------------------
 renderColor :: Color -> MisoString
@@ -197,6 +199,10 @@ renderColor (HSL h s l) = "hsl(" <> values <> ")"
       , MS.ms l
       ]
 renderColor (Hex s) = "#" <> s
+renderColor (VarColor n) = "var(--" <> n <> ")"
+-----------------------------------------------------------------------------
+var :: MisoString -> Color
+var = VarColor
 -----------------------------------------------------------------------------
 rgba :: Int -> Int -> Int -> Double -> Color
 rgba = RGBA

--- a/src/Miso/Style/Types.hs
+++ b/src/Miso/Style/Types.hs
@@ -1,0 +1,71 @@
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Miso.Style.Types
+-- Copyright   :  (C) 2016-2025 David M. Johnson (@dmjio)
+-- License     :  BSD3-style (see the file LICENSE)
+-- Maintainer  :  David M. Johnson <code@dmj.io>
+-- Stability   :  experimental
+-- Portability :  non-portable
+----------------------------------------------------------------------------
+module Miso.Style.Types
+  ( -- *** Types
+    Style
+  , Styles (..)
+  , StyleSheet (..)
+  ) where
+-----------------------------------------------------------------------------
+import Miso.String (MisoString)
+-----------------------------------------------------------------------------
+-- | Type for a CSS style on native.
+-- Internally it maps From CSS selectors to 'Styles'.
+-- @
+-- testSheet :: StyleSheet
+-- testSheet =
+--    sheet_
+--    [ selector_ ".name"
+--        [ backgroundColor red
+--        , alignContent "top"
+--        ]
+--    , selector_ "#container"
+--        [ backgroundColor blue
+--        , alignContent "center"
+--        ]
+--    , keyframes_ "slide-in"
+--      [ "from" =:
+--        [ transform "translateX(0%)"
+--        ]
+--      , "to" =:
+--        [ transform "translateX(100%)"
+--        , backgroundColor red
+--        , backgroundSize "10px"
+--        , backgroundRepeat "true"
+--        ]
+--      , pct 10 =:
+--        [ "foo" =: "bar"
+--        ]
+--      ]
+--    , media_ "screen and (min-width: 480px)"
+--      [ "header" =:
+--        [ height "auto"
+--        ]
+--      , "ul" =:
+--        [ display "block"
+--        ]
+--      ]
+--    ]
+-- @
+newtype StyleSheet = StyleSheet { getStyleSheet :: [Styles] }
+  deriving (Eq, Show)
+-----------------------------------------------------------------------------
+-- | Type for a CSS 'Style'
+--
+type Style = (MisoString, MisoString)
+-----------------------------------------------------------------------------
+-- | Type for a @Map@ of CSS 'Style'. Used with @StyleSheet@.
+-- It maps CSS properties to their values.
+data Styles
+  = Styles (MisoString, [Style])
+  | KeyFrame MisoString [(MisoString, [Style])]
+  | Media MisoString [(MisoString, [Style])]
+  deriving (Eq, Show)
+-----------------------------------------------------------------------------

--- a/src/Miso/Types.hs
+++ b/src/Miso/Types.hs
@@ -63,7 +63,7 @@ import           Servant.API (HasLink(MkLink, toLink))
 import           Miso.Effect (Effect, Sub, Sink)
 import           Miso.Event.Types
 import           Miso.String (MisoString, toMisoString, ms)
-import           Miso.Style (StyleSheet)
+import           Miso.Style.Types (StyleSheet)
 -----------------------------------------------------------------------------
 -- | Application entry point
 data Component (name :: Symbol) model action = Component

--- a/src/Miso/Types.hs
+++ b/src/Miso/Types.hs
@@ -63,6 +63,7 @@ import           Servant.API (HasLink(MkLink, toLink))
 import           Miso.Effect (Effect, Sub, Sink)
 import           Miso.Event.Types
 import           Miso.String (MisoString, toMisoString, ms)
+import           Miso.Style (StyleSheet)
 -----------------------------------------------------------------------------
 -- | Application entry point
 data Component (name :: Symbol) model action = Component
@@ -106,6 +107,8 @@ data CSS
   -- ^ 'Href' is a URL meant to link to hosted CSS
   | Style MisoString
   -- ^ 'Style' is meant to be raw CSS in a 'style_' tag
+  | Sheet StyleSheet
+  -- ^ 'Sheet' is meant to be CSS built with 'Miso.Style'
   deriving (Show, Eq)
 -----------------------------------------------------------------------------
 -- | Convenience for extracting mount point


### PR DESCRIPTION
- [x] Adds `keyframes_` and `media_` support
- [x] Addresses naming collision w/ `ms`
- [x] Parameterizes renderStyles by indentation level
- [x] Adds `selector_` combinator when operating in `StyleSheet`
- [x] Adds `Sheet` constructor
- [x] Updates `simple/` example to use the new API

```haskell
testSheet :: StyleSheet
testSheet =
  sheet_
  [ selector_ ".name"
      [ backgroundColor red
      , alignContent "top"
      ]
  , selector_ "#container"
      [ backgroundColor blue
      , alignContent "center"
      ]
  , keyframes_ "slide-in"
    [ "from" =:
      [ transform "translateX(0%)"
      ]
    , "to" =:
      [ transform "translateX(100%)"
      , backgroundColor red
      , backgroundSize "10px"
      , backgroundRepeat "true"
      ]
    , pct 10 =:
      [ "foo" =: "bar"
      ]
    ]
  ]
  ```
  
  ```bash
  λ> putStrLn $ MS.unpack (renderStyleSheet testSheet)
.name {
  background-color : rgba(255,0,0,1.0);
  align-content : top;
}

#container {
  background-color : rgba(0,0,255,1.0);
  align-content : center;
}

@keyframes slide-in {
 from {
    transform : translateX(0%);
  }

  to {
    transform : translateX(100%);
    background-color : rgba(255,0,0,1.0);
    background-size : 10px;
    background-repeat : true;
  }

  10.0% {
    foo : bar;
  }
 }
 ```