### PR TITLE
Add `Miso.State`

### DIFF
--- a/miso.cabal
+++ b/miso.cabal
@@ -146,6 +146,7 @@ library
     Miso.Render
     Miso.Router
     Miso.Run
+    Miso.State
     Miso.Subscription
     Miso.Subscription.History
     Miso.Subscription.Keyboard

--- a/src/Miso.hs
+++ b/src/Miso.hs
@@ -68,18 +68,11 @@ module Miso
     -- * FFI
   , module Miso.FFI
     -- * State management
-  , ask
-  , modify
-  , modify'
-  , get
-  , gets
-  , put
-  , tell
+  , module Miso.State
   ) where
 -----------------------------------------------------------------------------
 import           Control.Monad (void)
 import           Control.Monad.IO.Class (liftIO)
-import           Control.Monad.RWS (get, gets, modify, modify', tell, put, ask)
 import           Data.IORef (newIORef, IORef)
 import           Language.Javascript.JSaddle (Object(Object), JSM)
 #ifndef GHCJS_BOTH
@@ -100,6 +93,7 @@ import           Miso.Property
 import           Miso.Render
 import           Miso.Router
 import           Miso.Run
+import           Miso.State
 import           Miso.Storage
 import           Miso.String (MisoString)
 import           Miso.Subscription

--- a/src/Miso/State.hs
+++ b/src/Miso/State.hs
@@ -1,0 +1,36 @@
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Miso.State
+-- Copyright   :  (C) 2016-2025 David M. Johnson (@dmjio)
+-- License     :  BSD3-style (see the file LICENSE)
+-- Maintainer  :  David M. Johnson <code@dmj.io>
+-- Stability   :  experimental
+-- Portability :  non-portable
+--
+-- Similar to how one manages state in [React](https://react.dev/learn/managing-state),
+-- `miso` applications manage state with the 'State' monad.
+--
+-- The 'State' 'Monad' works well with `MonadState` lenses as seen in 'Miso.Lens' and the 'lens' library.
+--
+-- @
+-- updateModel :: Action -> Effect Model Action
+-- updateModel (AddOne event) = do
+--   modify (+1)
+--   io_ (consoleLog "Added One!")
+-- @
+--
+-- This module re-exports select combinators from 'Control.Monad.RWS' and serves as a placeholder to add new state management combinators.
+--
+----------------------------------------------------------------------------
+module Miso.State
+  ( ask
+  , modify
+  , modify'
+  , get
+  , gets
+  , put
+  , tell
+  ) where
+----------------------------------------------------------------------------
+import Control.Monad.RWS (get, gets, modify, modify', tell, put, ask)
+----------------------------------------------------------------------------


### PR DESCRIPTION
This is done to clean up `src/Miso.hs` re-export list. Also serves as a placeholder to add new combinators (unrelated to lenses).

- [x] Creates placeholder module to re-export `Control.Monad.RWS` from `src/Miso/State.hs`
- [x] Adds `Miso.State` module, re-exports from `src/Miso.hs`
- [x] Light haddocking