### PR TITLE
Update test for attribute removal.

### DIFF
--- a/ts/spec/dom.spec.ts
+++ b/ts/spec/dom.spec.ts
@@ -264,22 +264,22 @@ describe('DOM tests', () => {
     // populate DOM
     var currentNode = vnode({
       props: {
-        lol: 'lol',
+        lol: 'lol2',
       },
     });
     diff(null, currentNode, document.body, context);
-    expect(currentNode.domRef.getAttribute('lol')).toBe('lol');
+    expect(currentNode.domRef.getAttribute('lol')).toBe('lol2');
   });
 
   test('Should change a custom attribute on a DOM node', () => {
     // populate DOM
     var currentNode = vnode({
       props: {
-        lol: 'lol',
+        lol: 'lol2',
       },
     });
     diff(null, currentNode, document.body, context);
-    expect(currentNode.domRef.getAttribute('lol')).toBe('lol');
+    expect(currentNode.domRef.getAttribute('lol')).toBe('lol2');
 
     var newNode = vnode({
       props: {
@@ -295,11 +295,11 @@ describe('DOM tests', () => {
     // populate DOM
     var currentNode = vnode({
       props: {
-        lol: 'lol',
+        lol: 'lol2',
       },
     });
     diff(null, currentNode, document.body, context);
-    expect(currentNode.domRef.getAttribute('lol')).toBe('lol');
+    expect(currentNode.domRef.getAttribute('lol')).toBe('lol2');
 
     // test property change
     var newNode = vnode({});


### PR DESCRIPTION
Since the key and value were identical in the tests, the bug in #990 went undetected.

This PR changes the test corpus data so the keys and values are no longer identical.