### PR TITLE
Don't use JS `eval` on Wasm

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -3,7 +3,7 @@ packages:
   examples/
   sample-app/
 
-index-state: 2025-06-09T17:17:55Z
+index-state: 2025-06-27T20:43:14Z
 
 allow-newer:
   all:base

--- a/miso.cabal
+++ b/miso.cabal
@@ -61,7 +61,7 @@ common jsaddle
 
   if arch(wasm32)
     build-depends:
-      jsaddle-wasm >= 0.1.1 && < 0.2
+      jsaddle-wasm >= 0.1.2 && < 0.2
 
 common client
   if impl(ghcjs) || arch(javascript)


### PR DESCRIPTION
Motivated by https://github.com/tweag/ghc-wasm-miso-examples/issues/33

Depends on https://github.com/amesgen/jsaddle-wasm/pull/26, released in jsaddle-wasm 0.1.2.0