### PR TITLE
Enforce component naming at top-level

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ This file contains a simple `miso` counter application.
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
 {-# LANGUAGE LambdaCase        #-}
+{-# LANGUAGE DataKinds         #-}
 {-# LANGUAGE CPP               #-}
 ----------------------------------------------------------------------------
 module Main where
@@ -162,7 +163,7 @@ foreign export javascript "hs_start" main :: IO ()
 #endif
 ----------------------------------------------------------------------------
 -- | `defaultComponent` takes as arguments the initial model, update function, view function
-component :: Component name Model Action
+component :: Component "app" Model Action
 component = defaultComponent emptyModel updateModel viewModel
 ----------------------------------------------------------------------------
 -- | Empty application state

--- a/examples/canvas2d/Main.hs
+++ b/examples/canvas2d/Main.hs
@@ -1,6 +1,7 @@
 -----------------------------------------------------------------------------
-{-# LANGUAGE CPP #-}
-{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE CPP               #-}
+{-# LANGUAGE DataKinds         #-}
+{-# LANGUAGE TypeApplications  #-}
 {-# LANGUAGE OverloadedStrings #-}
 -----------------------------------------------------------------------------
 module Main where
@@ -33,7 +34,7 @@ main =
     sun <- newImage (baseUrl <> "canvas_sun.png")
     moon <- newImage (baseUrl <> "canvas_moon.png")
     earth <- newImage (baseUrl <> "canvas_earth.png")
-    startComponent (app sun moon earth) { initialAction = Just GetTime }
+    startComponent @"app" (app sun moon earth) { initialAction = Just GetTime }
   where
     app sun moon earth = defaultComponent (0.0, 0.0) updateModel (view_ sun moon earth)
     view_ sun moon earth m =

--- a/examples/components/Main.hs
+++ b/examples/components/Main.hs
@@ -41,9 +41,6 @@ type MainModel = Bool
 
 main :: IO ()
 main = run $ startComponent app
-  { logLevel = DebugHydrate
-  , subs = []
-  }
 
 secs :: Int -> Int
 secs = (* 1000000)
@@ -55,7 +52,10 @@ loggerSub msg = \_ ->
     consoleLog msg
 
 app :: Component "app" MainModel MainAction
-app = defaultComponent False updateModel1 viewModel1
+app = (defaultComponent False updateModel1 viewModel1)
+  { logLevel = DebugHydrate
+  , subs = []
+  } 
 
 counterComponent2 :: Component "app-2" Model Action
 counterComponent2 = (defaultComponent 0 updateModel2 viewModel2)

--- a/examples/fetch/Main.hs
+++ b/examples/fetch/Main.hs
@@ -33,12 +33,7 @@ foreign export javascript "hs_start" main :: IO ()
 ----------------------------------------------------------------------------
 -- | Main entry point
 main :: IO ()
-main = run $ startComponent app
-  { styles =
-    [ Href "https://cdnjs.cloudflare.com/ajax/libs/bulma/0.4.3/css/bulma.min.css"
-    , Href "https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css"
-    ]
-  }
+main = run (startComponent app)
 ----------------------------------------------------------------------------
 -- | Model
 newtype Model = Model
@@ -56,8 +51,13 @@ data Action
   | ErrorHandler MisoString
   deriving (Show, Eq)
 ----------------------------------------------------------------------------
-app :: Component name Model Action
-app = defaultComponent emptyModel updateModel viewModel
+app :: Component "app" Model Action
+app = (defaultComponent emptyModel updateModel viewModel)
+  { styles =
+    [ Href "https://cdnjs.cloudflare.com/ajax/libs/bulma/0.4.3/css/bulma.min.css"
+    , Href "https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css"
+    ]
+  }
 ----------------------------------------------------------------------------
 emptyModel :: Model
 emptyModel = Model Nothing

--- a/examples/file-reader/Main.hs
+++ b/examples/file-reader/Main.hs
@@ -1,7 +1,8 @@
 -----------------------------------------------------------------------------
 {-# LANGUAGE CPP               #-}
-{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE DataKinds         #-}
 {-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE OverloadedStrings #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Main
@@ -49,12 +50,7 @@ foreign export javascript "hs_start" main :: IO ()
 ----------------------------------------------------------------------------
 -- | Main entry point
 main :: IO ()
-main = run $ startComponent app
-  { styles =
-    [ Href "https://cdn.jsdelivr.net/npm/bulma@1.0.2/css/bulma.min.css"
-    , Style css
-    ]
-  }
+main = run (startComponent app)
 ----------------------------------------------------------------------------
 -- | Custom styling
 css :: MisoString
@@ -77,8 +73,13 @@ css = unlines
   ]
 ----------------------------------------------------------------------------
 -- | Miso application
-app :: Component name Model Action
-app = defaultComponent (Model mempty) updateModel viewModel
+app :: Component "app" Model Action
+app = (defaultComponent (Model mempty) updateModel viewModel)
+  { styles =
+      [ Href "https://cdn.jsdelivr.net/npm/bulma@1.0.2/css/bulma.min.css"
+      , Style css
+      ]
+  }
 ----------------------------------------------------------------------------
 -- | Update function
 updateModel :: Action -> Effect Model Action

--- a/examples/mario/Main.hs
+++ b/examples/mario/Main.hs
@@ -1,7 +1,9 @@
-{-# LANGUAGE CPP #-}
-{-# LANGUAGE MultiWayIf #-}
+{-# LANGUAGE CPP               #-}
+{-# LANGUAGE DataKinds         #-}
+{-# LANGUAGE MultiWayIf        #-}
+{-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE TypeApplications  #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RecordWildCards #-}
 
 module Main where
 
@@ -29,7 +31,7 @@ main :: IO ()
 main = run $ do
     time <- now
     let m = mario{time = time}
-    startComponent (defaultComponent m updateMario display)
+    startComponent @"app" (defaultComponent m updateMario display)
       { subs =
           [ arrowsSub GetArrows
           , windowCoordsSub WindowCoords

--- a/examples/mathml/Main.hs
+++ b/examples/mathml/Main.hs
@@ -1,4 +1,6 @@
-{-# LANGUAGE CPP #-}
+{-# LANGUAGE CPP               #-}
+{-# LANGUAGE DataKinds         #-}
+{-# LANGUAGE TypeApplications  #-}
 {-# LANGUAGE OverloadedStrings #-}
 module Main where
 
@@ -11,7 +13,7 @@ foreign export javascript "hs_start" main :: IO ()
 
 -- | Entry point for a miso application
 main :: IO ()
-main = run $ startComponent (defaultComponent Main.Empty updateModel viewModel)
+main = run $ startComponent @"app" (defaultComponent Main.Empty updateModel viewModel)
 
 data Model = Empty
   deriving (Eq)

--- a/examples/router/Main.hs
+++ b/examples/router/Main.hs
@@ -32,7 +32,7 @@ data Action
 -- | Main entry point
 main :: IO ()
 main = run $
-  miso $ \u ->
+  miso @"app" $ \u ->
     (defaultComponent (Model u) updateModel viewModel)
        { subs = [uriSub HandleURI]
        }

--- a/examples/simple/Main.hs
+++ b/examples/simple/Main.hs
@@ -1,5 +1,6 @@
 -----------------------------------------------------------------------------
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE OverloadedStrings #-}
 -----------------------------------------------------------------------------
 module Main where
@@ -32,12 +33,12 @@ foreign export javascript "hs_start" main :: IO ()
 -----------------------------------------------------------------------------
 main :: IO ()
 main = run $ startComponent app
+-----------------------------------------------------------------------------
+app :: Component "app" Model Action
+app = (defaultComponent (Model 0) updateModel viewModel)
   { events = pointerEvents
   , styles = [ Sheet sheet ]
   }
------------------------------------------------------------------------------
-app :: Component name Model Action
-app = defaultComponent (Model 0) updateModel viewModel
 -----------------------------------------------------------------------------
 updateModel :: Action -> Effect Model Action
 updateModel (AddOne event) = do

--- a/examples/sse/client/Main.hs
+++ b/examples/sse/client/Main.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE DataKinds #-}
 module Main where
 
 import Common (sse)
@@ -5,4 +7,4 @@ import Common (sse)
 import Miso (miso, run)
 
 main :: IO ()
-main = run (miso sse)
+main = run (miso @"sse" sse)

--- a/examples/svg/Main.hs
+++ b/examples/svg/Main.hs
@@ -1,6 +1,8 @@
-{-# LANGUAGE CPP #-}
+{-# LANGUAGE CPP               #-}
+{-# LANGUAGE DataKinds         #-}
+{-# LANGUAGE TypeFamilies      #-}
+{-# LANGUAGE TypeApplications  #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TypeFamilies #-}
 
 module Main where
 
@@ -18,7 +20,7 @@ foreign export javascript "hs_start" main :: IO ()
 #endif
 
 main :: IO ()
-main = run $ startComponent app
+main = run $ startComponent @"app" app
   { events = M.insert "pointermove" False pointerEvents
   , subs = [ mouseSub HandlePointer ]
   }

--- a/examples/three/Main.hs
+++ b/examples/three/Main.hs
@@ -1,9 +1,10 @@
-{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TypeApplications #-}
-{-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE CPP #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
+{-# LANGUAGE OverloadedStrings          #-}
+{-# LANGUAGE TypeApplications           #-}
+{-# LANGUAGE RecordWildCards            #-}
+{-# LANGUAGE DataKinds                  #-}
+{-# LANGUAGE CPP                        #-}
 module Main where
 
 import           Control.Monad
@@ -70,7 +71,7 @@ main = run $ do
   stats <- newStats
   ref <- liftIO $ newIORef $ Context (pure ()) (pure ()) stats
   m <- now
-  startComponent (defaultComponent m (updateModel ref) viewModel)
+  startComponent @"app" (defaultComponent m (updateModel ref) viewModel)
     { initialAction = Just Init
     }
 

--- a/examples/todo-mvc/Main.hs
+++ b/examples/todo-mvc/Main.hs
@@ -88,7 +88,10 @@ data Msg
     deriving (Show)
 
 main :: IO ()
-main = run $ startComponent app
+main = run (startComponent app)
+
+app :: Component "todo-mvc" Model Msg
+app = (defaultComponent emptyModel updateModel viewModel)
   { events = defaultEvents <> keyboardEvents
   , initialAction = Just FocusOnInput
   , styles =
@@ -96,9 +99,6 @@ main = run $ startComponent app
       , Href "https://cdn.jsdelivr.net/npm/todomvc-app-css@2.4.3/index.min.css"
       ]
   }
-
-app :: Component name Model Msg
-app = defaultComponent emptyModel updateModel viewModel
 
 updateModel :: Msg -> Effect Model Msg
 updateModel NoOp = pure ()

--- a/examples/websocket/Main.hs
+++ b/examples/websocket/Main.hs
@@ -27,7 +27,10 @@ foreign export javascript "hs_start" main :: IO ()
 #endif
 
 main :: IO ()
-main = run $ startComponent app
+main = run (startComponent app)
+
+app :: Component "websocket" Model Action
+app = (defaultComponent emptyModel updateModel appView)
   { events = defaultEvents <> keyboardEvents
   , subs =
     [ websocketSub url protocols HandleWebSocket
@@ -36,8 +39,6 @@ main = run $ startComponent app
       url = URL "wss://echo.websocket.org"
       protocols = Protocols []
 
-app :: Component name Model Action
-app = defaultComponent emptyModel updateModel appView
 
 emptyModel :: Model
 emptyModel = Model (Message "") mempty

--- a/haskell-miso.org/client/Main.hs
+++ b/haskell-miso.org/client/Main.hs
@@ -1,4 +1,6 @@
-{-# LANGUAGE CPP #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE DataKinds        #-}
+{-# LANGUAGE CPP              #-}
 
 module Main where
 
@@ -11,4 +13,4 @@ foreign export javascript "hs_start" main :: IO ()
 #endif
 
 main :: IO ()
-main = run (miso haskellMisoComponent)
+main = run (miso @"haskell-miso" haskellMisoComponent)

--- a/haskell-miso.org/client/Main.hs
+++ b/haskell-miso.org/client/Main.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE TypeApplications #-}
-{-# LANGUAGE DataKinds        #-}
 {-# LANGUAGE CPP              #-}
 
 module Main where
@@ -13,4 +11,4 @@ foreign export javascript "hs_start" main :: IO ()
 #endif
 
 main :: IO ()
-main = run (miso @"haskell-miso" haskellMisoComponent)
+main = run (miso haskellMisoComponent)

--- a/nix/source.nix
+++ b/nix/source.nix
@@ -46,25 +46,25 @@ in
   flatris = fetchFromGitHub {
     owner = "dmjio";
     repo = "hs-flatris";
-    rev = "aa7a2e00cf87832de660718c15f1d85093ded103";
-    hash = "sha256-RLBfjIGeoSTsAuxh8Pa8kcQkupVtFZEYewDE783lZFg=";
+    rev = "58d19c7";
+    hash = "sha256-S2vrKejF7pCfv9YFpbAo7/FDbTGvrUO4BfmQsoDxfCg=";
   };
   miso-plane = fetchFromGitHub {
     owner = "dmjio";
     repo = "miso-plane";
-    rev = "f143eb9";
-    hash = "sha256-S5urxw4eHrxsrZ9ivHeW5Nwec5eqpeat6GusNrxS+08=";
+    rev = "00fe15b";
+    hash = "sha256-gF8C4AKMrfLClmfx5Hy858qTBoz3sWEKzBJEjQ2ddSw=";
   };
   hs2048 = fetchFromGitHub {
     owner = "dmjio";
     repo = "hs2048";
-    rev = "65d7b3d";
-    hash = "sha256-46dhEMVutlPheLyw3/11WxF0STr9O3kR5w8xXMs9mCw=";
+    rev = "e64187b";
+    hash = "sha256-Z2a4WGGkBpzZVAVuTL3a1CWCu5orgAbjUXQ3TiHshco=";
   };
   snake = fetchFromGitHub {
     owner = "dmjio";
     repo = "miso-snake";
-    rev = "1da7afa";
-    hash = "sha256-bAfIlnd3PRn9wqGn38R3+6ok1dxRR3Jeb+UUIYJZ7/M=";
+    rev = "34345aa";
+    hash = "sha256-aVBJD3LvEOgmnJMHTL32w1+tJOd0pNmfpABMjDr+Woo=";
   };
 }

--- a/sample-app/Main.hs
+++ b/sample-app/Main.hs
@@ -1,6 +1,7 @@
 ----------------------------------------------------------------------------
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE LambdaCase        #-}
+{-# LANGUAGE DataKinds         #-}
 {-# LANGUAGE CPP               #-}
 ----------------------------------------------------------------------------
 module Main where
@@ -35,7 +36,7 @@ foreign export javascript "hs_start" main :: IO ()
 #endif
 ----------------------------------------------------------------------------
 -- | `defaultApp` takes as arguments the initial model, update function, view function
-app :: Component name Model Action
+app :: Component "app" Model Action
 app = defaultComponent emptyModel updateModel viewModel
 ----------------------------------------------------------------------------
 -- | Empty application state

--- a/src/Miso.hs
+++ b/src/Miso.hs
@@ -1,8 +1,12 @@
 -----------------------------------------------------------------------------
 {-# LANGUAGE CPP                       #-}
+{-# LANGUAGE DataKinds                 #-}
 {-# LANGUAGE NamedFieldPuns            #-}
 {-# LANGUAGE RecordWildCards           #-}
 {-# LANGUAGE TemplateHaskell           #-}
+{-# LANGUAGE KindSignatures            #-}
+{-# LANGUAGE TypeApplications          #-}
+{-# LANGUAGE ScopedTypeVariables       #-}
 {-# OPTIONS_GHC -Wno-duplicate-exports #-}
 -----------------------------------------------------------------------------
 -- |
@@ -74,6 +78,8 @@ module Miso
 import           Control.Monad (void)
 import           Control.Monad.IO.Class (liftIO)
 import           Data.IORef (newIORef, IORef)
+import           Data.Proxy (Proxy(Proxy))
+import           GHC.TypeLits (KnownSymbol(..), symbolVal)
 import           Language.Javascript.JSaddle (Object(Object), JSM)
 #ifndef GHCJS_BOTH
 #ifdef WASM
@@ -99,7 +105,7 @@ import           Miso.Router
 import           Miso.Run
 import           Miso.State
 import           Miso.Storage
-import           Miso.String (MisoString)
+import           Miso.String (MisoString, ms)
 import           Miso.Subscription
 import           Miso.Types
 import           Miso.Util
@@ -108,26 +114,28 @@ import           Miso.Util
 -- Assumes the pre-rendered DOM is already present.
 -- Note: Uses 'mountPoint' as the 'Component' name.
 -- Always mounts to \<body\>. Copies page into the virtual DOM.
-miso :: Eq model => (URI -> Component name model action) -> JSM ()
+miso
+  :: forall name model action . (KnownSymbol name, Eq model)
+  => (URI -> Component name model action) -> JSM ()
 miso f = withJS $ do
   app@Component {..} <- f <$> getURI
   initialize app $ \snk -> do
     renderStyles styles
     VTree (Object vtree) <- runView Hydrate (view model) snk logLevel events
-    let name = getMountPoint mountPoint
-    FFI.setComponentId name
+    let componentName = ms $ symbolVal (Proxy @name)
+    FFI.setComponentId componentName
     mount <- FFI.getBody
     FFI.hydrate (logLevel `elem` [DebugHydrate, DebugAll]) mount vtree
     viewRef <- liftIO $ newIORef $ VTree (Object vtree)
-    pure (name, mount, viewRef)
+    pure (componentName, mount, viewRef)
 -----------------------------------------------------------------------------
 -- | Alias for 'miso'.
-(🍜) :: Eq model => (URI -> Component name model action) -> JSM ()
+(🍜) :: (KnownSymbol name, Eq model) => (URI -> Component name model action) -> JSM ()
 (🍜) = miso
 ----------------------------------------------------------------------------
 -- | Runs a miso application
 -- Initializes application at 'mountPoint' (defaults to \<body\> when @Nothing@)
-startComponent :: Eq model => Component name model action -> JSM ()
+startComponent :: (KnownSymbol name, Eq model) => Component name model action -> JSM ()
 startComponent vcomp@Component { styles } = withJS $ initComponent vcomp (renderStyles styles)
 ----------------------------------------------------------------------------
 -- | Runs a miso application, but with a custom rendering engine.
@@ -135,7 +143,7 @@ startComponent vcomp@Component { styles } = withJS $ initComponent vcomp (render
 -- JS object that implements the context interface per 'ts/miso/context/dom.ts'
 -- This is necessary for native support.
 renderComponent
-  :: Eq model
+  :: (KnownSymbol name, Eq model)
   => Maybe MisoString
   -- ^ Name of the JS object that contains the drawing context
   -> Component name model action
@@ -150,7 +158,7 @@ renderComponent (Just renderer) vcomp hooks = withJS $ do
 ----------------------------------------------------------------------------
 -- | Internal helper function to support both 'render' and 'startComponent'
 initComponent
-  :: Eq model
+  :: forall name model action . (KnownSymbol name, Eq model)
   => Component name model action
   -- ^ Component application
   -> JSM ()
@@ -159,12 +167,12 @@ initComponent
 initComponent vcomp@Component{..} hooks = do
   initialize vcomp $ \snk -> hooks >> do
     vtree <- runView Draw (view model) snk logLevel events
-    let name = getMountPoint mountPoint
-    FFI.setComponentId name
-    mount <- mountElement name
+    let componentName = ms $ symbolVal (Proxy @name)
+    FFI.setComponentId componentName
+    mount <- mountElement (getMountPoint mountPoint)
     diff Nothing (Just vtree) mount
     viewRef <- liftIO (newIORef vtree)
-    pure (name, mount, viewRef)
+    pure (componentName, mount, viewRef)
 -----------------------------------------------------------------------------
 #ifdef PRODUCTION
 #define MISO_JS_PATH "js/miso.prod.js"

--- a/src/Miso.hs
+++ b/src/Miso.hs
@@ -79,7 +79,7 @@ import           Control.Monad (void)
 import           Control.Monad.IO.Class (liftIO)
 import           Data.IORef (newIORef, IORef)
 import           Data.Proxy (Proxy(Proxy))
-import           GHC.TypeLits (KnownSymbol(..), symbolVal)
+import           GHC.TypeLits (KnownSymbol, symbolVal)
 import           Language.Javascript.JSaddle (Object(Object), JSM)
 #ifndef GHCJS_BOTH
 #ifdef WASM


### PR DESCRIPTION
We must do this or we can potentially run into recursive component mounting issues. This is a breaking change, as it will force users to annotate their top-level components with a type-level `Symbol`.

We need this to allow `notify` and `sample` on the root component in an explicit way. cc @Zer0-