### PR TITLE
Add `Pub`/`Sub` system for `Component` communication 📡 

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,6 @@ This file contains a simple `miso` counter application.
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
 {-# LANGUAGE LambdaCase        #-}
-{-# LANGUAGE DataKinds         #-}
 {-# LANGUAGE CPP               #-}
 ----------------------------------------------------------------------------
 module Main where
@@ -162,9 +161,9 @@ main = run (startComponent component)
 foreign export javascript "hs_start" main :: IO ()
 #endif
 ----------------------------------------------------------------------------
--- | `defaultComponent` takes as arguments the initial model, update function, view function
-component :: Component "app" Model Action
-component = defaultComponent emptyModel updateModel viewModel
+-- | `component` takes as arguments the initial model, update function, view function
+component :: Component Model Action
+component = component emptyModel updateModel viewModel
 ----------------------------------------------------------------------------
 -- | Empty application state
 emptyModel :: Model

--- a/examples/canvas2d/Main.hs
+++ b/examples/canvas2d/Main.hs
@@ -1,6 +1,5 @@
 -----------------------------------------------------------------------------
 {-# LANGUAGE CPP               #-}
-{-# LANGUAGE DataKinds         #-}
 {-# LANGUAGE TypeApplications  #-}
 {-# LANGUAGE OverloadedStrings #-}
 -----------------------------------------------------------------------------
@@ -34,9 +33,9 @@ main =
     sun <- newImage (baseUrl <> "canvas_sun.png")
     moon <- newImage (baseUrl <> "canvas_moon.png")
     earth <- newImage (baseUrl <> "canvas_earth.png")
-    startComponent @"app" (app sun moon earth) { initialAction = Just GetTime }
+    startComponent (app sun moon earth) { initialAction = Just GetTime }
   where
-    app sun moon earth = defaultComponent (0.0, 0.0) updateModel (view_ sun moon earth)
+    app sun moon earth = component (0.0, 0.0) updateModel (view_ sun moon earth)
     view_ sun moon earth m =
       div_
       [ id_ "canvas grid" ]

--- a/examples/components/Main.hs
+++ b/examples/components/Main.hs
@@ -1,330 +1,103 @@
-{-# LANGUAGE CPP #-}
-{-# LANGUAGE DataKinds #-}
-{-# LANGUAGE TypeApplications #-}
-{-# LANGUAGE OverloadedStrings #-}
-
+-----------------------------------------------------------------------------
+{-# LANGUAGE CPP                #-}
+{-# LANGUAGE LambdaCase         #-}
+{-# LANGUAGE DeriveGeneric      #-}
+{-# LANGUAGE DeriveAnyClass     #-}
+{-# LANGUAGE TypeApplications   #-}
+{-# LANGUAGE OverloadedStrings  #-}
+-----------------------------------------------------------------------------
 module Main where
-
-import Control.Concurrent
-import Control.Monad
-import Control.Monad.IO.Class (liftIO)
-
-import Miso
-import Miso.String
-import Miso.Lens
-
-type Model = Int
-
+-----------------------------------------------------------------------------
+import           GHC.Generics
+import           Data.Aeson
+-----------------------------------------------------------------------------
+import           Miso
+import           Miso.String
+import           Miso.Lens
+-----------------------------------------------------------------------------
 #ifdef WASM
 foreign export javascript "hs_start" main :: IO ()
 #endif
-
+-----------------------------------------------------------------------------
 data Action
-    = AddOne
-    | SubtractOne
-    | SayHelloWorld
-    | ToggleAction
-    | UnMount MisoString
-    | Mount MisoString
-    | Sample
-    deriving (Show, Eq)
-
-data MainAction
-    = Toggle
-    | MountMain
-    | UnMountMain
-    | SampleChild
-    | StartLogger
-    | StopLogger
-
-type MainModel = Bool
-
+  = AddOne
+  | SubtractOne
+  | Mount MisoString
+  | Subscribe
+  | Unsubscribe
+  | Notification (Result Message)
+  deriving (Show, Eq, Generic)
+-----------------------------------------------------------------------------
+data Message
+  = Increment
+  | Decrement
+  deriving (Show, Eq, Generic, ToJSON, FromJSON)
+-----------------------------------------------------------------------------
 main :: IO ()
-main = run $ startComponent app
-
-secs :: Int -> Int
-secs = (* 1000000)
-
-loggerSub :: MisoString -> Sub action
-loggerSub msg = \_ ->
-  forever $ do
-    liftIO $ threadDelay (secs 1)
-    consoleLog msg
-
-app :: Component "app" MainModel MainAction
-app = (defaultComponent False updateModel1 viewModel1)
-  { logLevel = DebugHydrate
-  , subs = []
-  } 
-
-counterComponent2 :: Component "app-2" Model Action
-counterComponent2 = (defaultComponent 0 updateModel2 viewModel2)
-  { subs = [loggerSub "component-2 sub"]
-  }
-
-counterComponent3 :: Component "app-3" (Bool, Model) Action
-counterComponent3 = (defaultComponent (True, 0) updateModel3 viewModel3)
-  { subs = [ loggerSub "component-3 sub"]
-  }
-
-counterComponent4 :: Component "app-4" Model Action
-counterComponent4 = (defaultComponent 0 updateModel4 viewModel4)
-  { subs = [loggerSub "component-4 sub"]
-  }
-
--- | Constructs a virtual DOM from a model
-viewModel1 :: MainModel -> View MainAction
-viewModel1 x =
-    div_
-        []
-        [ "Component 1 - Three sub components nested recursively below me"
-        , br_ []
-        , "The +/- for Components 3 and 4 will affect their local state"
-        , br_ []
-        , "The +/- for Components 3 and 4 will affect their local state"
-        , br_ []
-        , "Toggle component button will oscillate between component 4 and 5"
-        , br_ []
-        , "Components 4 will update its own state and the state of component 3"
-        , br_ []
-        , "Components 5 will update its own state and the state of component 2"
-        , br_ []
-        , "Sample state will read from component 2 or 3's state depending on the toggle"
-        , br_ []
-        , "Example of using 'start' and 'stop' subscriptions dynamically"
-        , div_ []
-          [ button_ [ onClick StartLogger ] [ "start logger" ]
-          , button_ [ onClick StopLogger ] [ "stop logger" ]
-          ]
-        , button_ [onClick Toggle] [text "Toggle Component 2"]
-        , button_ [onClick SampleChild] [text "Sample Child (unsafe)"]
-        , if x
-            then
-                component_ counterComponent2
-                  [ onMounted MountMain
-                  , onUnmounted UnMountMain
-                  ]
-            else div_ [id_ "other test"] ["Main application content"]
-        ]
-
-data LoggerSub = LoggerSub
-  deriving (Eq, Ord)
-
-instance ToMisoString LoggerSub where
-  toMisoString LoggerSub = "LoggerSub"
-
--- | Updates model, optionally introduces side effects
-updateModel1 :: MainAction -> Effect MainModel MainAction
-updateModel1 StartLogger = startSub LoggerSub (loggerSub "main-app")
-updateModel1 StopLogger  = stopSub LoggerSub
-updateModel1 Toggle = modify not
-updateModel1 UnMountMain =
-  io_ (consoleLog "Component 2 was unmounted!")
-updateModel1 MountMain =
-  io_ (consoleLog "Component 2 was mounted!")
-updateModel1 SampleChild = do
-  io_ $ do
-    componentTwoModel <- sample counterComponent2
-    consoleLog $
-        "Sampling child component 2 from parent component main (unsafe): " <>
-          ms (show componentTwoModel)
-
--- | Updates model, optionally introduces side effects
-updateModel2 :: Action -> Effect Model Action
-updateModel2 AddOne = modify (+1)
-updateModel2 SubtractOne = modify (subtract 1)
-updateModel2 u@UnMount{} = unmountAction u
-updateModel2 m@Mount{} = mountAction m
-updateModel2 SayHelloWorld = do
-  io_ (consoleLog "Hello World from Component 2")
-updateModel2 _ = pure ()
-
-unmountAction :: Action -> Effect model action
-unmountAction (UnMount name) = io_ $ consoleLog ("Component " <> name <> " was unmounted!")
-unmountAction _ = pure ()
-
-mountAction :: Action -> Effect model action
-mountAction (Mount name) = io_ $ consoleLog ("Component " <> name <> " was mounted!")
-mountAction _ = pure ()
-
--- | Constructs a virtual DOM from a model
-viewModel2 :: Model -> View Action
-viewModel2 x =
-    div_
-        []
-        [ "This is the view for Component 2"
-        , button_ [onClick AddOne] [text "+"]
-        , text (ms x)
-        , button_ [onClick SubtractOne] [text "-"]
-        , component_ counterComponent3
-          [ onMounted (Mount "3")
-          , onUnmounted (UnMount "3")
-          ]
-        ]
-
--- | Updates model, optionally introduces side effects
-updateModel3 :: Action -> Effect (Bool, Model) Action
-updateModel3 AddOne = do
-  modify (fmap (+1))
-updateModel3 SubtractOne = do
-  modify (fmap (subtract 1))
-updateModel3 ToggleAction =
-  modify $ \(x,y) -> (not x, y)
-updateModel3 x@UnMount{} = unmountAction x
-updateModel3 x@Mount{} = mountAction x
-updateModel3 SayHelloWorld = do
-  io_ (consoleLog "Hello World from Component 3")
-updateModel3 _ = pure ()
-
--- | Constructs a virtual DOM from a model
-viewModel3 :: (Bool, Model) -> View Action
-viewModel3 (toggle, x) =
-    div_ [] $
-        [ "This is the view for Component 3"
-        , button_ [onClick AddOne] [text "+"]
-        , text (ms x)
-        , button_ [onClick SubtractOne] [text "-"]
-        , button_ [onClick ToggleAction]
-          [ text $ "Toggle Component " <> if toggle then "4" else "5"
-          ]
-        ] ++ [ if toggle
-               -- dmj: N.B. if you are replacing a component w/ another component
-               -- when using the 'component_' function you *must* use 'embedKeyed'
-               -- , think of it like a StableName. Failure to do so is undefined behavior
-               -- but it will probably result in the component not actually getting replaced.
-               --
-               -- If you are replacing an unnamed component (using 'component_') with anything else (e.g. 'vtext', 'vnode',
-               -- 'vcomp', null), then you don't need to worry about this.
-               then
-                 component_ counterComponent4
-                   [ onMounted (Mount "4")
-                   , onUnmounted (UnMount "4")
-                   ]
-               else
-                 component_ counterComponent5
-                   [ onMounted (Mount "5")
-                   , onUnmounted (UnMount "5")
-                   ]
-             ]
-
--- | Updates model, optionally introduces side effects
-updateModel4 :: Action -> Effect Model Action
-updateModel4 AddOne = do
-  modify (+1)
-  io_ (notify counterComponent3 AddOne)
-updateModel4 SubtractOne = do
-  modify (subtract 1)
-  io_ (notify counterComponent3 SubtractOne)
-updateModel4 Sample =
-  io_ $ do
-    componentTwoModel <- sample counterComponent3
-    consoleLog $
-      "Sampling parent component 3 from child component 4: " <>
-         ms (show componentTwoModel)
-updateModel4 SayHelloWorld = do
-  io_ (consoleLog "Hello World from Component 4")
-updateModel4 _ = pure ()
-
--- | Constructs a virtual DOM from a model
-viewModel4 :: Model -> View Action
-viewModel4 x =
-    div_
-        []
-        [ "This is the view for Component 4"
-        , button_ [onClick AddOne] [text "+"]
-        , text (ms x)
-        , button_ [onClick SubtractOne] [text "-"]
-        , button_ [onClick Sample] [text "Sample Component 3 state"]
-        ]
-
-app5 :: Component "app-5" (Model, Maybe MisoString) Action
-app5 =
-        counterComponent5
-            { subs = [loggerSub "component-5 sub"]
-            }
-
-counterComponent5 :: Component "app-5" (Model, Maybe MisoString) Action
-counterComponent5 = defaultComponent (0, Nothing) updateModel5 viewModel5
-
--- | Updates model, optionally introduces side effects
-updateModel5 :: Action -> Effect (Model, Maybe MisoString) Action
-updateModel5 AddOne = do
-  _1 += 1
-  maybeChildId <- use _2
-  forM_ maybeChildId $ \childId ->
-    io_ (notify' childId counterComponent6 AddOne)
-  io_ (notify counterComponent2 AddOne)
-updateModel5 SubtractOne = do
-  _1 -= 1
-  io_ (notify counterComponent2 SubtractOne)
-updateModel5 Sample = do
-  io_ $ do
-    componentTwoModel <- sample counterComponent2
-    consoleLog $
-      "Sampling parent component 2 from child component 5: " <>
-         ms (show componentTwoModel)
-
-  maybeChildId <- use _2
-  io_ $ do
-    forM_ maybeChildId $ \childId -> do
-      componentTwoModel <- sample' childId counterComponent6
-      consoleLog $
-        "Sampling parent component 6 from child component 5: " <>
-           ms (show componentTwoModel)
-
-updateModel5 SayHelloWorld = do
-  io_ (consoleLog "Hello World from Component 5")
-updateModel5 (Mount childId) = do
-  io_ $ consoleLog $ "In mount, setting childId: " <> childId
-  _2 ?= childId
-updateModel5 _ = pure ()
-
--- | Constructs a virtual DOM from a model
-viewModel5 :: (Model, Maybe MisoString) -> View Action
-viewModel5 (x, _) =
-    div_
-        []
-        [ "This is the view for Component 5"
-        , button_ [onClick AddOne] [text "+"]
-        , text (ms x)
-        , button_ [onClick SubtractOne] [text "-"]
-        , button_ [onClick Sample] [text "Sample Component 2 state"]
-        , "Here is dynamic component 6..."
-        , br_ []
-        , component_ counterComponent6
-          [ onMountedWith Mount
-          ]
-        ]
-
--- | "" here means the component is given a dynamically generated name, can also leave generic
--- the component_ or componentWith_
-counterComponent6 :: Component Dynamic Model Action
-counterComponent6 = defaultComponent 0 updateModel6 viewModel6
-
--- | Updates model, optionally introduces side effects
-updateModel6 :: Action -> Effect Model Action
-updateModel6 AddOne = do
-  modify (+1)
-updateModel6 SubtractOne = do
-  modify (subtract 1)
-updateModel6 Sample =
-  io_ $ do
-    componentTwoModel <- sample counterComponent3
-    consoleLog $
-      "Sampling parent component 3 from child component 6: " <>
-         ms (show componentTwoModel)
-updateModel6 SayHelloWorld = do
-  io_ (consoleLog "Hello World from Component 6")
-updateModel6 _ = pure ()
-
--- | Constructs a virtual DOM from a model
-viewModel6 :: Model -> View Action
-viewModel6 x =
-    div_
-        []
-        [ "This is the view for Component 6"
-        , button_ [onClick AddOne] [text "+"]
-        , text (ms x)
-        , button_ [onClick SubtractOne] [text "-"]
-        , button_ [onClick Sample] [text "Sample Component 3 state"]
-        ]
+main = run (startComponent server)
+-----------------------------------------------------------------------------
+arithmetic :: Topic Message
+arithmetic = topic "arithmetic"
+-----------------------------------------------------------------------------
+-- | Demonstrates a simple server / client, pub / sub setup for 'Component'
+-- In this contrived example, the server component holds the
+-- incrementing / decrementing actions, and relays them to the clients
+-- via the pub / sub mechanism.
+--
+-- Notice the server has no 'model' (e.g. `()`)
+--
+server :: Component () Action
+server = component () update_ $ \() ->
+  div_
+  []
+  [ "Server component"
+  , button_ [ onClick AddOne ] [ "+" ]
+  , button_ [ onClick SubtractOne ] [ "-" ]
+  , component_ (client_ "client 1")
+    [ onMountedWith Mount
+    ]
+  , component_ (client_ "client 2")
+    [ onMountedWith Mount
+    ]
+  ] where
+      update_ :: Action -> Effect () Action
+      update_ = \case
+        AddOne ->
+          publish arithmetic Increment
+        SubtractOne ->
+          publish arithmetic Decrement
+        Mount compId ->
+          io_ $ consoleLog ("Mounted component: " <> compId)
+        _ -> pure ()
+-----------------------------------------------------------------------------
+client_ :: MisoString -> Component Int Action
+client_ name = (clientComponent name) { initialAction = Just Subscribe }
+-----------------------------------------------------------------------------
+clientComponent :: MisoString -> Component Int Action
+clientComponent name = component 0 update_ $ \m ->
+  div_
+  []
+  [ br_ []
+  , text (name <> " : " <> ms (m ^. _id))
+  , button_ [ onClick Unsubscribe ] [ "unsubscribe" ]
+  , button_ [ onClick Subscribe ] [ "subscribe" ]
+  ] where
+      update_ :: Action -> Effect Int Action
+      update_ = \case
+        AddOne -> do
+          _id += 1
+        SubtractOne ->
+          _id -= 1
+        Unsubscribe ->
+          unsubscribe arithmetic
+        Subscribe -> do
+          io_ (consoleLog "subscribing...")
+          subscribe arithmetic Notification
+        Notification (Success Increment) ->
+          update_ AddOne
+        Notification (Success Decrement) ->
+          update_ SubtractOne
+        Notification (Error msg) ->
+          io_ $ consoleError ("Decode failure: " <> ms msg)
+        _ -> pure ()
+-----------------------------------------------------------------------------

--- a/examples/fetch/Main.hs
+++ b/examples/fetch/Main.hs
@@ -51,8 +51,8 @@ data Action
   | ErrorHandler MisoString
   deriving (Show, Eq)
 ----------------------------------------------------------------------------
-app :: Component "app" Model Action
-app = (defaultComponent emptyModel updateModel viewModel)
+app :: Component Model Action
+app = (component emptyModel updateModel viewModel)
   { styles =
     [ Href "https://cdnjs.cloudflare.com/ajax/libs/bulma/0.4.3/css/bulma.min.css"
     , Href "https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css"

--- a/examples/file-reader/Main.hs
+++ b/examples/file-reader/Main.hs
@@ -21,7 +21,7 @@ import           Language.Javascript.JSaddle ((!), (!!), (#), JSVal, (<#))
 import qualified Language.Javascript.JSaddle as J
 import           Prelude hiding ((!!), null, unlines)
 ----------------------------------------------------------------------------
-import           Miso (Component(styles), View,Effect, defaultComponent, run, CSS(..), startComponent, io, io_)
+import           Miso (Component(styles), View,Effect, component, run, CSS(..), startComponent, io, io_)
 import qualified Miso as M
 import           Miso.Lens ((.=), Lens, lens)
 import           Miso.String (MisoString, unlines, null)
@@ -73,8 +73,8 @@ css = unlines
   ]
 ----------------------------------------------------------------------------
 -- | Miso application
-app :: Component "app" Model Action
-app = (defaultComponent (Model mempty) updateModel viewModel)
+app :: Component Model Action
+app = (component (Model mempty) updateModel viewModel)
   { styles =
       [ Href "https://cdn.jsdelivr.net/npm/bulma@1.0.2/css/bulma.min.css"
       , Style css

--- a/examples/mario/Main.hs
+++ b/examples/mario/Main.hs
@@ -1,8 +1,6 @@
 {-# LANGUAGE CPP               #-}
-{-# LANGUAGE DataKinds         #-}
 {-# LANGUAGE MultiWayIf        #-}
 {-# LANGUAGE RecordWildCards   #-}
-{-# LANGUAGE TypeApplications  #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module Main where
@@ -31,7 +29,7 @@ main :: IO ()
 main = run $ do
     time <- now
     let m = mario{time = time}
-    startComponent @"app" (defaultComponent m updateMario display)
+    startComponent (component m updateMario display)
       { subs =
           [ arrowsSub GetArrows
           , windowCoordsSub WindowCoords

--- a/examples/mathml/Main.hs
+++ b/examples/mathml/Main.hs
@@ -1,6 +1,4 @@
 {-# LANGUAGE CPP               #-}
-{-# LANGUAGE DataKinds         #-}
-{-# LANGUAGE TypeApplications  #-}
 {-# LANGUAGE OverloadedStrings #-}
 module Main where
 
@@ -13,7 +11,7 @@ foreign export javascript "hs_start" main :: IO ()
 
 -- | Entry point for a miso application
 main :: IO ()
-main = run $ startComponent @"app" (defaultComponent Main.Empty updateModel viewModel)
+main = run $ startComponent (component Main.Empty updateModel viewModel)
 
 data Model = Empty
   deriving (Eq)

--- a/examples/router/Main.hs
+++ b/examples/router/Main.hs
@@ -32,8 +32,8 @@ data Action
 -- | Main entry point
 main :: IO ()
 main = run $
-  miso @"app" $ \u ->
-    (defaultComponent (Model u) updateModel viewModel)
+  miso $ \u ->
+    (component (Model u) updateModel viewModel)
        { subs = [uriSub HandleURI]
        }
 

--- a/examples/simple/Main.hs
+++ b/examples/simple/Main.hs
@@ -1,6 +1,5 @@
 -----------------------------------------------------------------------------
-{-# LANGUAGE CPP #-}
-{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE CPP               #-}
 {-# LANGUAGE OverloadedStrings #-}
 -----------------------------------------------------------------------------
 module Main where
@@ -34,8 +33,8 @@ foreign export javascript "hs_start" main :: IO ()
 main :: IO ()
 main = run $ startComponent app
 -----------------------------------------------------------------------------
-app :: Component "app" Model Action
-app = (defaultComponent (Model 0) updateModel viewModel)
+app :: Component Model Action
+app = (component (Model 0) updateModel viewModel)
   { events = pointerEvents
   , styles = [ Sheet sheet ]
   }

--- a/examples/sse/client/Main.hs
+++ b/examples/sse/client/Main.hs
@@ -7,4 +7,4 @@ import Common (sse)
 import Miso (miso, run)
 
 main :: IO ()
-main = run (miso @"sse" sse)
+main = run (miso sse)

--- a/examples/sse/server/Main.hs
+++ b/examples/sse/server/Main.hs
@@ -62,7 +62,7 @@ sendEvents chan =
         threadDelay (10 ^ (6 :: Int))
 
 -- | Page for setting HTML doctype and header
-newtype Page = Page (Component "app" Model Action)
+newtype Page = Page (Component Model Action)
 
 instance ToHtml Page where
     toHtml (Page x) =

--- a/examples/sse/shared/Common.hs
+++ b/examples/sse/shared/Common.hs
@@ -58,7 +58,7 @@ the404 =
 goHome :: URI
 goHome = allLinks' linkURI (Proxy :: Proxy ClientRoutes)
 
-sse :: URI -> Component name Model Action
+sse :: URI -> Component Model Action
 sse currentURI
   = app { subs =
           [ sseSub "/sse" handleSseMsg
@@ -66,7 +66,7 @@ sse currentURI
           ]
         }
   where
-    app = defaultComponent (Model currentURI "No event received") updateModel viewModel
+    app = component (Model currentURI "No event received") updateModel viewModel
     viewModel m
         | Right r <- route (Proxy :: Proxy ClientRoutes) home modelUri m =
             r

--- a/examples/svg/Main.hs
+++ b/examples/svg/Main.hs
@@ -1,7 +1,4 @@
 {-# LANGUAGE CPP               #-}
-{-# LANGUAGE DataKinds         #-}
-{-# LANGUAGE TypeFamilies      #-}
-{-# LANGUAGE TypeApplications  #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module Main where
@@ -20,14 +17,14 @@ foreign export javascript "hs_start" main :: IO ()
 #endif
 
 main :: IO ()
-main = run $ startComponent @"app" app
+main = run $ startComponent app
   { events = M.insert "pointermove" False pointerEvents
   , subs = [ mouseSub HandlePointer ]
   }
 
--- | Component definition (uses 'defaultComponent' smart constructor)
-app :: Component name Model Action
-app = defaultComponent emptyModel updateModel viewModel
+-- | Component definition (uses 'component' smart constructor)
+app :: Component Model Action
+app = component emptyModel updateModel viewModel
 
 emptyModel :: Model
 emptyModel = Model (0, 0)

--- a/examples/three/Main.hs
+++ b/examples/three/Main.hs
@@ -3,7 +3,6 @@
 {-# LANGUAGE OverloadedStrings          #-}
 {-# LANGUAGE TypeApplications           #-}
 {-# LANGUAGE RecordWildCards            #-}
-{-# LANGUAGE DataKinds                  #-}
 {-# LANGUAGE CPP                        #-}
 module Main where
 
@@ -71,7 +70,7 @@ main = run $ do
   stats <- newStats
   ref <- liftIO $ newIORef $ Context (pure ()) (pure ()) stats
   m <- now
-  startComponent @"app" (defaultComponent m (updateModel ref) viewModel)
+  startComponent (component m (updateModel ref) viewModel)
     { initialAction = Just Init
     }
 

--- a/examples/todo-mvc/Main.hs
+++ b/examples/todo-mvc/Main.hs
@@ -1,13 +1,7 @@
-{-# LANGUAGE CPP #-}
-{-# LANGUAGE DataKinds #-}
-{-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE ExtendedDefaultRules #-}
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE CPP               #-}
+{-# LANGUAGE DeriveGeneric     #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE RecordWildCards   #-}
 
 module Main where
 
@@ -90,8 +84,8 @@ data Msg
 main :: IO ()
 main = run (startComponent app)
 
-app :: Component "todo-mvc" Model Msg
-app = (defaultComponent emptyModel updateModel viewModel)
+app :: Component Model Msg
+app = (component emptyModel updateModel viewModel)
   { events = defaultEvents <> keyboardEvents
   , initialAction = Just FocusOnInput
   , styles =

--- a/examples/websocket/Main.hs
+++ b/examples/websocket/Main.hs
@@ -1,13 +1,12 @@
-{-# LANGUAGE CPP #-}
-{-# LANGUAGE DataKinds #-}
-{-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE ExtendedDefaultRules #-}
-{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE CPP                   #-}
+{-# LANGUAGE DeriveGeneric         #-}
+{-# LANGUAGE ExtendedDefaultRules  #-}
+{-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE OverloadedStrings     #-}
+{-# LANGUAGE RecordWildCards       #-}
+{-# LANGUAGE ScopedTypeVariables   #-}
+{-# LANGUAGE TypeFamilies          #-}
 
 module Main where
 
@@ -29,8 +28,8 @@ foreign export javascript "hs_start" main :: IO ()
 main :: IO ()
 main = run (startComponent app)
 
-app :: Component "websocket" Model Action
-app = (defaultComponent emptyModel updateModel appView)
+app :: Component Model Action
+app = (component emptyModel updateModel appView)
   { events = defaultEvents <> keyboardEvents
   , subs =
     [ websocketSub url protocols HandleWebSocket

--- a/haskell-miso.org/shared/Common.hs
+++ b/haskell-miso.org/shared/Common.hs
@@ -61,7 +61,7 @@ type ClientRoutes = Routes (View Action)
 type ServerRoutes = Routes (Get '[HTML] Page)
 
 -- | Component synonym
-type HaskellMisoComponent = Component "app" Model Action
+type HaskellMisoComponent = Component Model Action
 
 -- | Links
 uriHome, uriExamples, uriDocs, uriCommunity, uri404 :: URI
@@ -100,8 +100,8 @@ haskellMisoComponent uri
   , logLevel = DebugAll
   }
   
-app :: URI -> Component name Model Action
-app currentUri = defaultComponent emptyModel updateModel viewModel
+app :: URI -> Component Model Action
+app currentUri = component emptyModel updateModel viewModel
   where
     emptyModel = Model currentUri False
     viewModel m =

--- a/miso.cabal
+++ b/miso.cabal
@@ -193,3 +193,4 @@ library
     tagsoup       < 0.15,
     text          < 2.2,
     transformers  < 0.7,
+    stm >= 2.4 && < 2.6

--- a/nix/source.nix
+++ b/nix/source.nix
@@ -46,25 +46,25 @@ in
   flatris = fetchFromGitHub {
     owner = "dmjio";
     repo = "hs-flatris";
-    rev = "58d19c7";
-    hash = "sha256-S2vrKejF7pCfv9YFpbAo7/FDbTGvrUO4BfmQsoDxfCg=";
+    rev = "36d7f2b77242beeccb0321a7b6092b7c04cf0291";
+    hash = "sha256-cQz3l1lWNsU4m/db1ARwk+IGX2rQGXwYEnWT2aD+/IU=";
   };
   miso-plane = fetchFromGitHub {
     owner = "dmjio";
     repo = "miso-plane";
-    rev = "00fe15b";
-    hash = "sha256-gF8C4AKMrfLClmfx5Hy858qTBoz3sWEKzBJEjQ2ddSw=";
+    rev = "e6199d87d9161b25daca434d679330366ad0b42a";
+    hash = "sha256-TEOjj2Bb76MCWGvIRN5NhwmjEV7MZQHXnEK5szd5IqU=";
   };
   hs2048 = fetchFromGitHub {
     owner = "dmjio";
     repo = "hs2048";
-    rev = "e64187b";
-    hash = "sha256-Z2a4WGGkBpzZVAVuTL3a1CWCu5orgAbjUXQ3TiHshco=";
+    rev = "63e33d3751e3e6021d22983a08293f8c0a41cc9b";
+    hash = "sha256-pZwYdtDMZm/ptnw4kFWh0lKVxJB3C5kkq6CUZ7evIR0=";
   };
   snake = fetchFromGitHub {
     owner = "dmjio";
     repo = "miso-snake";
-    rev = "34345aa";
-    hash = "sha256-aVBJD3LvEOgmnJMHTL32w1+tJOd0pNmfpABMjDr+Woo=";
+    rev = "46e61b0c43c2c9b61aa388418770172cdd8af8b4";
+    hash = "sha256-HihtEbAnyMfNzSvJkjZeAbY/b/fm66wc4G0YuOJYfEA=";
   };
 }

--- a/sample-app/Main.hs
+++ b/sample-app/Main.hs
@@ -1,7 +1,6 @@
 ----------------------------------------------------------------------------
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE LambdaCase        #-}
-{-# LANGUAGE DataKinds         #-}
 {-# LANGUAGE CPP               #-}
 ----------------------------------------------------------------------------
 module Main where
@@ -35,9 +34,9 @@ main = run (startComponent app)
 foreign export javascript "hs_start" main :: IO ()
 #endif
 ----------------------------------------------------------------------------
--- | `defaultApp` takes as arguments the initial model, update function, view function
-app :: Component "app" Model Action
-app = defaultComponent emptyModel updateModel viewModel
+-- | `component` takes as arguments the initial model, update function, view function
+app :: Component Model Action
+app = component emptyModel updateModel viewModel
 ----------------------------------------------------------------------------
 -- | Empty application state
 emptyModel :: Model

--- a/src/Miso.hs
+++ b/src/Miso.hs
@@ -1,12 +1,8 @@
 -----------------------------------------------------------------------------
 {-# LANGUAGE CPP                       #-}
-{-# LANGUAGE DataKinds                 #-}
 {-# LANGUAGE NamedFieldPuns            #-}
 {-# LANGUAGE RecordWildCards           #-}
 {-# LANGUAGE TemplateHaskell           #-}
-{-# LANGUAGE KindSignatures            #-}
-{-# LANGUAGE TypeApplications          #-}
-{-# LANGUAGE ScopedTypeVariables       #-}
 {-# OPTIONS_GHC -Wno-duplicate-exports #-}
 -----------------------------------------------------------------------------
 -- |
@@ -27,13 +23,13 @@ module Miso
     -- ** Sink
   , withSink
   , Sink
-    -- ** Sampling
-  , sample
-  , sample'
-    -- ** Message Passing
-  , notify
-  , notify'
-    -- ** Subscription
+    -- ** Publishers / Subscribers
+  , subscribe
+  , unsubscribe
+  , publish
+  , Topic
+  , topic
+    -- ** Subscriptions
   , startSub
   , stopSub
   , Sub
@@ -78,8 +74,6 @@ module Miso
 import           Control.Monad (void)
 import           Control.Monad.IO.Class (liftIO)
 import           Data.IORef (newIORef, IORef)
-import           Data.Proxy (Proxy(Proxy))
-import           GHC.TypeLits (KnownSymbol, symbolVal)
 import           Language.Javascript.JSaddle (Object(Object), JSM)
 #ifndef GHCJS_BOTH
 #ifdef WASM
@@ -105,37 +99,38 @@ import           Miso.Router
 import           Miso.Run
 import           Miso.State
 import           Miso.Storage
-import           Miso.String (MisoString, ms)
+import           Miso.String (MisoString)
 import           Miso.Subscription
 import           Miso.Types
 import           Miso.Util
 ----------------------------------------------------------------------------
 -- | Runs an isomorphic @miso@ application.
 -- Assumes the pre-rendered DOM is already present.
--- Note: Uses 'mountPoint' as the 'Component' name.
 -- Always mounts to \<body\>. Copies page into the virtual DOM.
-miso
-  :: forall name model action . (KnownSymbol name, Eq model)
-  => (URI -> Component name model action) -> JSM ()
+miso :: Eq model => (URI -> Component model action) -> JSM ()
 miso f = withJS $ do
   app@Component {..} <- f <$> getURI
   initialize app $ \snk -> do
     renderStyles styles
     VTree (Object vtree) <- runView Hydrate (view model) snk logLevel events
-    let componentName = ms $ symbolVal (Proxy @name)
-    FFI.setComponentId componentName
+    componentId <- liftIO freshComponentId
+    FFI.setComponentId componentId
     mount <- FFI.getBody
     FFI.hydrate (logLevel `elem` [DebugHydrate, DebugAll]) mount vtree
     viewRef <- liftIO $ newIORef $ VTree (Object vtree)
-    pure (componentName, mount, viewRef)
+    pure (componentId, mount, viewRef)
 -----------------------------------------------------------------------------
 -- | Alias for 'miso'.
-(🍜) :: (KnownSymbol name, Eq model) => (URI -> Component name model action) -> JSM ()
+(🍜) :: Eq model => (URI -> Component model action) -> JSM ()
 (🍜) = miso
 ----------------------------------------------------------------------------
 -- | Runs a miso application
 -- Initializes application at 'mountPoint' (defaults to \<body\> when @Nothing@)
-startComponent :: (KnownSymbol name, Eq model) => Component name model action -> JSM ()
+startComponent
+  :: Eq model
+  => Component model action
+  -- ^ Component application
+  -> JSM ()
 startComponent vcomp@Component { styles } = withJS $ initComponent vcomp (renderStyles styles)
 ----------------------------------------------------------------------------
 -- | Runs a miso application, but with a custom rendering engine.
@@ -143,23 +138,23 @@ startComponent vcomp@Component { styles } = withJS $ initComponent vcomp (render
 -- JS object that implements the context interface per 'ts/miso/context/dom.ts'
 -- This is necessary for native support.
 renderComponent
-  :: (KnownSymbol name, Eq model)
+  :: Eq model
   => Maybe MisoString
   -- ^ Name of the JS object that contains the drawing context
-  -> Component name model action
+  -> Component model action
   -- ^ Component application
   -> JSM ()
   -- ^ Custom hook to perform any JSM action (e.g. render styles) before initialization.
   -> JSM ()
-renderComponent Nothing component _ = startComponent component
+renderComponent Nothing vcomp _ = startComponent vcomp
 renderComponent (Just renderer) vcomp hooks = withJS $ do
   FFI.setDrawingContext renderer
   initComponent vcomp hooks
 ----------------------------------------------------------------------------
 -- | Internal helper function to support both 'render' and 'startComponent'
 initComponent
-  :: forall name model action . (KnownSymbol name, Eq model)
-  => Component name model action
+  :: Eq model
+  => Component model action
   -- ^ Component application
   -> JSM ()
   -- ^ Custom hook to perform any JSM action (e.g. render styles) before initialization.
@@ -167,12 +162,12 @@ initComponent
 initComponent vcomp@Component{..} hooks = do
   initialize vcomp $ \snk -> hooks >> do
     vtree <- runView Draw (view model) snk logLevel events
-    let componentName = ms $ symbolVal (Proxy @name)
-    FFI.setComponentId componentName
+    componentId <- liftIO freshComponentId
+    FFI.setComponentId componentId
     mount <- mountElement (getMountPoint mountPoint)
     diff Nothing (Just vtree) mount
     viewRef <- liftIO (newIORef vtree)
-    pure (componentName, mount, viewRef)
+    pure (componentId, mount, viewRef)
 -----------------------------------------------------------------------------
 #ifdef PRODUCTION
 #define MISO_JS_PATH "js/miso.prod.js"

--- a/src/Miso/Effect.hs
+++ b/src/Miso/Effect.hs
@@ -77,6 +77,7 @@ infixr 0 #>
 (#>) = flip (<#)
 -----------------------------------------------------------------------------
 -- | Smart constructor for an 'Effect' with multiple actions.
+-- @since 1.9.0.0
 batch :: [JSM action] -> Effect model action
 batch actions = sequence_
   [ tell [ \f -> f =<< action ]
@@ -84,6 +85,7 @@ batch actions = sequence_
   ]
 -----------------------------------------------------------------------------
 -- | Like @batch@ but action are discarded
+-- @since 1.9.0.0
 batch_ :: [JSM ()] -> Effect model action
 batch_ actions = sequence_
   [ tell [ const action ]
@@ -151,6 +153,8 @@ mapSub f sub = \g -> sub (g . f)
 --
 -- Note that multiple 'IO' action can be scheduled using
 -- 'Control.Monad.Writer.Class.tell' from the @mtl@ library.
+--
+-- @since 1.9.0.0
 io :: JSM action -> Effect model action
 io action = withSink (action >>=)
 -----------------------------------------------------------------------------
@@ -159,6 +163,8 @@ io action = withSink (action >>=)
 --
 -- This is handy for scheduling @IO@ computations where you don't care
 -- about their results or when they complete.
+--
+-- @since 1.9.0.0
 io_ :: JSM () -> Effect model action
 io_ action = withSink (\_ -> action)
 -----------------------------------------------------------------------------
@@ -166,6 +172,7 @@ io_ action = withSink (\_ -> action)
 --
 -- This is handy for scheduling @IO@ computations that return a @Maybe@ value
 --
+-- @since 1.9.0.0
 for :: Foldable f => JSM (f action) -> Effect model action
 for actions = withSink $ \sink -> actions >>= flip for_ sink
 -----------------------------------------------------------------------------
@@ -180,6 +187,7 @@ for actions = withSink $ \sink -> actions >>= flip for_ sink
 --
 -- > update FetchJSON = withSink $ \sink -> getJSON (sink . ReceivedJSON) (sink . HandleError)
 --
+-- @since 1.9.0.0
 withSink :: (Sink action -> JSM ()) -> Effect model action
 withSink f = tell [ f ]
 -----------------------------------------------------------------------------

--- a/src/Miso/Event.hs
+++ b/src/Miso/Event.hs
@@ -106,10 +106,6 @@ onMounted action =
 -- element is created. It returns the /component-id/ from the component.
 -- Returning /component-id/ is useful when creating 'Component' dynamically.
 --
--- This way the parent can maintain a 'Map' of the child 'Component' IDs. When
--- the parent 'Component' wants to send a child 'Component' a message it can use
--- @notify'@.
---
 -- Use this or @onMounted@, but not both in the same @[Attribute action]@ list.
 --
 onMountedWith :: (MisoString -> action) -> Attribute action
@@ -159,12 +155,6 @@ onUnmounted action =
 -----------------------------------------------------------------------------
 -- | @onUnmounted action@ is an event that gets called after the DOM element
 -- is removed from the DOM. It returns the /component-id/ after the unmount call.
--- Returning /component-id/ is useful when dynamically created @Component@ need
--- to notify their parents about their own destruction.
---
--- This way the parent can maintain a @Map@ of the child @Component@ IDs. When
--- the parent @Component@ wants to send a child @Component@ a message it can use
--- @notify'@.
 --
 -- Use this or @onUnmounted@, but not both in the same @[Attribute action]@ list.
 --

--- a/src/Miso/Exception.hs
+++ b/src/Miso/Exception.hs
@@ -26,11 +26,6 @@ import qualified Miso.FFI as FFI
 --
 -- The two mounting errors that can occur during the lifetime of a miso application are
 --
--- * Not Mounted Exception
---
--- This occurs if a user tries to call @sample myComponent@ when @myComponent@ is currently
--- not mounted on the DOM.
---
 -- * Already Mounted Exception
 --
 -- It is a requirement that all @Component@ be named uniquely
@@ -43,9 +38,7 @@ import qualified Miso.FFI as FFI
 -- and logged to the console with /console.error()/
 --
 data MisoException
-  = NotMountedException MisoString
-  -- ^ Thrown when a @Component@ is sampled, yet not mounted.
-  | AlreadyMountedException MisoString
+  = AlreadyMountedException MisoString
   -- ^ Thrown when a @Component@ is attempted to be mounted twice.
   deriving (Show, Eq)
 ----------------------------------------------------------------------------
@@ -58,10 +51,6 @@ instance Exception MisoException
 -- > action `catch` exception
 exception :: SomeException -> JSM JSVal
 exception ex
-  | Just (NotMountedException name) <- fromException ex = do
-      FFI.consoleError
-        ("NotMountedException: Could not sample model state from the Component \"" <> name <> "\"")
-      pure jsNull
   | Just (AlreadyMountedException name) <- fromException ex = do
       FFI.consoleError ("AlreadyMountedException: Component \"" <> name <> "\" is already")
       pure jsNull

--- a/src/Miso/Internal.hs
+++ b/src/Miso/Internal.hs
@@ -1,13 +1,14 @@
 -----------------------------------------------------------------------------
-{-# LANGUAGE CPP                 #-}
-{-# LANGUAGE DataKinds           #-}
-{-# LANGUAGE LambdaCase          #-}
-{-# LANGUAGE BangPatterns        #-}
-{-# LANGUAGE KindSignatures      #-}
-{-# LANGUAGE RecordWildCards     #-}
-{-# LANGUAGE TypeApplications    #-}
-{-# LANGUAGE OverloadedStrings   #-}
-{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE CPP                        #-}
+{-# LANGUAGE DataKinds                  #-}
+{-# LANGUAGE LambdaCase                 #-}
+{-# LANGUAGE BangPatterns               #-}
+{-# LANGUAGE KindSignatures             #-}
+{-# LANGUAGE RecordWildCards            #-}
+{-# LANGUAGE TypeApplications           #-}
+{-# LANGUAGE OverloadedStrings          #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Miso.Internal
@@ -20,23 +21,25 @@
 module Miso.Internal
   ( -- * Internal functions
     initialize
-  , componentMap
-  , notify
-  , notify'
+  , freshComponentId
   , runView
-  , sample
-  , sample'
   , renderStyles
   , Hydrate(..)
   -- * Subscription
   , startSub
   , stopSub
+  -- * Pub / Sub
+  , subscribe
+  , unsubscribe
+  , publish
+  , Topic (..)
+  , topic
   ) where
 -----------------------------------------------------------------------------
-import           Control.Exception (throwIO)
-import           Control.Monad (forM, forM_, when, void)
+import           Control.Monad (forM, forM_, when, void, forever)
 import           Control.Monad.Reader (ask)
 import           Control.Monad.IO.Class
+import           Data.Aeson (FromJSON, ToJSON, Result, fromJSON, toJSON)
 import           Data.Foldable (toList)
 import           Data.IORef (IORef, newIORef, atomicModifyIORef', readIORef, atomicWriteIORef, modifyIORef')
 import           Data.Map.Strict (Map)
@@ -45,23 +48,21 @@ import qualified Data.Sequence as S
 import           Data.Sequence (Seq)
 import qualified JavaScript.Array as JSArray
 #ifndef GHCJS_BOTH
-import           Language.Javascript.JSaddle hiding (Sync)
+import           Language.Javascript.JSaddle hiding (Sync, Result)
 #else
 import           Language.Javascript.JSaddle
 #endif
-import           GHC.TypeLits (KnownSymbol, symbolVal)
 import           GHC.Conc (ThreadStatus(ThreadDied, ThreadFinished), ThreadId, killThread, threadStatus)
-import           Data.Proxy (Proxy(..))
 import           Prelude hiding (null)
 import           System.IO.Unsafe (unsafePerformIO)
 import           System.Mem.StableName (makeStableName)
 import           Text.HTML.TagSoup (Tag(..))
 import           Text.HTML.TagSoup.Tree (parseTree, TagTree(..))
 -----------------------------------------------------------------------------
-import           Miso.Concurrent (Waiter(..), waiter)
+import           Miso.Concurrent (Waiter(..), waiter, Mailbox, copyMailbox, readMail, sendMail, newMailbox)
 import           Miso.Delegate (delegator, undelegator)
 import           Miso.Diff (diff)
-import           Miso.Exception (MisoException(..), exception)
+import           Miso.Exception (exception)
 import qualified Miso.FFI.Internal as FFI
 import           Miso.String hiding (reverse)
 import           Miso.Types
@@ -73,7 +74,7 @@ import           Miso.Effect (Sub, Sink, Effect, runEffect, io_)
 -- | Helper function to abstract out initialization of @Component@ between top-level API functions.
 initialize
   :: Eq model
-  => Component name model action
+  => Component model action
   -> (Sink action -> JSM (MisoString, JSVal, IORef VTree))
   -- ^ Callback function is used to perform the creation of VTree
   -> JSM (IORef VTree)
@@ -84,7 +85,7 @@ initialize Component {..} getView = do
     componentSink = \action -> liftIO $ do
       atomicModifyIORef' componentActions $ \actions -> (actions S.|> action, ())
       serve
-  (componentName, componentMount, componentVTree) <- getView componentSink
+  (componentId, componentMount, componentVTree) <- getView componentSink
   componentSubThreads <- liftIO (newIORef M.empty)
   forM_ subs $ \sub -> do
     threadId <- FFI.forkJSM (sub componentSink)
@@ -95,7 +96,7 @@ initialize Component {..} getView = do
   let
     eventLoop !oldModel = liftIO wait >> do
       as <- liftIO $ atomicModifyIORef' componentActions $ \actions -> (S.empty, actions)
-      newModel <- foldEffects update Async componentName componentSink (toList as) oldModel
+      newModel <- foldEffects update Async componentId componentSink (toList as) oldModel
       oldName <- liftIO $ oldModel `seq` makeStableName oldModel
       newName <- liftIO $ newModel `seq` makeStableName newModel
       when (oldName /= newName && oldModel /= newModel) $ do
@@ -124,7 +125,7 @@ data Hydrate
 -- | @Component@ state, data associated with the lifetime of a @Component@
 data ComponentState model action
   = ComponentState
-  { componentName       :: MisoString
+  { componentId         :: ComponentId
   , componentSubThreads :: IORef (Map MisoString ThreadId)
   , componentMount      :: JSVal
   , componentVTree      :: IORef VTree
@@ -132,6 +133,248 @@ data ComponentState model action
   , componentModel      :: IORef model
   , componentActions    :: IORef (Seq action)
   }
+-----------------------------------------------------------------------------
+-- | A 'Topic' represents a place to send and receive messages. 'Topic' is used to facilitate
+-- communication between 'Component'. 'Component' can 'subscribe' to or 'publish' to any 'Topic',
+-- within the same 'Component' or across 'Component'.
+--
+-- This requires creating a custom 'ToJSON' / 'FromJSON'. Any other 'Component'
+-- can 'publish' or 'subscribe' to this @Topic message@. It is a way to provide
+-- loosely-coupled communication between 'Components'.
+--
+-- See 'publish', 'subscribe', 'unsubscribe' for more details.
+--
+-- When distributing 'Component' for third-party use, it is recommended to export
+-- the 'Topic', where 'message' is the JSON protocol.
+--
+--
+-- @since 1.9.0.0
+newtype Topic a = Topic MisoString
+  deriving (Ord, Eq, Show, ToMisoString)
+-----------------------------------------------------------------------------
+-- | Smart constructor for creating a @Topic message@ to write to
+--
+-- @
+--
+-- data Message
+--   = Increment
+--   | Decrement
+--   deriving (Show, Eq, Generic, ToJSON, FromJSON)
+--
+-- arithmetic :: Topic Message
+-- arithmetic = topic "arithmetic"
+--
+-- data Action
+--   = Notification (Result Message)
+--   | Subscribe
+--   | Unsubscribe
+--
+-- update_ :: Action -> Effect Int Action
+-- update_ = \case
+--   Unsubscribe ->
+--     unsubscribe arithmetic
+--   Subscribe ->
+--     subscribe arithmetic Notification
+--   Notification (Success Increment) ->
+--     update_ AddOne
+--   Notification (Success Decrement) ->
+--     update_ SubtractOne
+--   Notification (Error msg) ->
+--     io_ $ consoleError ("Decode failure: " <> ms msg)
+--
+-- @
+--
+-- @since 1.9.0.0
+topic :: MisoString -> Topic a
+topic = Topic
+-----------------------------------------------------------------------------
+mailboxes :: IORef (Map (Topic a) Mailbox)
+{-# NOINLINE mailboxes #-}
+mailboxes = unsafePerformIO $ liftIO (newIORef mempty)
+-----------------------------------------------------------------------------
+subscribers :: IORef (Map (ComponentId, Topic a) ThreadId)
+{-# NOINLINE subscribers #-}
+subscribers = unsafePerformIO $ liftIO (newIORef mempty)
+-----------------------------------------------------------------------------
+-- | Subscribes to a 'Topic', provides callback function that writes to 'Component' 'Sink'
+--
+-- If a @Topic message@ does not exist when calling 'subscribe' it is generated dynamically.
+-- Each subscriber decodes the received 'Value' using it's own 'FromJSON' instance. This provides
+-- for loose-coupling between 'Component'. As long as the underlying 'Value' are identical
+-- 'Component' can use their own types without serialization issues. @Topic message@ should
+-- have their own JSON API specification when being distributed.
+--
+-- @
+--
+-- arithmetic :: Topic Message
+-- arithmetic = topic "arithmetic"
+--
+-- clientComponent :: MisoString -> Component Int Action
+-- clientComponent name = component 0 update_ $ \m ->
+--   div_
+--   []
+--   [ br_ []
+--   , text (name <> " : " <> ms (m ^. _id))
+--   , button_ [ onClick Unsubscribe ] [ "unsubscribe" ]
+--   , button_ [ onClick Subscribe ] [ "subscribe" ]
+--   ] where
+--       update_ :: Action -> Effect Int Action
+--       update_ = \case
+--         AddOne -> do
+--           _id += 1
+--         SubtractOne ->
+--           _id -= 1
+--         Unsubscribe ->
+--           unsubscribe arithmetic
+--         Subscribe ->
+--           subscribe arithmetic Notification
+--         Notification (Success Increment) -> do
+--           update_ AddOne
+--         Notification (Success Decrement) -> do
+--           update_ SubtractOne
+--         Notification (Error msg) ->
+--           io_ $ consoleError ("Decode failure: " <> ms msg)
+--         _ -> pure ()
+--
+-- @
+--
+-- @since 1.9.0.0
+subscribe
+  :: FromJSON message
+  => Topic message
+  -> (Result message -> action)
+  -> Effect model action
+subscribe topicName toAction = do
+  vcompId <- ask
+  io_ $ do
+    subscribersMap <- liftIO (readIORef subscribers)
+    let key = (vcompId, topicName)
+    case M.lookup key subscribersMap of
+      Just _ ->
+        FFI.consoleWarn ("Already subscribed to: " <> ms topicName)
+      Nothing -> do
+        M.lookup topicName <$> liftIO (readIORef mailboxes) >>= \case
+          Nothing -> do
+            -- no mailbox exists, create a new one, register it and subscribe
+            mailbox <- liftIO $ do
+              mailbox <- newMailbox
+              atomicModifyIORef' mailboxes $ \m -> (M.insert topicName mailbox m, ())
+              pure mailbox
+            subscribeToMailbox key mailbox vcompId
+          Just mailbox -> do
+            subscribeToMailbox key mailbox vcompId
+  where
+    subscribeToMailbox key mailbox vcompId = do
+      threadId <- FFI.forkJSM $ do
+        clonedMailbox <- liftIO (copyMailbox mailbox)
+        ComponentState {..} <- (M.! vcompId) <$> liftIO (readIORef components)
+        forever $ do
+          message <- liftIO (readMail clonedMailbox)
+          componentSink $ toAction (fromJSON message)
+      liftIO $ atomicModifyIORef' subscribers $ \m ->
+        (M.insert key threadId m, ())
+-----------------------------------------------------------------------------
+-- Pub / Sub implementation
+--
+-- (Subscribe)
+--
+-- Check if you're already subscribed to this topic.
+--
+--  [true]  - If you're already subscribed, then it's a no-op (warn)
+--
+--  [false] - If you're not subscribed then fork a new thread that holds the duplicated topic
+--            and blocks on the read end of the duplicated topic, sink messages into component sink
+--
+-- (Unsubscribe)
+--
+-- Check if you're already subscribed to this topic
+--
+--  [true] - Kill the thread, delete the subscriber entry
+--
+--  [false] - If you're not subscribed, then it's a no-op (warn)
+--
+-- (Publish)
+--
+-- Check if the Topic exists
+--
+--  [true] - If it exists then write the message to the topic
+--
+--  [false] - If it doesn't exist, create it.
+--
+-- N.B. Components can be both publishers and subscribers to their own topics.
+-----------------------------------------------------------------------------
+-- | Unsubscribe to a 'Topic'
+--
+-- Unsubscribes a 'Component' from receiving messages from @Topic message@
+--
+-- See 'subscribe' for more use.
+--
+-- @since 1.9.0.0
+unsubscribe :: Topic message -> Effect model action
+unsubscribe topicName = ask >>= io_ . unsubscribe_ topicName
+-----------------------------------------------------------------------------
+-- | Internal unsubscribe used in component unmounting and in 'unsubscribe'
+unsubscribe_ :: Topic message -> ComponentId -> JSM ()
+unsubscribe_ topicName vcompId = do
+  let key = (vcompId, topicName)
+  subscribersMap <- liftIO (readIORef subscribers)
+  case M.lookup key subscribersMap of
+    Just threadId -> do
+      liftIO $ do
+        killThread threadId
+        atomicModifyIORef' subscribers $ \m ->
+          (M.delete key m, ())
+    Nothing ->
+      pure ()
+-----------------------------------------------------------------------------
+-- | Publish to a @Topic message@
+--
+-- @Topic message@ are generated dynamically if they do not exist. When using 'publish'
+-- all subscribers are immediately notified of a new message. A message is distributed as a 'Value'
+-- The underlying 'ToJSON' instance is used to construct this 'Value'.
+--
+-- We recommend documenting a public API for the JSON protocol message when distributing a 'Component'
+-- downstream to end users for consumption (be it inside a single cabal project or across multiple
+-- cabal projects).
+--
+-- @
+--
+-- arithmetic :: Topic Message
+-- arithmetic = topic "arithmetic"
+--
+-- server :: Component () Action
+-- server = component () update_ $ \() ->
+--   div_
+--   []
+--   [ "Server component"
+--   , button_ [ onClick AddOne ] [ "+" ]
+--   , button_ [ onClick SubtractOne ] [ "-" ]
+--   , component_ (client_ "client 1")
+--     [ onMountedWith Mount
+--     ]
+--   , component_ (client_ "client 2")
+--     [ onMountedWith Mount
+--     ]
+--   ] where
+--       update_ :: Action -> Effect () Action
+--       update_ = \case
+--         AddOne ->
+--           publish arithmetic Increment
+--         SubtractOne ->
+--           publish arithemtic Decrement
+--
+-- @
+--
+-- @since 1.9.0.0
+publish :: ToJSON message => Topic message -> message -> Effect model action
+publish topicName value = io_ $ do
+  result <- M.lookup topicName <$> liftIO (readIORef mailboxes)
+  case result of
+    Just mailbox ->
+      liftIO $ sendMail mailbox (toJSON value)
+    Nothing -> liftIO $ do
+      mailbox <- newMailbox
+      void $ atomicModifyIORef' mailboxes $ \m -> (M.insert topicName mailbox m, ())
 -----------------------------------------------------------------------------
 subIds :: IORef Int
 {-# NOINLINE subIds #-}
@@ -146,7 +389,9 @@ componentIds :: IORef Int
 {-# NOINLINE componentIds #-}
 componentIds = unsafePerformIO $ liftIO (newIORef 0)
 -----------------------------------------------------------------------------
-freshComponentId :: IO MisoString
+type ComponentId = MisoString
+-----------------------------------------------------------------------------
+freshComponentId :: IO ComponentId
 freshComponentId = do
   x <- atomicModifyIORef' componentIds $ \y -> (y + 1, y)
   pure ("miso-component-id-" <> ms x)
@@ -155,88 +400,9 @@ freshComponentId = do
 --
 -- This is a global @Component@ @Map@ that holds the state of all currently
 -- mounted @Component@s
-componentMap :: IORef (Map MisoString (ComponentState model action))
-{-# NOINLINE componentMap #-}
-componentMap = unsafePerformIO (newIORef mempty)
------------------------------------------------------------------------------
--- | Read-only access to another @Component@'s @model@.
--- This function is safe to use when a child @Component@ wishes access
--- a parent @Components@ @model@ state. Under this circumstance the parent
--- will always be mounted and available.
---
--- Otherwise, if a sibling or parent @Component@'s @model@ state is attempted
--- to be accessed. Then we throw a @NotMountedException@, in the case the
--- @Component@ being accessed is not available.
-sample
-  :: forall name model action . KnownSymbol name
-  => Component name model action
-  -> JSM model
-sample _ = do
-  componentStateMap <- liftIO (readIORef componentMap)
-  liftIO (case M.lookup name componentStateMap of
-    Nothing -> throwIO (NotMountedException name)
-    Just ComponentState {..} -> readIORef componentModel)
-  where
-    name = ms $ symbolVal (Proxy @name)
------------------------------------------------------------------------------
--- | Like @sample@ except used for @Component Dynamic model action@ where the component-id has been retrieved via @ask@ and generated using @onMountedWith@.
---
--- We use the @Component Dynamic model action@ argument to ensure the 'model'
--- sampled unifies with what @sample'@ returns.
---
-sample'
-  :: MisoString
-  -> Component Dynamic model action
-  -> JSM model
-sample' name _ = do
-  componentStateMap <- liftIO (readIORef componentMap)
-  liftIO (case M.lookup name componentStateMap of
-    Nothing -> throwIO (NotMountedException name)
-    Just ComponentState {..} -> readIORef componentModel)
------------------------------------------------------------------------------
--- | Used for bidirectional communication between components.
--- Specify the mounted @Component@ you'd like to target.
---
--- This function is used to send messages to @Component@ that are mounted on
--- other parts of the DOM tree.
---
-notify
-  :: forall name model action . KnownSymbol name
-  => Component name model action
-  -> action
-  -> JSM ()
-notify Component {..} action = do
-  componentStateMap <- liftIO (readIORef componentMap)
-  case M.lookup name componentStateMap of
-    Nothing -> do
-      when (logLevel `elem` [DebugNotify, DebugAll]) $ do
-        FFI.consoleWarn $
-          "[DEBUG_NOTIFY] Could not find component named: " <> name
-    Just ComponentState {..} ->
-      componentSink action
-  where
-    name = ms $ symbolVal (Proxy @name)
------------------------------------------------------------------------------
--- | Like @notify@ except used for dynamic @Component@ where the /component-id/
--- has been retrieved via @ask@ and generated from @onMountedWith@.
---
--- We use the @Component Dynamic model action@ argument to ensure the 'action'
--- being used unified with what the component expects.
---
-notify'
-  :: MisoString
-  -> Component Dynamic model action
-  -> action
-  -> JSM ()
-notify' name Component {..} action = do
-  componentStateMap <- liftIO (readIORef componentMap)
-  case M.lookup name componentStateMap of
-    Nothing ->
-      when (logLevel `elem` [DebugNotify, DebugAll]) $ do
-        FFI.consoleWarn $
-          "[DEBUG_NOTIFY'] Could not find component named: " <> name
-    Just ComponentState {..} ->
-      componentSink action
+components :: IORef (Map MisoString (ComponentState model action))
+{-# NOINLINE components #-}
+components = unsafePerformIO (newIORef mempty)
 -----------------------------------------------------------------------------
 -- | Data type to indicate if effects should be handled asynchronously
 -- or synchronously.
@@ -274,7 +440,7 @@ foldEffects update synchronicity name snk (e:es) o =
 drawComponent
   :: Hydrate
   -> MisoString
-  -> Component name model action
+  -> Component model action
   -> Sink action
   -> JSM (MisoString, JSVal, IORef VTree)
 drawComponent hydrate name Component {..} snk = do
@@ -286,7 +452,7 @@ drawComponent hydrate name Component {..} snk = do
 -----------------------------------------------------------------------------
 -- | Drains the event queue before unmounting, executed synchronously
 drain
-  :: Component name model action
+  :: Component model action
   -> ComponentState model action
   -> JSM ()
 drain app@Component{..} cs@ComponentState {..} = do
@@ -295,22 +461,28 @@ drain app@Component{..} cs@ComponentState {..} = do
     where
       go as = do
         x <- liftIO (readIORef componentModel)
-        y <- foldEffects update Sync componentName componentSink (toList as) x
+        y <- foldEffects update Sync componentId componentSink (toList as) x
         liftIO (atomicWriteIORef componentModel y)
         drain app cs
 -----------------------------------------------------------------------------
 -- | Helper function for cleanly destroying a @Component@
 unmount
   :: Function
-  -> Component name model action
+  -> Component model action
   -> ComponentState model action
   -> JSM ()
 unmount mountCallback app@Component {..} cs@ComponentState {..} = do
   undelegator componentMount componentVTree events (logLevel `elem` [DebugEvents, DebugAll])
   freeFunction mountCallback
   liftIO (mapM_ killThread =<< readIORef componentSubThreads)
+  killSubscribers componentId
   drain app cs
-  liftIO $ atomicModifyIORef' componentMap $ \m -> (M.delete componentName m, ())
+  liftIO $ atomicModifyIORef' components $ \m -> (M.delete componentId m, ())
+-----------------------------------------------------------------------------
+killSubscribers :: ComponentId -> JSM ()
+killSubscribers componentId =
+  mapM_ (flip unsubscribe_ componentId) =<<
+    M.keys <$> liftIO (readIORef mailboxes)
 -----------------------------------------------------------------------------
 -- | Internal function for construction of a Virtual DOM.
 --
@@ -326,11 +498,8 @@ runView
   -> LogLevel
   -> Events
   -> JSM VTree
-runView hydrate (VComp name attrs (SomeComponent app)) snk _ _ = do
-  compName <-
-    if null name
-    then liftIO freshComponentId
-    else pure name
+runView hydrate (VComp attrs (SomeComponent app)) snk _ _ = do
+  compName <- liftIO freshComponentId
   mountCallback <- do
     FFI.syncCallback1 $ \continuation -> do
       vtreeRef <- initialize app (drawComponent hydrate compName app)
@@ -338,7 +507,7 @@ runView hydrate (VComp name attrs (SomeComponent app)) snk _ _ = do
       void $ call continuation global [vtree]
   unmountCallback <- toJSVal =<< do
     FFI.syncCallback $ do
-      M.lookup compName <$> liftIO (readIORef componentMap) >>= \case
+      M.lookup compName <$> liftIO (readIORef components) >>= \case
         Nothing -> pure ()
         Just componentState ->
           unmount mountCallback app componentState
@@ -447,8 +616,8 @@ parseView html = reverse (go (parseTree html) [])
 -- | Registers components in the global state
 registerComponent :: MonadIO m => ComponentState model action -> m ()
 registerComponent componentState = liftIO
-  $ modifyIORef' componentMap
-  $ M.insert (componentName componentState) componentState
+  $ modifyIORef' components
+  $ M.insert (componentId componentState) componentState
 -----------------------------------------------------------------------------
 -- | Registers components in the global state
 renderStyles :: [CSS] -> JSM ()
@@ -469,11 +638,13 @@ renderStyles styles =
 -- update Action =
 --   startSub LoggerSub $ \sink -> forever (threadDelay (secs 1) >> consoleLog "test")
 -- @
+--
+-- @since 1.9.0.0
 startSub :: ToMisoString subKey => subKey -> Sub action -> Effect model action
 startSub subKey sub = do
   compName <- ask
   io_
-    (M.lookup compName <$> liftIO (readIORef componentMap) >>= \case
+    (M.lookup compName <$> liftIO (readIORef components) >>= \case
       Nothing -> pure ()
       Just compState@ComponentState {..} -> do
         mtid <- liftIO (M.lookup (ms subKey) <$> readIORef componentSubThreads)
@@ -502,11 +673,13 @@ startSub subKey sub = do
 -- update Action = do
 --   stopSub LoggerSub
 -- @
+--
+-- @since 1.9.0.0
 stopSub :: ToMisoString subKey => subKey -> Effect model action
 stopSub subKey = do
   compName <- ask
   io_
-    (M.lookup compName <$> liftIO (readIORef componentMap) >>= \case
+    (M.lookup compName <$> liftIO (readIORef components) >>= \case
       Nothing -> do
         pure ()
       Just ComponentState {..} -> do

--- a/src/Miso/Lens.hs
+++ b/src/Miso/Lens.hs
@@ -135,6 +135,7 @@ module Miso.Lens
   , (<>~)
   , _1
   , _2
+  , _id
   ) where
 ----------------------------------------------------------------------------
 import Control.Monad.State (MonadState, modify, gets)
@@ -168,7 +169,7 @@ type Lens' record field = Lens record field
 ----------------------------------------------------------------------------
 -- | Lens are Categories, and can therefore be composed.
 instance Category Lens where
-  id = Lens (\x -> x) (\x _ -> x)
+  id = Lens Prelude.id (flip const)
   Lens g1 s1 . Lens g2 s2 = Lens
     { _get = g1 <<< g2
     , _set = \r f -> s2 r (s1 (g2 r) f)
@@ -654,6 +655,15 @@ _1 = lens fst $ \(_,b) x -> (x,b)
 -- @
 _2 :: Lens (a,b) b
 _2 = lens snd $ \(a,_) x -> (a,x)
+---------------------------------------------------------------------------------
+-- | @Lens@ that operates on itself 
+--
+-- @
+-- update AddOne = do
+--   _id += 1
+-- @
+_id :: Lens a a
+_id = Control.Category.id
 ---------------------------------------------------------------------------------
 -- | Smart constructor @lens@ function. Used to easily construct a @Lens@
 --

--- a/src/Miso/Render.hs
+++ b/src/Miso/Render.hs
@@ -93,10 +93,10 @@ renderBuilder (VNode _ tag attrs children) =
     | tag `notElem` ["img", "input", "br", "hr", "meta", "link"]
     ]
   ]
-renderBuilder (VComp mount attributes (SomeComponent Component {..})) =
+renderBuilder (VComp attributes (SomeComponent Component {..})) =
   mconcat
   [ stringUtf8 "<div data-component-id=\""
-  , fromMisoString mount
+  , fromMisoString ""
   , "\" "
   , intercalate " " (renderAttrs <$> attributes)
   , ">"


### PR DESCRIPTION
:artificial_satellite: Pub / Sub 📡  / Mailboxes 📬 
============

Per chats with @kaol in #1000, while `Component` are now completely isolated due to the existential type encoding, `Component` communication is not. Currently `notify` and `sample` require type-level unification on either `action` or `model`.

This has practical implications for module dependencies, and `Component` sharing, which make usage unwieldy at times (as noted in #1000)

This PR is a complete overhaul of `Component` communication, aimed at preserving isolation of `Component`, yet allowing for intra & inter-`Component` communication with `publish`, `subscribe`, `unsubscribe` primitives via a user-defined JSON protocol.

This PR aims to implement a variant of the original Elm mailbox system pioneered by @evancz. Under the hood this uses a broadcast `TChan` from `stm` (`newBroadCastTChanIO`) which only allows `dupTChan` for reads and ensures memory is reclaimed. See `Miso.Concurrent`.

`Component` can now communicate via a JSON protocol, this is embedded in the new primitives via `ToJSON` / `FromJSON` constraints. This frees up `Component` consumers to use their own types as long as the underlying `Value` is identical. This should also avoid the overhead of encoding / decoding via strings.

We can now drop `DataKinds` which was arguably a hindrance for adoption and not simple Haskell philosophy.

`Topic` are created on demand in `publish` / `subscribe` if they do not exist.

 - [x] Add `subscribe`, `unsubscribe`, `publish` primitives.
 - [x] Remove `"name"` from `Component` (all components are now dynamic)
 - [x] Rework `examples/component` to include pub sub system
 - [x] Add `stm` dep.
 - [x] Drop `notify`, `sample`.
 - [x] Update `Miso.Concurrent` to use `Topic`, a wrapper over a broadcast `TChan`.
 - [x] `componentMap` -> `components`
 - [x] Add `_id` lens (tweak `Category` instance on `Lens`)
 - [x] Update `unmount` to unsubscribe from all topics
 - [x] `defaultComponent` -> `component`
Example usage of `server` / `client` communication pattern in `examples/components`.