### PR TITLE
Type safe pub/sub

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,9 +161,9 @@ main = run (startComponent component)
 foreign export javascript "hs_start" main :: IO ()
 #endif
 ----------------------------------------------------------------------------
--- | `defaultComponent` takes as arguments the initial model, update function, view function
+-- | `component` takes as arguments the initial model, update function, view function
 component :: Component Model Action
-component = defaultComponent emptyModel updateModel viewModel
+component = component emptyModel updateModel viewModel
 ----------------------------------------------------------------------------
 -- | Empty application state
 emptyModel :: Model

--- a/README.md
+++ b/README.md
@@ -129,7 +129,6 @@ This file contains a simple `miso` counter application.
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
 {-# LANGUAGE LambdaCase        #-}
-{-# LANGUAGE DataKinds         #-}
 {-# LANGUAGE CPP               #-}
 ----------------------------------------------------------------------------
 module Main where
@@ -163,7 +162,7 @@ foreign export javascript "hs_start" main :: IO ()
 #endif
 ----------------------------------------------------------------------------
 -- | `defaultComponent` takes as arguments the initial model, update function, view function
-component :: Component "app" Model Action
+component :: Component Model Action
 component = defaultComponent emptyModel updateModel viewModel
 ----------------------------------------------------------------------------
 -- | Empty application state

--- a/examples/canvas2d/Main.hs
+++ b/examples/canvas2d/Main.hs
@@ -35,7 +35,7 @@ main =
     earth <- newImage (baseUrl <> "canvas_earth.png")
     startComponent (app sun moon earth) { initialAction = Just GetTime }
   where
-    app sun moon earth = defaultComponent (0.0, 0.0) updateModel (view_ sun moon earth)
+    app sun moon earth = component (0.0, 0.0) updateModel (view_ sun moon earth)
     view_ sun moon earth m =
       div_
       [ id_ "canvas grid" ]

--- a/examples/canvas2d/Main.hs
+++ b/examples/canvas2d/Main.hs
@@ -1,6 +1,5 @@
 -----------------------------------------------------------------------------
 {-# LANGUAGE CPP               #-}
-{-# LANGUAGE DataKinds         #-}
 {-# LANGUAGE TypeApplications  #-}
 {-# LANGUAGE OverloadedStrings #-}
 -----------------------------------------------------------------------------
@@ -34,7 +33,7 @@ main =
     sun <- newImage (baseUrl <> "canvas_sun.png")
     moon <- newImage (baseUrl <> "canvas_moon.png")
     earth <- newImage (baseUrl <> "canvas_earth.png")
-    startComponent @"app" (app sun moon earth) { initialAction = Just GetTime }
+    startComponent (app sun moon earth) { initialAction = Just GetTime }
   where
     app sun moon earth = defaultComponent (0.0, 0.0) updateModel (view_ sun moon earth)
     view_ sun moon earth m =

--- a/examples/components/Main.hs
+++ b/examples/components/Main.hs
@@ -60,9 +60,9 @@ server = component () update_ $ \() ->
       update_ :: Action -> Effect () Action
       update_ = \case
         AddOne ->
-          publish "command" Increment
+          publish topic Increment
         SubtractOne ->
-          publish "command" Decrement
+          publish topic Decrement
         Mount compId ->
           io_ $ consoleLog ("Mounted component: " <> compId)
         _ -> pure ()
@@ -86,10 +86,10 @@ clientComponent name = component 0 update_ $ \m ->
         SubtractOne ->
           _id -= 1
         Unsubscribe ->
-          unsubscribe "command"
+          unsubscribe topic
         Subscribe -> do
           io_ (consoleLog "subscribing...")
-          subscribe "command" Notification
+          subscribe topic Notification
         Notification (Success Increment) ->
           update_ AddOne
         Notification (Success Decrement) ->
@@ -97,4 +97,7 @@ clientComponent name = component 0 update_ $ \m ->
         Notification (Error msg) ->
           io_ $ consoleError ("Decode failure: " <> ms msg)
         _ -> pure ()
+
+topic :: TopicName Message
+topic = mkTopic "command"
 -----------------------------------------------------------------------------

--- a/examples/components/Main.hs
+++ b/examples/components/Main.hs
@@ -90,13 +90,11 @@ clientComponent name = defaultComponent 0 update_ $ \m ->
         Subscribe -> do
           io_ (consoleLog "subscribing...")
           subscribe "command" Notification
-        Notification (Success Increment) -> do
-          io_ $ consoleLog "inside of success increment"
+        Notification (Success Increment) ->
           update_ AddOne
-        Notification (Success Decrement) -> do
-          io_ $ consoleLog "inside of success decrement"
+        Notification (Success Decrement) ->
           update_ SubtractOne
-        Notification msg ->
-          io_ $ consoleError ("Decode failure: " <> ms (show msg))
+        Notification (Error msg) ->
+          io_ $ consoleError ("Decode failure: " <> ms msg)
         _ -> pure ()
 -----------------------------------------------------------------------------

--- a/examples/components/Main.hs
+++ b/examples/components/Main.hs
@@ -1,330 +1,102 @@
-{-# LANGUAGE CPP #-}
-{-# LANGUAGE DataKinds #-}
-{-# LANGUAGE TypeApplications #-}
-{-# LANGUAGE OverloadedStrings #-}
-
+-----------------------------------------------------------------------------
+{-# LANGUAGE CPP                #-}
+{-# LANGUAGE LambdaCase         #-}
+{-# LANGUAGE DeriveGeneric      #-}
+{-# LANGUAGE DeriveAnyClass     #-}
+{-# LANGUAGE TypeApplications   #-}
+{-# LANGUAGE OverloadedStrings  #-}
+-----------------------------------------------------------------------------
 module Main where
-
-import Control.Concurrent
-import Control.Monad
-import Control.Monad.IO.Class (liftIO)
-
-import Miso
-import Miso.String
-import Miso.Lens
-
-type Model = Int
-
+-----------------------------------------------------------------------------
+import           GHC.Generics
+import           Data.Aeson
+-----------------------------------------------------------------------------
+import           Miso
+import           Miso.String
+import           Miso.Lens
+-----------------------------------------------------------------------------
 #ifdef WASM
 foreign export javascript "hs_start" main :: IO ()
 #endif
-
+-----------------------------------------------------------------------------
 data Action
-    = AddOne
-    | SubtractOne
-    | SayHelloWorld
-    | ToggleAction
-    | UnMount MisoString
-    | Mount MisoString
-    | Sample
-    deriving (Show, Eq)
-
-data MainAction
-    = Toggle
-    | MountMain
-    | UnMountMain
-    | SampleChild
-    | StartLogger
-    | StopLogger
-
-type MainModel = Bool
-
+  = AddOne
+  | SubtractOne
+  | Mount MisoString
+  | Subscribe
+  | Unsubscribe
+  | Notification (Result Message)
+  deriving (Show, Eq, Generic)
+-----------------------------------------------------------------------------
+data Message
+  = Increment
+  | Decrement
+  deriving (Show, Eq, Generic, ToJSON, FromJSON)
+-----------------------------------------------------------------------------
 main :: IO ()
-main = run $ startComponent app
-
-secs :: Int -> Int
-secs = (* 1000000)
-
-loggerSub :: MisoString -> Sub action
-loggerSub msg = \_ ->
-  forever $ do
-    liftIO $ threadDelay (secs 1)
-    consoleLog msg
-
-app :: Component "app" MainModel MainAction
-app = (defaultComponent False updateModel1 viewModel1)
-  { logLevel = DebugHydrate
-  , subs = []
-  } 
-
-counterComponent2 :: Component "app-2" Model Action
-counterComponent2 = (defaultComponent 0 updateModel2 viewModel2)
-  { subs = [loggerSub "component-2 sub"]
-  }
-
-counterComponent3 :: Component "app-3" (Bool, Model) Action
-counterComponent3 = (defaultComponent (True, 0) updateModel3 viewModel3)
-  { subs = [ loggerSub "component-3 sub"]
-  }
-
-counterComponent4 :: Component "app-4" Model Action
-counterComponent4 = (defaultComponent 0 updateModel4 viewModel4)
-  { subs = [loggerSub "component-4 sub"]
-  }
-
--- | Constructs a virtual DOM from a model
-viewModel1 :: MainModel -> View MainAction
-viewModel1 x =
-    div_
-        []
-        [ "Component 1 - Three sub components nested recursively below me"
-        , br_ []
-        , "The +/- for Components 3 and 4 will affect their local state"
-        , br_ []
-        , "The +/- for Components 3 and 4 will affect their local state"
-        , br_ []
-        , "Toggle component button will oscillate between component 4 and 5"
-        , br_ []
-        , "Components 4 will update its own state and the state of component 3"
-        , br_ []
-        , "Components 5 will update its own state and the state of component 2"
-        , br_ []
-        , "Sample state will read from component 2 or 3's state depending on the toggle"
-        , br_ []
-        , "Example of using 'start' and 'stop' subscriptions dynamically"
-        , div_ []
-          [ button_ [ onClick StartLogger ] [ "start logger" ]
-          , button_ [ onClick StopLogger ] [ "stop logger" ]
-          ]
-        , button_ [onClick Toggle] [text "Toggle Component 2"]
-        , button_ [onClick SampleChild] [text "Sample Child (unsafe)"]
-        , if x
-            then
-                component_ counterComponent2
-                  [ onMounted MountMain
-                  , onUnmounted UnMountMain
-                  ]
-            else div_ [id_ "other test"] ["Main application content"]
-        ]
-
-data LoggerSub = LoggerSub
-  deriving (Eq, Ord)
-
-instance ToMisoString LoggerSub where
-  toMisoString LoggerSub = "LoggerSub"
-
--- | Updates model, optionally introduces side effects
-updateModel1 :: MainAction -> Effect MainModel MainAction
-updateModel1 StartLogger = startSub LoggerSub (loggerSub "main-app")
-updateModel1 StopLogger  = stopSub LoggerSub
-updateModel1 Toggle = modify not
-updateModel1 UnMountMain =
-  io_ (consoleLog "Component 2 was unmounted!")
-updateModel1 MountMain =
-  io_ (consoleLog "Component 2 was mounted!")
-updateModel1 SampleChild = do
-  io_ $ do
-    componentTwoModel <- sample counterComponent2
-    consoleLog $
-        "Sampling child component 2 from parent component main (unsafe): " <>
-          ms (show componentTwoModel)
-
--- | Updates model, optionally introduces side effects
-updateModel2 :: Action -> Effect Model Action
-updateModel2 AddOne = modify (+1)
-updateModel2 SubtractOne = modify (subtract 1)
-updateModel2 u@UnMount{} = unmountAction u
-updateModel2 m@Mount{} = mountAction m
-updateModel2 SayHelloWorld = do
-  io_ (consoleLog "Hello World from Component 2")
-updateModel2 _ = pure ()
-
-unmountAction :: Action -> Effect model action
-unmountAction (UnMount name) = io_ $ consoleLog ("Component " <> name <> " was unmounted!")
-unmountAction _ = pure ()
-
-mountAction :: Action -> Effect model action
-mountAction (Mount name) = io_ $ consoleLog ("Component " <> name <> " was mounted!")
-mountAction _ = pure ()
-
--- | Constructs a virtual DOM from a model
-viewModel2 :: Model -> View Action
-viewModel2 x =
-    div_
-        []
-        [ "This is the view for Component 2"
-        , button_ [onClick AddOne] [text "+"]
-        , text (ms x)
-        , button_ [onClick SubtractOne] [text "-"]
-        , component_ counterComponent3
-          [ onMounted (Mount "3")
-          , onUnmounted (UnMount "3")
-          ]
-        ]
-
--- | Updates model, optionally introduces side effects
-updateModel3 :: Action -> Effect (Bool, Model) Action
-updateModel3 AddOne = do
-  modify (fmap (+1))
-updateModel3 SubtractOne = do
-  modify (fmap (subtract 1))
-updateModel3 ToggleAction =
-  modify $ \(x,y) -> (not x, y)
-updateModel3 x@UnMount{} = unmountAction x
-updateModel3 x@Mount{} = mountAction x
-updateModel3 SayHelloWorld = do
-  io_ (consoleLog "Hello World from Component 3")
-updateModel3 _ = pure ()
-
--- | Constructs a virtual DOM from a model
-viewModel3 :: (Bool, Model) -> View Action
-viewModel3 (toggle, x) =
-    div_ [] $
-        [ "This is the view for Component 3"
-        , button_ [onClick AddOne] [text "+"]
-        , text (ms x)
-        , button_ [onClick SubtractOne] [text "-"]
-        , button_ [onClick ToggleAction]
-          [ text $ "Toggle Component " <> if toggle then "4" else "5"
-          ]
-        ] ++ [ if toggle
-               -- dmj: N.B. if you are replacing a component w/ another component
-               -- when using the 'component_' function you *must* use 'embedKeyed'
-               -- , think of it like a StableName. Failure to do so is undefined behavior
-               -- but it will probably result in the component not actually getting replaced.
-               --
-               -- If you are replacing an unnamed component (using 'component_') with anything else (e.g. 'vtext', 'vnode',
-               -- 'vcomp', null), then you don't need to worry about this.
-               then
-                 component_ counterComponent4
-                   [ onMounted (Mount "4")
-                   , onUnmounted (UnMount "4")
-                   ]
-               else
-                 component_ counterComponent5
-                   [ onMounted (Mount "5")
-                   , onUnmounted (UnMount "5")
-                   ]
-             ]
-
--- | Updates model, optionally introduces side effects
-updateModel4 :: Action -> Effect Model Action
-updateModel4 AddOne = do
-  modify (+1)
-  io_ (notify counterComponent3 AddOne)
-updateModel4 SubtractOne = do
-  modify (subtract 1)
-  io_ (notify counterComponent3 SubtractOne)
-updateModel4 Sample =
-  io_ $ do
-    componentTwoModel <- sample counterComponent3
-    consoleLog $
-      "Sampling parent component 3 from child component 4: " <>
-         ms (show componentTwoModel)
-updateModel4 SayHelloWorld = do
-  io_ (consoleLog "Hello World from Component 4")
-updateModel4 _ = pure ()
-
--- | Constructs a virtual DOM from a model
-viewModel4 :: Model -> View Action
-viewModel4 x =
-    div_
-        []
-        [ "This is the view for Component 4"
-        , button_ [onClick AddOne] [text "+"]
-        , text (ms x)
-        , button_ [onClick SubtractOne] [text "-"]
-        , button_ [onClick Sample] [text "Sample Component 3 state"]
-        ]
-
-app5 :: Component "app-5" (Model, Maybe MisoString) Action
-app5 =
-        counterComponent5
-            { subs = [loggerSub "component-5 sub"]
-            }
-
-counterComponent5 :: Component "app-5" (Model, Maybe MisoString) Action
-counterComponent5 = defaultComponent (0, Nothing) updateModel5 viewModel5
-
--- | Updates model, optionally introduces side effects
-updateModel5 :: Action -> Effect (Model, Maybe MisoString) Action
-updateModel5 AddOne = do
-  _1 += 1
-  maybeChildId <- use _2
-  forM_ maybeChildId $ \childId ->
-    io_ (notify' childId counterComponent6 AddOne)
-  io_ (notify counterComponent2 AddOne)
-updateModel5 SubtractOne = do
-  _1 -= 1
-  io_ (notify counterComponent2 SubtractOne)
-updateModel5 Sample = do
-  io_ $ do
-    componentTwoModel <- sample counterComponent2
-    consoleLog $
-      "Sampling parent component 2 from child component 5: " <>
-         ms (show componentTwoModel)
-
-  maybeChildId <- use _2
-  io_ $ do
-    forM_ maybeChildId $ \childId -> do
-      componentTwoModel <- sample' childId counterComponent6
-      consoleLog $
-        "Sampling parent component 6 from child component 5: " <>
-           ms (show componentTwoModel)
-
-updateModel5 SayHelloWorld = do
-  io_ (consoleLog "Hello World from Component 5")
-updateModel5 (Mount childId) = do
-  io_ $ consoleLog $ "In mount, setting childId: " <> childId
-  _2 ?= childId
-updateModel5 _ = pure ()
-
--- | Constructs a virtual DOM from a model
-viewModel5 :: (Model, Maybe MisoString) -> View Action
-viewModel5 (x, _) =
-    div_
-        []
-        [ "This is the view for Component 5"
-        , button_ [onClick AddOne] [text "+"]
-        , text (ms x)
-        , button_ [onClick SubtractOne] [text "-"]
-        , button_ [onClick Sample] [text "Sample Component 2 state"]
-        , "Here is dynamic component 6..."
-        , br_ []
-        , component_ counterComponent6
-          [ onMountedWith Mount
-          ]
-        ]
-
--- | "" here means the component is given a dynamically generated name, can also leave generic
--- the component_ or componentWith_
-counterComponent6 :: Component Dynamic Model Action
-counterComponent6 = defaultComponent 0 updateModel6 viewModel6
-
--- | Updates model, optionally introduces side effects
-updateModel6 :: Action -> Effect Model Action
-updateModel6 AddOne = do
-  modify (+1)
-updateModel6 SubtractOne = do
-  modify (subtract 1)
-updateModel6 Sample =
-  io_ $ do
-    componentTwoModel <- sample counterComponent3
-    consoleLog $
-      "Sampling parent component 3 from child component 6: " <>
-         ms (show componentTwoModel)
-updateModel6 SayHelloWorld = do
-  io_ (consoleLog "Hello World from Component 6")
-updateModel6 _ = pure ()
-
--- | Constructs a virtual DOM from a model
-viewModel6 :: Model -> View Action
-viewModel6 x =
-    div_
-        []
-        [ "This is the view for Component 6"
-        , button_ [onClick AddOne] [text "+"]
-        , text (ms x)
-        , button_ [onClick SubtractOne] [text "-"]
-        , button_ [onClick Sample] [text "Sample Component 3 state"]
-        ]
+main = run (startComponent server)
+-----------------------------------------------------------------------------
+-- | Demonstrates a simple server / client, pub / sub setup for 'Component'
+-- In this contrived example, the server component holds the
+-- incrementing / decrementing actions, and relays them to the clients
+-- via the pub / sub mechanism.
+--
+-- Notice the server has no 'model' (e.g. `()`)
+--
+server :: Component () Action
+server = defaultComponent () update_ $ \() ->
+  div_
+  []
+  [ "Server component"
+  , button_ [ onClick AddOne ] [ "+" ]
+  , button_ [ onClick SubtractOne ] [ "-" ]
+  , component_ (client_ "client 1")
+    [ onMountedWith Mount
+    ]
+  , component_ (client_ "client 2")
+    [ onMountedWith Mount
+    ]
+  ] where
+      update_ :: Action -> Effect () Action
+      update_ = \case
+        AddOne ->
+          publish "command" Increment
+        SubtractOne ->
+          publish "command" Decrement
+        Mount compId ->
+          io_ $ consoleLog ("Mounted component: " <> compId)
+        _ -> pure ()
+-----------------------------------------------------------------------------
+client_ :: MisoString -> Component Int Action
+client_ name = (clientComponent name) { initialAction = Just Subscribe }
+-----------------------------------------------------------------------------
+clientComponent :: MisoString -> Component Int Action
+clientComponent name = defaultComponent 0 update_ $ \m ->
+  div_
+  []
+  [ br_ []
+  , text (name <> " : " <> ms (m ^. _id))
+  , button_ [ onClick Unsubscribe ] [ "unsubscribe" ]
+  , button_ [ onClick Subscribe ] [ "subscribe" ]
+  ] where
+      update_ :: Action -> Effect Int Action
+      update_ = \case
+        AddOne -> do
+          _id += 1
+        SubtractOne ->
+          _id -= 1
+        Unsubscribe ->
+          unsubscribe "command"
+        Subscribe -> do
+          io_ (consoleLog "subscribing...")
+          subscribe "command" Notification
+        Notification (Success Increment) -> do
+          io_ $ consoleLog "inside of success increment"
+          update_ AddOne
+        Notification (Success Decrement) -> do
+          io_ $ consoleLog "inside of success decrement"
+          update_ SubtractOne
+        Notification msg ->
+          io_ $ consoleError ("Decode failure: " <> ms (show msg))
+        _ -> pure ()
+-----------------------------------------------------------------------------

--- a/examples/components/Main.hs
+++ b/examples/components/Main.hs
@@ -44,7 +44,7 @@ main = run (startComponent server)
 -- Notice the server has no 'model' (e.g. `()`)
 --
 server :: Component () Action
-server = defaultComponent () update_ $ \() ->
+server = component () update_ $ \() ->
   div_
   []
   [ "Server component"
@@ -71,7 +71,7 @@ client_ :: MisoString -> Component Int Action
 client_ name = (clientComponent name) { initialAction = Just Subscribe }
 -----------------------------------------------------------------------------
 clientComponent :: MisoString -> Component Int Action
-clientComponent name = defaultComponent 0 update_ $ \m ->
+clientComponent name = component 0 update_ $ \m ->
   div_
   []
   [ br_ []

--- a/examples/fetch/Main.hs
+++ b/examples/fetch/Main.hs
@@ -52,7 +52,7 @@ data Action
   deriving (Show, Eq)
 ----------------------------------------------------------------------------
 app :: Component Model Action
-app = (defaultComponent emptyModel updateModel viewModel)
+app = (component emptyModel updateModel viewModel)
   { styles =
     [ Href "https://cdnjs.cloudflare.com/ajax/libs/bulma/0.4.3/css/bulma.min.css"
     , Href "https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css"

--- a/examples/fetch/Main.hs
+++ b/examples/fetch/Main.hs
@@ -51,7 +51,7 @@ data Action
   | ErrorHandler MisoString
   deriving (Show, Eq)
 ----------------------------------------------------------------------------
-app :: Component "app" Model Action
+app :: Component Model Action
 app = (defaultComponent emptyModel updateModel viewModel)
   { styles =
     [ Href "https://cdnjs.cloudflare.com/ajax/libs/bulma/0.4.3/css/bulma.min.css"

--- a/examples/file-reader/Main.hs
+++ b/examples/file-reader/Main.hs
@@ -21,7 +21,7 @@ import           Language.Javascript.JSaddle ((!), (!!), (#), JSVal, (<#))
 import qualified Language.Javascript.JSaddle as J
 import           Prelude hiding ((!!), null, unlines)
 ----------------------------------------------------------------------------
-import           Miso (Component(styles), View,Effect, defaultComponent, run, CSS(..), startComponent, io, io_)
+import           Miso (Component(styles), View,Effect, component, run, CSS(..), startComponent, io, io_)
 import qualified Miso as M
 import           Miso.Lens ((.=), Lens, lens)
 import           Miso.String (MisoString, unlines, null)
@@ -74,7 +74,7 @@ css = unlines
 ----------------------------------------------------------------------------
 -- | Miso application
 app :: Component Model Action
-app = (defaultComponent (Model mempty) updateModel viewModel)
+app = (component (Model mempty) updateModel viewModel)
   { styles =
       [ Href "https://cdn.jsdelivr.net/npm/bulma@1.0.2/css/bulma.min.css"
       , Style css

--- a/examples/file-reader/Main.hs
+++ b/examples/file-reader/Main.hs
@@ -73,7 +73,7 @@ css = unlines
   ]
 ----------------------------------------------------------------------------
 -- | Miso application
-app :: Component "app" Model Action
+app :: Component Model Action
 app = (defaultComponent (Model mempty) updateModel viewModel)
   { styles =
       [ Href "https://cdn.jsdelivr.net/npm/bulma@1.0.2/css/bulma.min.css"

--- a/examples/mario/Main.hs
+++ b/examples/mario/Main.hs
@@ -29,7 +29,7 @@ main :: IO ()
 main = run $ do
     time <- now
     let m = mario{time = time}
-    startComponent (defaultComponent m updateMario display)
+    startComponent (component m updateMario display)
       { subs =
           [ arrowsSub GetArrows
           , windowCoordsSub WindowCoords

--- a/examples/mario/Main.hs
+++ b/examples/mario/Main.hs
@@ -1,8 +1,6 @@
 {-# LANGUAGE CPP               #-}
-{-# LANGUAGE DataKinds         #-}
 {-# LANGUAGE MultiWayIf        #-}
 {-# LANGUAGE RecordWildCards   #-}
-{-# LANGUAGE TypeApplications  #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module Main where
@@ -31,7 +29,7 @@ main :: IO ()
 main = run $ do
     time <- now
     let m = mario{time = time}
-    startComponent @"app" (defaultComponent m updateMario display)
+    startComponent (defaultComponent m updateMario display)
       { subs =
           [ arrowsSub GetArrows
           , windowCoordsSub WindowCoords

--- a/examples/mathml/Main.hs
+++ b/examples/mathml/Main.hs
@@ -1,6 +1,4 @@
 {-# LANGUAGE CPP               #-}
-{-# LANGUAGE DataKinds         #-}
-{-# LANGUAGE TypeApplications  #-}
 {-# LANGUAGE OverloadedStrings #-}
 module Main where
 
@@ -13,7 +11,7 @@ foreign export javascript "hs_start" main :: IO ()
 
 -- | Entry point for a miso application
 main :: IO ()
-main = run $ startComponent @"app" (defaultComponent Main.Empty updateModel viewModel)
+main = run $ startComponent (defaultComponent Main.Empty updateModel viewModel)
 
 data Model = Empty
   deriving (Eq)

--- a/examples/mathml/Main.hs
+++ b/examples/mathml/Main.hs
@@ -11,7 +11,7 @@ foreign export javascript "hs_start" main :: IO ()
 
 -- | Entry point for a miso application
 main :: IO ()
-main = run $ startComponent (defaultComponent Main.Empty updateModel viewModel)
+main = run $ startComponent (component Main.Empty updateModel viewModel)
 
 data Model = Empty
   deriving (Eq)

--- a/examples/router/Main.hs
+++ b/examples/router/Main.hs
@@ -32,7 +32,7 @@ data Action
 -- | Main entry point
 main :: IO ()
 main = run $
-  miso @"app" $ \u ->
+  miso $ \u ->
     (defaultComponent (Model u) updateModel viewModel)
        { subs = [uriSub HandleURI]
        }

--- a/examples/router/Main.hs
+++ b/examples/router/Main.hs
@@ -33,7 +33,7 @@ data Action
 main :: IO ()
 main = run $
   miso $ \u ->
-    (defaultComponent (Model u) updateModel viewModel)
+    (component (Model u) updateModel viewModel)
        { subs = [uriSub HandleURI]
        }
 

--- a/examples/simple/Main.hs
+++ b/examples/simple/Main.hs
@@ -1,6 +1,5 @@
 -----------------------------------------------------------------------------
-{-# LANGUAGE CPP #-}
-{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE CPP               #-}
 {-# LANGUAGE OverloadedStrings #-}
 -----------------------------------------------------------------------------
 module Main where
@@ -34,7 +33,7 @@ foreign export javascript "hs_start" main :: IO ()
 main :: IO ()
 main = run $ startComponent app
 -----------------------------------------------------------------------------
-app :: Component "app" Model Action
+app :: Component Model Action
 app = (defaultComponent (Model 0) updateModel viewModel)
   { events = pointerEvents
   , styles = [ Sheet sheet ]

--- a/examples/simple/Main.hs
+++ b/examples/simple/Main.hs
@@ -34,7 +34,7 @@ main :: IO ()
 main = run $ startComponent app
 -----------------------------------------------------------------------------
 app :: Component Model Action
-app = (defaultComponent (Model 0) updateModel viewModel)
+app = (component (Model 0) updateModel viewModel)
   { events = pointerEvents
   , styles = [ Sheet sheet ]
   }

--- a/examples/sse/client/Main.hs
+++ b/examples/sse/client/Main.hs
@@ -7,4 +7,4 @@ import Common (sse)
 import Miso (miso, run)
 
 main :: IO ()
-main = run (miso @"sse" sse)
+main = run (miso sse)

--- a/examples/sse/server/Main.hs
+++ b/examples/sse/server/Main.hs
@@ -62,7 +62,7 @@ sendEvents chan =
         threadDelay (10 ^ (6 :: Int))
 
 -- | Page for setting HTML doctype and header
-newtype Page = Page (Component "app" Model Action)
+newtype Page = Page (Component Model Action)
 
 instance ToHtml Page where
     toHtml (Page x) =

--- a/examples/sse/shared/Common.hs
+++ b/examples/sse/shared/Common.hs
@@ -58,7 +58,7 @@ the404 =
 goHome :: URI
 goHome = allLinks' linkURI (Proxy :: Proxy ClientRoutes)
 
-sse :: URI -> Component name Model Action
+sse :: URI -> Component Model Action
 sse currentURI
   = app { subs =
           [ sseSub "/sse" handleSseMsg

--- a/examples/sse/shared/Common.hs
+++ b/examples/sse/shared/Common.hs
@@ -66,7 +66,7 @@ sse currentURI
           ]
         }
   where
-    app = defaultComponent (Model currentURI "No event received") updateModel viewModel
+    app = component (Model currentURI "No event received") updateModel viewModel
     viewModel m
         | Right r <- route (Proxy :: Proxy ClientRoutes) home modelUri m =
             r

--- a/examples/svg/Main.hs
+++ b/examples/svg/Main.hs
@@ -1,7 +1,4 @@
 {-# LANGUAGE CPP               #-}
-{-# LANGUAGE DataKinds         #-}
-{-# LANGUAGE TypeFamilies      #-}
-{-# LANGUAGE TypeApplications  #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module Main where
@@ -20,13 +17,13 @@ foreign export javascript "hs_start" main :: IO ()
 #endif
 
 main :: IO ()
-main = run $ startComponent @"app" app
+main = run $ startComponent app
   { events = M.insert "pointermove" False pointerEvents
   , subs = [ mouseSub HandlePointer ]
   }
 
 -- | Component definition (uses 'defaultComponent' smart constructor)
-app :: Component name Model Action
+app :: Component Model Action
 app = defaultComponent emptyModel updateModel viewModel
 
 emptyModel :: Model

--- a/examples/svg/Main.hs
+++ b/examples/svg/Main.hs
@@ -22,9 +22,9 @@ main = run $ startComponent app
   , subs = [ mouseSub HandlePointer ]
   }
 
--- | Component definition (uses 'defaultComponent' smart constructor)
+-- | Component definition (uses 'component' smart constructor)
 app :: Component Model Action
-app = defaultComponent emptyModel updateModel viewModel
+app = component emptyModel updateModel viewModel
 
 emptyModel :: Model
 emptyModel = Model (0, 0)

--- a/examples/three/Main.hs
+++ b/examples/three/Main.hs
@@ -3,7 +3,6 @@
 {-# LANGUAGE OverloadedStrings          #-}
 {-# LANGUAGE TypeApplications           #-}
 {-# LANGUAGE RecordWildCards            #-}
-{-# LANGUAGE DataKinds                  #-}
 {-# LANGUAGE CPP                        #-}
 module Main where
 
@@ -71,7 +70,7 @@ main = run $ do
   stats <- newStats
   ref <- liftIO $ newIORef $ Context (pure ()) (pure ()) stats
   m <- now
-  startComponent @"app" (defaultComponent m (updateModel ref) viewModel)
+  startComponent (defaultComponent m (updateModel ref) viewModel)
     { initialAction = Just Init
     }
 

--- a/examples/three/Main.hs
+++ b/examples/three/Main.hs
@@ -70,7 +70,7 @@ main = run $ do
   stats <- newStats
   ref <- liftIO $ newIORef $ Context (pure ()) (pure ()) stats
   m <- now
-  startComponent (defaultComponent m (updateModel ref) viewModel)
+  startComponent (component m (updateModel ref) viewModel)
     { initialAction = Just Init
     }
 

--- a/examples/todo-mvc/Main.hs
+++ b/examples/todo-mvc/Main.hs
@@ -85,7 +85,7 @@ main :: IO ()
 main = run (startComponent app)
 
 app :: Component Model Msg
-app = (defaultComponent emptyModel updateModel viewModel)
+app = (component emptyModel updateModel viewModel)
   { events = defaultEvents <> keyboardEvents
   , initialAction = Just FocusOnInput
   , styles =

--- a/examples/todo-mvc/Main.hs
+++ b/examples/todo-mvc/Main.hs
@@ -1,13 +1,7 @@
-{-# LANGUAGE CPP #-}
-{-# LANGUAGE DataKinds #-}
-{-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE ExtendedDefaultRules #-}
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE CPP               #-}
+{-# LANGUAGE DeriveGeneric     #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE RecordWildCards   #-}
 
 module Main where
 
@@ -90,7 +84,7 @@ data Msg
 main :: IO ()
 main = run (startComponent app)
 
-app :: Component "todo-mvc" Model Msg
+app :: Component Model Msg
 app = (defaultComponent emptyModel updateModel viewModel)
   { events = defaultEvents <> keyboardEvents
   , initialAction = Just FocusOnInput

--- a/examples/websocket/Main.hs
+++ b/examples/websocket/Main.hs
@@ -29,7 +29,7 @@ main :: IO ()
 main = run (startComponent app)
 
 app :: Component Model Action
-app = (defaultComponent emptyModel updateModel appView)
+app = (component emptyModel updateModel appView)
   { events = defaultEvents <> keyboardEvents
   , subs =
     [ websocketSub url protocols HandleWebSocket

--- a/examples/websocket/Main.hs
+++ b/examples/websocket/Main.hs
@@ -1,13 +1,12 @@
-{-# LANGUAGE CPP #-}
-{-# LANGUAGE DataKinds #-}
-{-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE ExtendedDefaultRules #-}
-{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE CPP                   #-}
+{-# LANGUAGE DeriveGeneric         #-}
+{-# LANGUAGE ExtendedDefaultRules  #-}
+{-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE OverloadedStrings     #-}
+{-# LANGUAGE RecordWildCards       #-}
+{-# LANGUAGE ScopedTypeVariables   #-}
+{-# LANGUAGE TypeFamilies          #-}
 
 module Main where
 
@@ -29,7 +28,7 @@ foreign export javascript "hs_start" main :: IO ()
 main :: IO ()
 main = run (startComponent app)
 
-app :: Component "websocket" Model Action
+app :: Component Model Action
 app = (defaultComponent emptyModel updateModel appView)
   { events = defaultEvents <> keyboardEvents
   , subs =

--- a/haskell-miso.org/shared/Common.hs
+++ b/haskell-miso.org/shared/Common.hs
@@ -101,7 +101,7 @@ haskellMisoComponent uri
   }
   
 app :: URI -> Component Model Action
-app currentUri = defaultComponent emptyModel updateModel viewModel
+app currentUri = component emptyModel updateModel viewModel
   where
     emptyModel = Model currentUri False
     viewModel m =

--- a/haskell-miso.org/shared/Common.hs
+++ b/haskell-miso.org/shared/Common.hs
@@ -61,7 +61,7 @@ type ClientRoutes = Routes (View Action)
 type ServerRoutes = Routes (Get '[HTML] Page)
 
 -- | Component synonym
-type HaskellMisoComponent = Component "app" Model Action
+type HaskellMisoComponent = Component Model Action
 
 -- | Links
 uriHome, uriExamples, uriDocs, uriCommunity, uri404 :: URI
@@ -100,7 +100,7 @@ haskellMisoComponent uri
   , logLevel = DebugAll
   }
   
-app :: URI -> Component name Model Action
+app :: URI -> Component Model Action
 app currentUri = defaultComponent emptyModel updateModel viewModel
   where
     emptyModel = Model currentUri False

--- a/miso.cabal
+++ b/miso.cabal
@@ -193,3 +193,4 @@ library
     tagsoup       < 0.15,
     text          < 2.2,
     transformers  < 0.7,
+    stm >= 2.4 && < 2.6

--- a/nix/source.nix
+++ b/nix/source.nix
@@ -46,25 +46,25 @@ in
   flatris = fetchFromGitHub {
     owner = "dmjio";
     repo = "hs-flatris";
-    rev = "58d19c7";
-    hash = "sha256-S2vrKejF7pCfv9YFpbAo7/FDbTGvrUO4BfmQsoDxfCg=";
+    rev = "aa7a2e00cf87832de660718c15f1d85093ded103";
+    hash = "sha256-RLBfjIGeoSTsAuxh8Pa8kcQkupVtFZEYewDE783lZFg=";
   };
   miso-plane = fetchFromGitHub {
     owner = "dmjio";
     repo = "miso-plane";
-    rev = "00fe15b";
-    hash = "sha256-gF8C4AKMrfLClmfx5Hy858qTBoz3sWEKzBJEjQ2ddSw=";
+    rev = "f143eb9";
+    hash = "sha256-S5urxw4eHrxsrZ9ivHeW5Nwec5eqpeat6GusNrxS+08=";
   };
   hs2048 = fetchFromGitHub {
     owner = "dmjio";
     repo = "hs2048";
-    rev = "e64187b";
-    hash = "sha256-Z2a4WGGkBpzZVAVuTL3a1CWCu5orgAbjUXQ3TiHshco=";
+    rev = "65d7b3d";
+    hash = "sha256-46dhEMVutlPheLyw3/11WxF0STr9O3kR5w8xXMs9mCw=";
   };
   snake = fetchFromGitHub {
     owner = "dmjio";
     repo = "miso-snake";
-    rev = "34345aa";
-    hash = "sha256-aVBJD3LvEOgmnJMHTL32w1+tJOd0pNmfpABMjDr+Woo=";
+    rev = "1da7afa";
+    hash = "sha256-bAfIlnd3PRn9wqGn38R3+6ok1dxRR3Jeb+UUIYJZ7/M=";
   };
 }

--- a/nix/source.nix
+++ b/nix/source.nix
@@ -46,25 +46,25 @@ in
   flatris = fetchFromGitHub {
     owner = "dmjio";
     repo = "hs-flatris";
-    rev = "aa7a2e00cf87832de660718c15f1d85093ded103";
-    hash = "sha256-RLBfjIGeoSTsAuxh8Pa8kcQkupVtFZEYewDE783lZFg=";
+    rev = "36d7f2b77242beeccb0321a7b6092b7c04cf0291";
+    hash = "sha256-cQz3l1lWNsU4m/db1ARwk+IGX2rQGXwYEnWT2aD+/IU=";
   };
   miso-plane = fetchFromGitHub {
     owner = "dmjio";
     repo = "miso-plane";
-    rev = "f143eb9";
-    hash = "sha256-S5urxw4eHrxsrZ9ivHeW5Nwec5eqpeat6GusNrxS+08=";
+    rev = "e6199d87d9161b25daca434d679330366ad0b42a";
+    hash = "sha256-TEOjj2Bb76MCWGvIRN5NhwmjEV7MZQHXnEK5szd5IqU=";
   };
   hs2048 = fetchFromGitHub {
     owner = "dmjio";
     repo = "hs2048";
-    rev = "65d7b3d";
-    hash = "sha256-46dhEMVutlPheLyw3/11WxF0STr9O3kR5w8xXMs9mCw=";
+    rev = "63e33d3751e3e6021d22983a08293f8c0a41cc9b";
+    hash = "sha256-pZwYdtDMZm/ptnw4kFWh0lKVxJB3C5kkq6CUZ7evIR0=";
   };
   snake = fetchFromGitHub {
     owner = "dmjio";
     repo = "miso-snake";
-    rev = "1da7afa";
-    hash = "sha256-bAfIlnd3PRn9wqGn38R3+6ok1dxRR3Jeb+UUIYJZ7/M=";
+    rev = "46e61b0c43c2c9b61aa388418770172cdd8af8b4";
+    hash = "sha256-HihtEbAnyMfNzSvJkjZeAbY/b/fm66wc4G0YuOJYfEA=";
   };
 }

--- a/sample-app/Main.hs
+++ b/sample-app/Main.hs
@@ -1,7 +1,6 @@
 ----------------------------------------------------------------------------
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE LambdaCase        #-}
-{-# LANGUAGE DataKinds         #-}
 {-# LANGUAGE CPP               #-}
 ----------------------------------------------------------------------------
 module Main where
@@ -36,7 +35,7 @@ foreign export javascript "hs_start" main :: IO ()
 #endif
 ----------------------------------------------------------------------------
 -- | `defaultApp` takes as arguments the initial model, update function, view function
-app :: Component "app" Model Action
+app :: Component Model Action
 app = defaultComponent emptyModel updateModel viewModel
 ----------------------------------------------------------------------------
 -- | Empty application state

--- a/sample-app/Main.hs
+++ b/sample-app/Main.hs
@@ -34,9 +34,9 @@ main = run (startComponent app)
 foreign export javascript "hs_start" main :: IO ()
 #endif
 ----------------------------------------------------------------------------
--- | `defaultApp` takes as arguments the initial model, update function, view function
+-- | `component` takes as arguments the initial model, update function, view function
 app :: Component Model Action
-app = defaultComponent emptyModel updateModel viewModel
+app = component emptyModel updateModel viewModel
 ----------------------------------------------------------------------------
 -- | Empty application state
 emptyModel :: Model

--- a/src/Miso.hs
+++ b/src/Miso.hs
@@ -104,7 +104,6 @@ import           Miso.Util
 ----------------------------------------------------------------------------
 -- | Runs an isomorphic @miso@ application.
 -- Assumes the pre-rendered DOM is already present.
--- Note: Uses 'mountPoint' as the 'Component' name.
 -- Always mounts to \<body\>. Copies page into the virtual DOM.
 miso :: Eq model => (URI -> Component model action) -> JSM ()
 miso f = withJS $ do

--- a/src/Miso.hs
+++ b/src/Miso.hs
@@ -24,6 +24,8 @@ module Miso
   , withSink
   , Sink
     -- ** Publishers / Subscribers
+  , TopicName
+  , mkTopic
   , subscribe
   , unsubscribe
   , publish

--- a/src/Miso/Concurrent.hs
+++ b/src/Miso/Concurrent.hs
@@ -10,12 +10,21 @@
 -- Portability :  non-portable
 ----------------------------------------------------------------------------
 module Miso.Concurrent
-  ( Waiter (..)
+  ( -- * Syncrhonization primitives
+    Waiter (..)
   , waiter
+  , Topic
+  , newTopic
+  , copyTopic
+  , writeTopic
+  , readTopic
   ) where
 -----------------------------------------------------------------------------
 import Control.Concurrent
+import Control.Concurrent.STM
+import Data.Aeson
 -----------------------------------------------------------------------------
+-- | Synchronization primitive for event loop
 data Waiter
   = Waiter
   { wait :: IO ()
@@ -34,4 +43,19 @@ waiter = do
         _ <- tryPutMVar mvar ()
         pure ()
     }
+-----------------------------------------------------------------------------
+-- | Publish / Subscribe concurrency primitive
+type Topic = TChan Value
+-----------------------------------------------------------------------------
+newTopic :: IO Topic
+newTopic = newBroadcastTChanIO
+-----------------------------------------------------------------------------
+copyTopic :: Topic -> IO Topic
+copyTopic topic = atomically (dupTChan topic)
+-----------------------------------------------------------------------------
+writeTopic :: Topic -> Value -> IO ()
+writeTopic topic value = atomically (writeTChan topic value)
+-----------------------------------------------------------------------------
+readTopic :: Topic -> IO Value
+readTopic topic = atomically (readTChan topic)
 -----------------------------------------------------------------------------

--- a/src/Miso/Event.hs
+++ b/src/Miso/Event.hs
@@ -106,10 +106,6 @@ onMounted action =
 -- element is created. It returns the /component-id/ from the component.
 -- Returning /component-id/ is useful when creating 'Component' dynamically.
 --
--- This way the parent can maintain a 'Map' of the child 'Component' IDs. When
--- the parent 'Component' wants to send a child 'Component' a message it can use
--- @notify'@.
---
 -- Use this or @onMounted@, but not both in the same @[Attribute action]@ list.
 --
 onMountedWith :: (MisoString -> action) -> Attribute action
@@ -159,12 +155,6 @@ onUnmounted action =
 -----------------------------------------------------------------------------
 -- | @onUnmounted action@ is an event that gets called after the DOM element
 -- is removed from the DOM. It returns the /component-id/ after the unmount call.
--- Returning /component-id/ is useful when dynamically created @Component@ need
--- to notify their parents about their own destruction.
---
--- This way the parent can maintain a @Map@ of the child @Component@ IDs. When
--- the parent @Component@ wants to send a child @Component@ a message it can use
--- @notify'@.
 --
 -- Use this or @onUnmounted@, but not both in the same @[Attribute action]@ list.
 --

--- a/src/Miso/Exception.hs
+++ b/src/Miso/Exception.hs
@@ -26,11 +26,6 @@ import qualified Miso.FFI as FFI
 --
 -- The two mounting errors that can occur during the lifetime of a miso application are
 --
--- * Not Mounted Exception
---
--- This occurs if a user tries to call @sample myComponent@ when @myComponent@ is currently
--- not mounted on the DOM.
---
 -- * Already Mounted Exception
 --
 -- It is a requirement that all @Component@ be named uniquely
@@ -43,9 +38,7 @@ import qualified Miso.FFI as FFI
 -- and logged to the console with /console.error()/
 --
 data MisoException
-  = NotMountedException MisoString
-  -- ^ Thrown when a @Component@ is sampled, yet not mounted.
-  | AlreadyMountedException MisoString
+  = AlreadyMountedException MisoString
   -- ^ Thrown when a @Component@ is attempted to be mounted twice.
   deriving (Show, Eq)
 ----------------------------------------------------------------------------
@@ -58,10 +51,6 @@ instance Exception MisoException
 -- > action `catch` exception
 exception :: SomeException -> JSM JSVal
 exception ex
-  | Just (NotMountedException name) <- fromException ex = do
-      FFI.consoleError
-        ("NotMountedException: Could not sample model state from the Component \"" <> name <> "\"")
-      pure jsNull
   | Just (AlreadyMountedException name) <- fromException ex = do
       FFI.consoleError ("AlreadyMountedException: Component \"" <> name <> "\" is already")
       pure jsNull

--- a/src/Miso/Internal.hs
+++ b/src/Miso/Internal.hs
@@ -153,7 +153,7 @@ subscribers = unsafePerformIO $ liftIO (newIORef mempty)
 -- @
 --
 -- clientComponent :: MisoString -> Component Int Action
--- clientComponent name = defaultComponent 0 update_ $ \m ->
+-- clientComponent name = component 0 update_ $ \m ->
 --   div_
 --   []
 --   [ br_ []
@@ -281,7 +281,7 @@ unsubscribe_ topicName vcompId = do
 -- @
 --
 -- server :: Component () Action
--- server = defaultComponent () update_ $ \() ->
+-- server = component () update_ $ \() ->
 --   div_
 --   []
 --   [ "Server component"

--- a/src/Miso/Lens.hs
+++ b/src/Miso/Lens.hs
@@ -135,6 +135,7 @@ module Miso.Lens
   , (<>~)
   , _1
   , _2
+  , _id
   ) where
 ----------------------------------------------------------------------------
 import Control.Monad.State (MonadState, modify, gets)
@@ -168,7 +169,7 @@ type Lens' record field = Lens record field
 ----------------------------------------------------------------------------
 -- | Lens are Categories, and can therefore be composed.
 instance Category Lens where
-  id = Lens (\x -> x) (\x _ -> x)
+  id = Lens Prelude.id (flip const)
   Lens g1 s1 . Lens g2 s2 = Lens
     { _get = g1 <<< g2
     , _set = \r f -> s2 r (s1 (g2 r) f)
@@ -654,6 +655,15 @@ _1 = lens fst $ \(_,b) x -> (x,b)
 -- @
 _2 :: Lens (a,b) b
 _2 = lens snd $ \(a,_) x -> (a,x)
+---------------------------------------------------------------------------------
+-- | @Lens@ that operates on itself 
+--
+-- @
+-- update AddOne = do
+--   _id += 1
+-- @
+_id :: Lens a a
+_id = Control.Category.id
 ---------------------------------------------------------------------------------
 -- | Smart constructor @lens@ function. Used to easily construct a @Lens@
 --

--- a/src/Miso/Render.hs
+++ b/src/Miso/Render.hs
@@ -93,10 +93,10 @@ renderBuilder (VNode _ tag attrs children) =
     | tag `notElem` ["img", "input", "br", "hr", "meta", "link"]
     ]
   ]
-renderBuilder (VComp mount attributes (SomeComponent Component {..})) =
+renderBuilder (VComp attributes (SomeComponent Component {..})) =
   mconcat
   [ stringUtf8 "<div data-component-id=\""
-  , fromMisoString mount
+  , fromMisoString ""
   , "\" "
   , intercalate " " (renderAttrs <$> attributes)
   , ">"

--- a/src/Miso/Types.hs
+++ b/src/Miso/Types.hs
@@ -34,7 +34,7 @@ module Miso.Types
   , ToView           (..)
   , ToKey            (..)
   -- ** Smart Constructors
-  , defaultComponent
+  , component
   -- ** Components
   , component_
   -- ** Utils
@@ -113,12 +113,12 @@ getMountPoint :: Maybe MisoString -> MisoString
 getMountPoint = fromMaybe "body"
 -----------------------------------------------------------------------------
 -- | Smart constructor for @Component@ with sane defaults.
-defaultComponent
+component
   :: model
   -> (action -> Effect model action)
   -> (model -> View action)
   -> Component model action
-defaultComponent m u v = Component
+component m u v = Component
   { model = m
   , update = u
   , view = v
@@ -133,7 +133,7 @@ defaultComponent m u v = Component
 -- | Optional Logging for debugging miso internals (useful to see if prerendering is successful)
 data LogLevel
   = Off
-  -- ^ No debug logging, the default value used in @defaultComponent@
+  -- ^ No debug logging, the default value used in @component@
   | DebugHydrate
   -- ^ Will warn if the structure or properties of the
   -- DOM vs. Virtual DOM differ during prerendering.

--- a/src/Miso/Types.hs
+++ b/src/Miso/Types.hs
@@ -142,8 +142,6 @@ data LogLevel
   -- handler that raised it. Also will warn if an event handler is
   -- being used, yet it's not being listened for by the event
   -- delegator mount point.
-  | DebugNotify
-  -- ^ Will warn if a @Component@ can't be found when using @notify@ or @notify'@
   | DebugAll
   -- ^ Logs on all of the above
   deriving (Show, Eq)
@@ -162,8 +160,6 @@ data SomeComponent
   => SomeComponent (Component model action)
 -----------------------------------------------------------------------------
 -- | Used in the @view@ function to embed an @Component@ into another @Component@
--- Use this function if you'd like send messages to this @Component@ at @name@ via
--- @notify@ or to read the state of this @Component@ via @sample@.
 component_
   :: forall model action a . Eq model
   => Component model action

--- a/src/Miso/Types.hs
+++ b/src/Miso/Types.hs
@@ -151,7 +151,7 @@ data View action
   = VNode NS MisoString [Attribute action] [View action]
   | VText MisoString
   | VTextRaw MisoString
-  | VComp MisoString [Attribute action] SomeComponent
+  | VComp [Attribute action] SomeComponent
   deriving Functor
 -----------------------------------------------------------------------------
 -- | Existential wrapper used to allow the nesting of @Component@ in @Component@
@@ -165,7 +165,7 @@ component_
   => Component model action
   -> [Attribute a]
   -> View a
-component_ app attrs = VComp mempty attrs (SomeComponent app)
+component_ app attrs = VComp attrs (SomeComponent app)
 -----------------------------------------------------------------------------
 -- | For constructing type-safe links
 instance HasLink (View a) where


### PR DESCRIPTION
I think #1002 is a positive step in principle, but I'm not convinced we need to throw out so much type safety and force the user to care about decode errors etc. This is a rough sketch of some improvements.

The first commit arguably just gives the illusion of type safety, since it suffers the same "footguns" that @kaol mentions in #1000. The second is a proof-of-concept of the API I'd like to see, but to work nicely it really requires the ability to use side effects to initialise component state, e.g. by putting the `model` field in to IO/JSM. I have already argued that this would be a good thing anyway (see my complaints on Matrix a while back about building an encapsulated clock component).

Basically, the idea is that creating a topic returns an abstract identifier parameterised by the type of message it supports.