### PR TITLE
Media: new -> newAudio

### DIFF
--- a/src/Miso/Media.hs
+++ b/src/Miso/Media.hs
@@ -16,7 +16,7 @@ module Miso.Media
   , NetworkState (..)
   , ReadyState   (..)
   -- *** Constructors
-  , new
+  , newAudio
   -- *** Methods
   , canPlayType
   , load
@@ -76,10 +76,10 @@ data ReadyState
   | HAVE_ENOUGH_DATA
   deriving (Show, Eq, Enum)
 -----------------------------------------------------------------------------
--- | Smart constructor for @Media@ with 'src' element
-new :: MisoString -> JSM Media
-new url = do
-  a <- JS.new (jsg ("Media" :: MisoString)) ([] :: [MisoString])
+-- | Smart constructor for an audio @Media@ with 'src' element
+newAudio :: MisoString -> JSM Media
+newAudio url = do
+  a <- JS.new (jsg ("Audio" :: MisoString)) ([] :: [MisoString])
   o <- makeObject a
   set ("src" :: MisoString) url o
   pure (Media a)


### PR DESCRIPTION
Audio/Video API only has a constructor for `Audio` (not `Media` or `Video`).