### PR TITLE
nix: Switch from flake-utils to flake-parts

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,20 +1,20 @@
 {
   "nodes": {
-    "flake-utils": {
+    "flake-parts": {
       "inputs": {
-        "systems": "systems"
+        "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "lastModified": 1751413152,
+        "narHash": "sha256-Tyw1RjYEsp5scoigs1384gIg6e0GoBVjms4aXFfRssQ=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "77826244401ea9de6e3bac47c2db46005e1f30b5",
         "type": "github"
       },
       "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
         "type": "github"
       }
     },
@@ -30,25 +30,25 @@
         "url": "https://github.com/alexfmpe/nixpkgs/archive/b594b289740a2bc917ed9c66fef5d905f389cb96.tar.gz"
       }
     },
-    "root": {
-      "inputs": {
-        "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs"
-      }
-    },
-    "systems": {
+    "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "lastModified": 1751159883,
+        "narHash": "sha256-urW/Ylk9FIfvXfliA1ywh75yszAbiTEVgpPeinFyVZo=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "14a40a1d7fb9afa4739275ac642ed7301a9ba1ab",
         "type": "github"
       },
       "original": {
-        "owner": "nix-systems",
-        "repo": "default",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
         "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -1,27 +1,33 @@
 {
   description = "A flake for miso";
 
-  inputs = {
+  nixConfig = {
+    extra-substituters = [
+      "https://haskell-miso-cachix.cachix.org"
+    ];
+    extra-trusted-public-keys = [
+      "haskell-miso-cachix.cachix.org-1:m8hN1cvFMJtYib4tj+06xkKt5ABMSGfe8W7s40x1kQ0="
+    ];
+  };
 
+  inputs = {
     nixpkgs.url =
       "https://github.com/alexfmpe/nixpkgs/archive/b594b289740a2bc917ed9c66fef5d905f389cb96.tar.gz";
 
-    flake-utils.url =
-      "github:numtide/flake-utils";
-
+    flake-parts.url = "github:hercules-ci/flake-parts";
   };
-  outputs = { self, nixpkgs, flake-utils }:
 
-   flake-utils.lib.eachSystem
-      [
+  outputs = inputs@{ flake-parts, ... }:
+    flake-parts.lib.mkFlake { inherit inputs; } {
+      systems = [
         "x86_64-linux"
         "aarch64-darwin"
         "aarch64-linux"
         "x86_64-darwin"
-      ] (system:
+      ];
 
-      let
-        pkgs = import nixpkgs {
+      perSystem = { config, self', inputs', pkgs, system, ... }: {
+        _module.args.pkgs = import inputs.nixpkgs {
           inherit system;
           overlays = [ (import ./nix/overlay.nix) ];
           config = {
@@ -30,24 +36,14 @@
           };
         };
 
-      in {
-        nixConfig = {
-          extra-substituters = [
-            "https://haskell-miso-cachix.cachix.org"
-          ];
-          extra-trusted-public-keys = [
-            "haskell-miso-cachix.cachix.org-1:m8hN1cvFMJtYib4tj+06xkKt5ABMSGfe8W7s40x1kQ0="
-          ];
-        };
         packages.default = pkgs.haskell.packages.ghc9122.miso;
 
-        devShells.default =
-          pkgs.mkShell {
-            name = "The miso ghc9122 shell";
-            buildInputs = with pkgs; [
-              pkgs.pkgsCross.ghcjs.haskell.packages.ghc9122.miso
-            ];
-          };
-      }
-   );
+        devShells.default = pkgs.mkShell {
+          name = "The miso ghc9122 shell";
+          buildInputs = with pkgs; [
+            pkgs.pkgsCross.ghcjs.haskell.packages.ghc9122.miso
+          ];
+        };
+      };
+    };
 }


### PR DESCRIPTION
https://flake.parts/ allows us to keep our Nix modular, and paves way for using `haskell-flake`.

This PR is fairly simple since, at its most basic usage, flake-parts provides a 1-on-1 translation to flake-utils' `eachSystem` pattern.