### PR TITLE
Canvas: remove unnecessary () arguments

### DIFF
--- a/src/Miso/Canvas.hs
+++ b/src/Miso/Canvas.hs
@@ -545,8 +545,8 @@ lineTo :: Coord -> Canvas ()
 lineTo = LineTo
 -----------------------------------------------------------------------------
 -- | [ctx.fill()](https://www.w3schools.com/tags/canvas_fill.asp)
-fill :: Canvas ()
-fill = Fill
+fill :: () -> Canvas ()
+fill () = Fill
 -----------------------------------------------------------------------------
 -- | [ctx.rect(x,y,width,height)](https://www.w3schools.com/tags/canvas_rect.asp)
 rect :: (Double, Double, Double, Double) -> Canvas ()


### PR DESCRIPTION
Currently, we have something like this:
```hs
draw :: Canvas ()
draw = do
  ...
  beginPath ()
  ...
  fill
```
This PR removes the `()` argument for `beginPath`, `clip`, `save`, `restore` and `stroke` so we can use them in the same way as `fill`.