### PR TITLE
Add `modelCheck :: Bool` to `Component`

### DIFF
--- a/examples/canvas2d/Main.hs
+++ b/examples/canvas2d/Main.hs
@@ -20,10 +20,6 @@ foreign export javascript "hs_start" main :: IO ()
 -----------------------------------------------------------------------------
 type Model = (Double, Double)
 -----------------------------------------------------------------------------
-data Action
-  = GetTime
-  | SetTime Model
------------------------------------------------------------------------------
 baseUrl :: MisoString
 baseUrl = "https://7b40c187-5088-4a99-9118-37d20a2f875e.mdnplay.dev/en-US/docs/Web/API/Canvas_API/Tutorial/Basic_animations/"
 -----------------------------------------------------------------------------
@@ -33,9 +29,11 @@ main =
     sun <- newImage (baseUrl <> "canvas_sun.png")
     moon <- newImage (baseUrl <> "canvas_moon.png")
     earth <- newImage (baseUrl <> "canvas_earth.png")
-    startComponent (app sun moon earth) { initialAction = Just GetTime }
+    startComponent (app sun moon earth)
+      { modelCheck = False
+      }
   where
-    app sun moon earth = component (0.0, 0.0) updateModel (view_ sun moon earth)
+    app sun moon earth = component (0.0, 0.0) (\() -> pure ()) (view_ sun moon earth)
     view_ sun moon earth m =
       div_
       [ id_ "canvas grid" ]
@@ -80,12 +78,4 @@ newTime = do
   Just millis <- fromJSVal millis'
   Just seconds <- fromJSVal seconds'
   pure (millis, seconds)
------------------------------------------------------------------------------
-updateModel
-  :: Action
-  -> Effect Model Action
-updateModel GetTime =
-  io (SetTime <$> newTime)
-updateModel (SetTime m) =
-  m <# pure GetTime
 -----------------------------------------------------------------------------

--- a/src/Miso/Internal.hs
+++ b/src/Miso/Internal.hs
@@ -94,7 +94,7 @@ initialize Component {..} getView = do
       (M.insert subKey threadId m, ())
   componentModel <- liftIO (newIORef model)
   let
-    eventLoop !oldModel =
+    eventLoop !oldModel = do
       liftIO (when modelCheck wait)
       as <- liftIO $ atomicModifyIORef' componentActions $ \actions -> (S.empty, actions)
       newModel <- foldEffects update Async componentId componentSink (toList as) oldModel

--- a/src/Miso/Types.hs
+++ b/src/Miso/Types.hs
@@ -86,10 +86,17 @@ data Component model action = Component
   --
   -- @since 1.9.0.0
   , mountPoint :: Maybe MountPoint
-  -- ^ Id of the root element for DOM diff.
+  -- ^ Id of the root element for DOM 'diff'.
   -- If 'Nothing' is provided, the entire document body is used as a mount point.
   , logLevel :: LogLevel
   -- ^ Debugging for prerendering and event delegation
+  , modelCheck :: Bool
+  -- ^ Used to decide if we should 'diff' the model before diffing the virtual DOM
+  -- By default this is 'True', it is recommended to set this to 'False' when developing
+  -- full-screen 'canvas' applications. If 'False', model diffing is bypassed
+  -- and the 'Component' will not block on an empty event queue.
+  --
+  -- @since 1.9.0.0
   }
 -----------------------------------------------------------------------------
 -- | @mountPoint@ for @Component@, e.g "body"
@@ -128,6 +135,7 @@ component m u v = Component
   , mountPoint = Nothing
   , logLevel = Off
   , initialAction = Nothing
+  , modelCheck = True
   }
 -----------------------------------------------------------------------------
 -- | Optional Logging for debugging miso internals (useful to see if prerendering is successful)

--- a/src/Miso/Types.hs
+++ b/src/Miso/Types.hs
@@ -94,7 +94,8 @@ data Component model action = Component
   -- ^ Used to decide if we should 'diff' the model before diffing the virtual DOM
   -- By default this is 'True', it is recommended to set this to 'False' when developing
   -- full-screen 'canvas' applications. If 'False', model diffing is bypassed
-  -- and the 'Component' will not block on an empty event queue.
+  -- and the 'Component' will not block on an empty event queue. This means
+  -- 'requestAnimationFrame` is called in a tight loop.
   --
   -- @since 1.9.0.0
   }


### PR DESCRIPTION
`modelCheck` is used to decide if we should diff the model before diffing the virtual DOM. By default this is `True`. It is recommended to set to `False` when developing full-screen `canvas` applications. If `False` model diffing is bypassed and the `Component` will not block on an empty event queue. This means `requestAnimationFrame` is called in a tight loop (like what `three.js` `setAnimationLoop` does).

- [x] Update `canvas2D` and three examples. 

This should make canvas applications slightly more performant.

This also means we can drop `GetTime` / `SetTime` boilerplate, since we don't need to update the `model` to force a `draw` if `modelCheck = False`.