### PR TITLE
Specify `servant` lower bound

### DIFF
--- a/miso.cabal
+++ b/miso.cabal
@@ -188,7 +188,7 @@ library
     jsaddle       < 0.10,
     mtl           < 2.4,
     network-uri   < 2.7,
-    servant       < 0.21,
+    servant       > 0.15 && < 0.21,
     tagsoup       < 0.15,
     text          < 2.2,
     transformers  < 0.7,


### PR DESCRIPTION
Specify a lower bound for `servant`. This avoids the resolver selecting the lowest version in some cases.