### PR TITLE
📬 Adds `Component` `mailbox`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -118,7 +118,7 @@
               '';
             };
 
-          # GHCJS shell
+          # GHCJS9122 shell
           ghcjs =
             pkgs.mkShell {
               name = "The miso ${system} GHC JS 9.12.2 shell";
@@ -147,6 +147,7 @@
                  http-server
                  cabal-install
                  nodejs
+                 emscripten
               ];
             };
 
@@ -172,6 +173,7 @@
                  pkgs.gnumake
                  pkgs.http-server
                  pkgs.cabal-install
+                 pkgs.emscripten
               ];
             };
 

--- a/src/Miso.hs
+++ b/src/Miso.hs
@@ -30,7 +30,11 @@ module Miso
   , publish
   , Topic
   , topic
-    -- ** Subscriptions
+  -- ** Component
+  , mail
+  , getComponentId
+  , getParentComponentId
+  -- ** Subscriptions
   , startSub
   , stopSub
   , Sub
@@ -87,7 +91,7 @@ import           Miso.Diff
 import           Miso.Effect
 import           Miso.Event
 import           Miso.Fetch
-import           Miso.FFI
+import           Miso.FFI hiding (getComponentId, getParentComponentId)
 import qualified Miso.FFI.Internal as FFI
 import           Miso.Html
 import           Miso.Internal

--- a/src/Miso/Canvas.hs
+++ b/src/Miso/Canvas.hs
@@ -128,15 +128,15 @@ canvas_ attributes initialize_ draw_ = node HTML "canvas" attrs []
     attrs = initCallback : drawCallack : attributes
 
     initCallback :: Attribute action
-    initCallback = Event $ \_ o _ _ -> do
-      flip (FFI.set "onCreated") o =<< do
+    initCallback = Event $ \_ (VTree vtree) _ _ -> do
+      flip (FFI.set "onCreated") vtree =<< do
         FFI.syncCallback1 $ \domRef -> do
           initialState <- initialize_ domRef
           FFI.set "state" initialState (Object domRef)
 
     drawCallack :: Attribute action
-    drawCallack = Event $ \_ o _ _ -> do
-      flip (FFI.set "draw") o =<< do
+    drawCallack = Event $ \_ (VTree vtree) _ _ -> do
+      flip (FFI.set "draw") vtree =<< do
         FFI.syncCallback1 $ \domRef -> do
           state <- fromJSValUnchecked =<< domRef ! ("state" :: MisoString)
           draw_ state
@@ -159,16 +159,16 @@ canvas attributes initialize draw = node HTML "canvas" attrs []
     attrs = initCallback : drawCallack : attributes
 
     initCallback :: Attribute action
-    initCallback = Event $ \_ obj _ _ -> do
-      flip (FFI.set "onCreated") obj =<< do
+    initCallback = Event $ \_ (VTree vtree) _ _ -> do
+      flip (FFI.set "onCreated") vtree =<< do
         FFI.syncCallback1 $ \domRef -> do
           ctx <- domRef # ("getContext" :: MisoString) $ ["2d" :: MisoString]
           initialState <- runReaderT (initialize domRef) ctx
           FFI.set "state" initialState (Object domRef)
 
     drawCallack :: Attribute action
-    drawCallack = Event $ \_ obj _ _ -> do
-      flip (FFI.set "draw") obj =<< do
+    drawCallack = Event $ \_ (VTree vtree) _ _ -> do
+      flip (FFI.set "draw") vtree =<< do
         FFI.syncCallback1 $ \domRef -> do
           jval <- domRef ! ("state" :: MisoString)
           initialState <- fromJSValUnchecked jval

--- a/src/Miso/FFI.hs
+++ b/src/Miso/FFI.hs
@@ -42,8 +42,9 @@ module Miso.FFI
   , newDate
   , getSeconds
   , getMilliseconds
-  -- * Component
+  -- ** Component
   , getParentComponentId
+  , getComponentId
   ) where
 -----------------------------------------------------------------------------
 import           Miso.FFI.Internal

--- a/src/Miso/FFI/Internal.hs
+++ b/src/Miso/FFI/Internal.hs
@@ -543,11 +543,15 @@ getSeconds date =
   fromJSValUnchecked =<< do
     date # "getSeconds" $ ([] :: [MisoString])
 -----------------------------------------------------------------------------
+-- | Climb the tree, get the parent.
 getParentComponentId :: JSVal -> JSM (Maybe Int)
 getParentComponentId domRef =
   fromJSVal =<< do
     jsg "miso" # "getParentComponentId" $ [domRef]
 -----------------------------------------------------------------------------
+-- | Get access to the 'ComponentId'
+-- N.B. you * must * call this on the DOMRef, otherwise, problems.
+-- For use in `onMounted`, etc.
 getComponentId :: JSVal -> JSM Int
-getComponentId domRef = fromJSValUnchecked =<< domRef ! "component-id"
+getComponentId vtree = fromJSValUnchecked =<< vtree ! "component-id"
 -----------------------------------------------------------------------------

--- a/src/Miso/Types.hs
+++ b/src/Miso/Types.hs
@@ -58,13 +58,15 @@ import           Language.Javascript.JSaddle (ToJSVal(toJSVal), Object(..), JSM)
 import           Prelude hiding (null)
 import           Servant.API (HasLink(MkLink, toLink))
 -----------------------------------------------------------------------------
+import           Miso.Concurrent (Mail)
 import           Miso.Effect (Effect, Sub, Sink, DOMRef)
 import           Miso.Event.Types
 import           Miso.String (MisoString, toMisoString)
 import           Miso.Style.Types (StyleSheet)
 -----------------------------------------------------------------------------
 -- | Application entry point
-data Component model action = Component
+data Component model action
+  = Component
   { model :: model
   -- ^ initial model
   , update :: action -> Effect model action
@@ -91,6 +93,10 @@ data Component model action = Component
   -- If 'Nothing' is provided, the entire document body is used as a mount point.
   , logLevel :: LogLevel
   -- ^ Debugging for prerendering and event delegation
+  , mailbox :: Mail -> Maybe action
+  -- ^ Used to receive mail from other 'Component'
+  --
+  -- @since 1.9.0.0
   }
 -----------------------------------------------------------------------------
 -- | @mountPoint@ for @Component@, e.g "body"
@@ -129,6 +135,7 @@ component m u v = Component
   , mountPoint = Nothing
   , logLevel = Off
   , initialAction = Nothing
+  , mailbox = const Nothing
   }
 -----------------------------------------------------------------------------
 -- | Optional Logging for debugging miso internals (useful to see if prerendering is successful)

--- a/src/Miso/Types.hs
+++ b/src/Miso/Types.hs
@@ -21,6 +21,7 @@
 module Miso.Types
   ( -- ** Types
     Component        (..)
+  , ComponentId
   , SomeComponent    (..)
   , View             (..)
   , Key              (..)
@@ -101,6 +102,9 @@ data Component model action
 -----------------------------------------------------------------------------
 -- | @mountPoint@ for @Component@, e.g "body"
 type MountPoint = MisoString
+-----------------------------------------------------------------------------
+-- | ID for 'Component'
+type ComponentId = Int
 -----------------------------------------------------------------------------
 -- | Allow users to express CSS and append it to <head> before the first draw
 --
@@ -259,7 +263,7 @@ instance ToKey Word where toKey = Key . toMisoString
 -- vnode the attribute is attached to.
 data Attribute action
   = Property MisoString Value
-  | Event (Sink action -> Object -> LogLevel -> Events -> JSM ())
+  | Event (Sink action -> VTree -> LogLevel -> Events -> JSM ())
   | Styles (M.Map MisoString MisoString)
   deriving Functor
 -----------------------------------------------------------------------------
@@ -275,7 +279,6 @@ newtype VTree = VTree { getTree :: Object }
 instance ToJSVal VTree where
   toJSVal (VTree (Object vtree)) = pure vtree
 -----------------------------------------------------------------------------
-
 -- | Create a new @Miso.Types.TextRaw@.
 --
 -- @expandable@


### PR DESCRIPTION
This PR adds a `Mailbox` to each `Component`. This means any `Component` can send any `Value` to any other `Component` (including itself). `ComponentId` can be obtained via on `onMountedWith` callback, or published to a `Topic` for distribution via the Pub / Sub mechanism (this can be done using the `onMounted` hook as well).

- [x] Adds `mail` function, used for messaging.
- [x] Adds `getComponentId`, `getParentComponentId` helper functions in `FFI` and in `Effect`
- [x] Adds an existential 'mailbox' to 'Component', defaults to `\_ -> Nothing`
- [x] Calls `killThread` on `Component` unmount cleanup.