### PR TITLE
Adjust GHCJS 9.12.2 shell environment

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -123,6 +123,12 @@
             pkgs.mkShell {
               name = "The miso ${system} GHC JS 9.12.2 shell";
               shellHook = ''
+                export CC=${pkgs.emscripten}/bin/emcc
+                mkdir -p ~/.emscripten_cache
+                chmod u+rwX -R ~/.emscripten_cache
+                cp -r ${pkgs.emscripten}/share/emscripten/cache ~/.emscripten_cache
+                export EM_CACHE=~/.emscripten_cache
+
                 function build () {
                    cabal build $1 \
                      --with-compiler=javascript-unknown-ghcjs-ghc \
@@ -135,11 +141,12 @@
                    cabal update
                 }
               '';
-              packages = [
-                 pkgs.pkgsCross.ghcjs.haskell.packages.ghc9122.ghc
-                 pkgs.gnumake
-                 pkgs.http-server
-                 pkgs.cabal-install
+              packages = with pkgs; [
+                 pkgsCross.ghcjs.haskell.packages.ghc9122.ghc
+                 gnumake
+                 http-server
+                 cabal-install
+                 nodejs
               ];
             };
 

--- a/shell.nix
+++ b/shell.nix
@@ -5,7 +5,6 @@ with (import ./default.nix {});
 if pkg == "ghcjs9122"
 then miso-ghcjs-9122.env.overrideAttrs (drv: {
   shellHook = ''
-    export NIXPKGS_ALLOW_UNSUPPORTED_SYSTEM=1
     export CC=${pkgs.emscripten}/bin/emcc
     mkdir -p ~/.emscripten_cache
     chmod u+rwX -R ~/.emscripten_cache


### PR DESCRIPTION
 - [x] Add `nodejs` (required for builds)
 - [x] Port `emscripten` cache settings from `shell.nix` to `flake.nix`