### PR TITLE
Add `cloneMailbox`

### DIFF
--- a/src/Miso/Concurrent.hs
+++ b/src/Miso/Concurrent.hs
@@ -17,6 +17,7 @@ module Miso.Concurrent
   , Mail
   , newMailbox
   , copyMailbox
+  , cloneMailbox
   , sendMail
   , readMail
   ) where
@@ -76,6 +77,11 @@ newMailbox = newBroadcastTChanIO
 -- | Duplicates a 'Mailbox', all new 'Mail' is sent to all duplicated 'Mailbox'
 copyMailbox :: Mailbox -> IO Mailbox
 copyMailbox mailbox = atomically (dupTChan mailbox)
+-----------------------------------------------------------------------------
+-- | Duplicates a 'Mailbox', all new 'Mail' is sent to all cloned 'Mailbox'
+-- Messages in original 'Mailbox' are retained (unlike `copyMailbox`).
+cloneMailbox :: Mailbox -> IO Mailbox
+cloneMailbox mailbox = atomically (cloneTChan mailbox)
 -----------------------------------------------------------------------------
 -- | Sends mail to a mailbox, all duplicated 'Mailbox' receive the same message.
 sendMail :: Mailbox -> Mail -> IO ()

--- a/src/Miso/Event.hs
+++ b/src/Miso/Event.hs
@@ -43,7 +43,7 @@ import           Miso.Event.Decoder
 import           Miso.Event.Types
 import qualified Miso.FFI.Internal as FFI
 import           Miso.Types (Attribute (Event), LogLevel(..), DOMRef, VTree(..), ComponentId)
-import           Miso.String (MisoString, unpack, ms)
+import           Miso.String (MisoString, unpack)
 -----------------------------------------------------------------------------
 -- | Convenience wrapper for @onWithOptions defaultOptions@.
 --

--- a/src/Miso/Internal.hs
+++ b/src/Miso/Internal.hs
@@ -68,7 +68,7 @@ import           System.Mem.StableName (makeStableName)
 import           Text.HTML.TagSoup (Tag(..))
 import           Text.HTML.TagSoup.Tree (parseTree, TagTree(..))
 -----------------------------------------------------------------------------
-import           Miso.Concurrent (Waiter(..), waiter, Mailbox, copyMailbox, readMail, sendMail, newMailbox)
+import           Miso.Concurrent (Waiter(..), waiter, Mailbox, copyMailbox, readMail, sendMail, newMailbox, cloneMailbox)
 import           Miso.Delegate (delegator, undelegator)
 import           Miso.Diff (diff)
 import qualified Miso.FFI.Internal as FFI
@@ -122,7 +122,7 @@ initialize Component {..} getView = do
   componentMailbox <- liftIO newMailbox
   componentMailboxThreadId <- do
     FFI.forkJSM . forever $ do
-      message <- liftIO (readMail =<< copyMailbox componentMailbox)
+      message <- liftIO (readMail =<< cloneMailbox componentMailbox)
       mapM_ componentSink (mailbox message)
   let vcomp = ComponentState {..}
   registerComponent vcomp


### PR DESCRIPTION
Uses `cloneTChan` over `dupChan` for `Component` `Mailbox`. This ensures reads on `Component` `Mailbox` always refer to the contents of the original cloned `Mailbox`. Avoids missing messages potentially in a single reader scenario. For subscribers of `Topic` we should use `dupTChan` instead. `mail` should ensure reliable delivery, whereas `subscribe` is a notification stream.