### PR TITLE
Add `scripts :: [JS]`

### DIFF
--- a/src/Miso.hs
+++ b/src/Miso.hs
@@ -114,6 +114,7 @@ miso f = withJS $ do
   app@Component {..} <- f <$> getURI
   initialize app $ \snk -> do
     renderStyles styles
+    renderScripts scripts
     VTree (Object vtree) <- runView Hydrate (view model) snk logLevel events
     mount <- FFI.getBody
     FFI.hydrate (logLevel `elem` [DebugHydrate, DebugAll]) mount vtree
@@ -131,7 +132,10 @@ startComponent
   => Component model action
   -- ^ Component application
   -> JSM ()
-startComponent vcomp@Component { styles } = withJS $ initComponent vcomp (renderStyles styles)
+startComponent vcomp@Component { styles, scripts } =
+  withJS $ initComponent vcomp $ do
+    renderStyles styles
+    renderScripts scripts
 ----------------------------------------------------------------------------
 -- | Runs a miso application, but with a custom rendering engine.
 -- The @MisoString@ specified here is the variable name of a globally-scoped

--- a/src/Miso.hs
+++ b/src/Miso.hs
@@ -113,8 +113,8 @@ miso :: Eq model => (URI -> Component model action) -> JSM ()
 miso f = withJS $ do
   app@Component {..} <- f <$> getURI
   initialize app $ \snk -> do
-    renderStyles styles
     renderScripts scripts
+    renderStyles styles
     VTree (Object vtree) <- runView Hydrate (view model) snk logLevel events
     mount <- FFI.getBody
     FFI.hydrate (logLevel `elem` [DebugHydrate, DebugAll]) mount vtree
@@ -134,8 +134,8 @@ startComponent
   -> JSM ()
 startComponent vcomp@Component { styles, scripts } =
   withJS $ initComponent vcomp $ do
-    renderStyles styles
     renderScripts scripts
+    renderStyles styles
 ----------------------------------------------------------------------------
 -- | Runs a miso application, but with a custom rendering engine.
 -- The @MisoString@ specified here is the variable name of a globally-scoped

--- a/src/Miso/FFI/Internal.hs
+++ b/src/Miso/FFI/Internal.hs
@@ -15,7 +15,9 @@
 ----------------------------------------------------------------------------
 module Miso.FFI.Internal
    ( JSM
+   -- * Concurrency
    , forkJSM
+   -- * Callbacks
    , syncCallback
    , syncCallback1
    , syncCallback2
@@ -23,51 +25,73 @@ module Miso.FFI.Internal
    , asyncCallback1
    , asyncCallback2
    , ghcjsPure
+   -- * JSAddle
    , syncPoint
+   -- * Events
    , addEventListener
+   , eventPreventDefault
+   , eventStopPropagation
+   -- * Window
    , windowAddEventListener
    , windowInnerHeight
    , windowInnerWidth
-   , eventPreventDefault
-   , eventStopPropagation
+   -- * Performance
    , now
+   -- * Console
    , consoleWarn
    , consoleLog
    , consoleError
    , consoleLog'
+   -- * JSON
    , jsonStringify
    , jsonParse
    , eventJSON
+   -- * Object
    , set
+   -- * DOM
    , getBody
    , getDocument
    , getContext
    , getElementById
    , diff
+   -- * Conversions
    , integralToJSString
    , realFloatToJSString
    , jsStringToDouble
+   -- * Events
    , delegateEvent
    , undelegateEvent
+   -- * Isomorphic
    , hydrate
+   -- * Misc.
    , focus
    , blur
    , scrollIntoView
    , alert
    , reload
+   -- * CSS
    , addStyle
    , addStyleSheet
+   -- * JS
+   , addSrc
+   , addScript
+   -- * XHR
    , fetch
    , shouldSync
-   , flush
+   -- * Drawing
    , requestAnimationFrame
    , setDrawingContext
+   , flush
+   -- * Image
    , Image (..)
    , newImage
+   -- * Date
    , Date (..)
    , newDate
+   -- * Utils
    , getMilliseconds
    , getSeconds
+   -- * Component
    , getParentComponentId
    , getComponentId
    ) where
@@ -422,6 +446,26 @@ addStyle css = do
   style <- jsg "document" # "createElement" $ ["style"]
   (style <# "innerHTML") css
   void $ jsg "document" ! "head" # "appendChild" $ [style]
+-----------------------------------------------------------------------------
+-- | Appends a 'script_' element containing JS to 'head_'
+--
+-- > addScript "function () { alert('hi'); }"
+--
+addScript :: MisoString -> JSM ()
+addScript css = do
+  script <- jsg "document" # "createElement" $ ["script"]
+  (script <# "innerHTML") css
+  void $ jsg "document" ! "head" # "appendChild" $ [script]
+-----------------------------------------------------------------------------
+-- | Appends a \<script\> element to 'head_'
+--
+-- > addSrc "https://example.com/script.js"
+--
+addSrc :: MisoString -> JSM ()
+addSrc url = do
+  link <- jsg "document" # "createElement" $ ["script"]
+  _ <- link # "setAttribute" $ ["src", fromMisoString url]
+  void $ jsg "document" ! "head" # "appendChild" $ [link]
 -----------------------------------------------------------------------------
 -- | Appends a StyleSheet 'link_' element to 'head_'
 -- The 'link_' tag will contain a URL to a CSS file.

--- a/src/Miso/Internal.hs
+++ b/src/Miso/Internal.hs
@@ -24,6 +24,7 @@ module Miso.Internal
   , freshComponentId
   , runView
   , renderStyles
+  , renderScripts
   , Hydrate(..)
   -- * Subscription
   , startSub
@@ -639,13 +640,28 @@ registerComponent componentState = liftIO
   $ modifyIORef' components
   $ IM.insert (componentId componentState) componentState
 -----------------------------------------------------------------------------
--- | Registers components in the global state
+-- | Renders styles
+--
+-- Meant for development purposes
+-- Appends CSS to <head>
+--
 renderStyles :: [CSS] -> JSM ()
 renderStyles styles =
   forM_ styles $ \case
     Href url -> FFI.addStyleSheet url
     Style css -> FFI.addStyle css
     Sheet sheet -> FFI.addStyle (renderStyleSheet sheet)
+-----------------------------------------------------------------------------
+-- | Renders scripts
+--
+-- Meant for development purposes
+-- Appends JS to <head>
+--
+renderScripts :: [JS] -> JSM ()
+renderScripts scripts =
+  forM_ scripts $ \case
+    Src src -> FFI.addSrc src
+    Script script -> FFI.addScript script
 -----------------------------------------------------------------------------
 -- | Starts a named 'Sub' dynamically, during the life of a 'Component'.
 -- The 'Sub' can be stopped by calling @Ord subKey => stop subKey@ from the 'update' function.

--- a/src/Miso/Types.hs
+++ b/src/Miso/Types.hs
@@ -28,6 +28,7 @@ module Miso.Types
   , Attribute        (..)
   , NS               (..)
   , CSS              (..)
+  , JS               (..)
   , LogLevel         (..)
   , VTree            (..)
   , MountPoint
@@ -85,6 +86,12 @@ data Component model action
   -- before the initial draw on <body> occurs.
   --
   -- @since 1.9.0.0
+  , scripts :: [JS]
+  -- ^ List of JavaScript styles expressed as either a URL ('Href') or as 'Style' text.
+  -- These styles are appended dynamically to the <head> section of your HTML page
+  -- before the initial draw on <body> occurs.
+  --
+  -- @since 1.9.0.0
   , initialAction :: Maybe action
   -- ^ Initial action that is run after the application has loaded, optional
   --
@@ -119,6 +126,22 @@ data CSS
   -- ^ 'Sheet' is meant to be CSS built with 'Miso.Style'
   deriving (Show, Eq)
 -----------------------------------------------------------------------------
+-- | Allow users to express JS and append it to <head> before the first draw
+--
+-- This is meant to be useful in development only.
+--
+-- @
+--   Src "http://example.com/script.js
+--   Script "http://example.com/script.js
+-- @
+--
+data JS
+  = Src MisoString
+  -- ^ 'src' is a URL meant to link to hosted CSS
+  | Script MisoString
+  -- ^ 'script' is meant to be raw CSS in a 'style_' tag
+  deriving (Show, Eq)
+-----------------------------------------------------------------------------
 -- | Convenience for extracting mount point
 getMountPoint :: Maybe MisoString -> MisoString
 getMountPoint = fromMaybe "body"
@@ -136,6 +159,7 @@ component m u v = Component
   , subs = []
   , events = defaultEvents
   , styles = []
+  , scripts = []
   , mountPoint = Nothing
   , logLevel = Off
   , initialAction = Nothing

--- a/src/Miso/Types.hs
+++ b/src/Miso/Types.hs
@@ -87,8 +87,8 @@ data Component model action
   --
   -- @since 1.9.0.0
   , scripts :: [JS]
-  -- ^ List of JavaScript styles expressed as either a URL ('Href') or as 'Style' text.
-  -- These styles are appended dynamically to the <head> section of your HTML page
+  -- ^ List of JavaScript <scripts> expressed as either a URL ('Src') or raw JS text.
+  -- These scripts are appended dynamically to the <head> section of your HTML page
   -- before the initial draw on <body> occurs.
   --
   -- @since 1.9.0.0
@@ -137,9 +137,9 @@ data CSS
 --
 data JS
   = Src MisoString
-  -- ^ 'src' is a URL meant to link to hosted CSS
+  -- ^ 'src' is a URL meant to link to hosted JS
   | Script MisoString
-  -- ^ 'script' is meant to be raw CSS in a 'style_' tag
+  -- ^ 'script' is meant to be raw JS in a 'script' tag
   deriving (Show, Eq)
 -----------------------------------------------------------------------------
 -- | Convenience for extracting mount point


### PR DESCRIPTION
This is meant for development purposes primarily (similar to `renderStyles`). This allows dynamic appending of `<script>` to `<head>` on `Component` mount.

- [x] Add `renderScripts` function
- [x] Call `renderScripts` in `miso` / `renderComponent`
- [x] Create `addSrc` / `addScript`
- [x] Defaults to empty
- [x] Defines `JS (Src, Script)` datatype

```haskell
main :: IO ()
main = run $ startComponent vcomp
  { styles =
    [ Href "https://cdn.jsdelivr.net/npm/basecoat-css@0.2.8/dist/basecoat.cdn.min.css"
    ]
  , scripts =
    [ Src "https://cdn.tailwindcss.com"
    , Script "(function () { alert ('hey'); })()"
    ]
  }
 ```