### PR TITLE
Use github links to host examples

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -75,9 +75,6 @@ jobs:
      - name: (JS) Miso examples (GHCJS 9.12.2)
        run: nix-build -A miso-examples-ghcjs-9122
 
-     - name: (JS) Miso third-party examples (2048, flatris, etc.) (GHCJS 8.6.5)
-       run: nix-build -A more-examples -j1
-
      - name: (JS) Miso sample app (GHCJS 8.6)
        run: nix-build -A sample-app-js
 

--- a/default.nix
+++ b/default.nix
@@ -92,10 +92,6 @@ with pkgs.haskell.lib;
   inherit (pkgs.haskell.packages.ghc9122)
     miso-from-html;
 
-  # misc. examples
-  inherit (legacyPkgs)
-    more-examples;
-
   # dmj: make a NixOS test to ensure examples can be hosted
   # dry-running this ensures we catch the failure before deploy
   inherit (legacyPkgs)

--- a/flake.nix
+++ b/flake.nix
@@ -78,10 +78,6 @@
           inherit (pkgs.haskell.packages.ghc9122)
             miso-from-html;
 
-          # Misc.
-          inherit (pkgs.haskell.packages.ghc9122)
-            more-examples;
-
         };
 
         # Miso's dev shells

--- a/haskell-miso.org/nix/nginx.nix
+++ b/haskell-miso.org/nix/nginx.nix
@@ -54,42 +54,6 @@ with (import ../../default.nix {});
            };
          };
        };
-       "flatris.haskell-miso.org" = {
-          forceSSL = true;
-          enableACME = true;
-          locations = {
-          "/" = {
-            root = "${more-examples.miso-flatris}/bin/app.jsexe";
-           };
-         };
-       };
-       "miso-plane.haskell-miso.org" = {
-          forceSSL = true;
-          enableACME = true;
-          locations = {
-          "/" = {
-            root = more-examples.miso-plane;
-           };
-         };
-       };
-       "2048.haskell-miso.org" = {
-          forceSSL = true;
-          enableACME = true;
-          locations = {
-          "/" = {
-            root = more-examples.miso-2048;
-           };
-         };
-       };
-       "snake.haskell-miso.org" = {
-          forceSSL = true;
-          enableACME = true;
-          locations = {
-          "/" = {
-            root = "${more-examples.miso-snake}/bin/app.jsexe";
-           };
-         };
-       };
        "router.haskell-miso.org" = {
           forceSSL = true;
           enableACME = true;

--- a/nix/legacy/overlay.nix
+++ b/nix/legacy/overlay.nix
@@ -82,7 +82,4 @@ options: self: super: {
     nix shell github:nixos/nixpkgs/8ad5e8132c5dcf977e308e7bf5517cc6cc0bf7d8#nix -c \
       nixops deploy -j1 -d haskell-miso --option substituters "https://cache.nixos.org/"
   '';
-  more-examples = with super.haskell.lib; {
-    inherit (self.haskell.packages.ghcjs) miso-flatris miso-2048 miso-snake miso-plane;
-  };
 }

--- a/nix/source.nix
+++ b/nix/source.nix
@@ -47,28 +47,4 @@ in
     rev = "8c7635889ca0a5aaac36a8b21db7f5e5ec0ae4c9";
     sha256 = "0s6kzqxbshsnqbqfj7rblqkrr5mzkjxknb6k8m8z4h10mcv1zh7j";
   };
-  miso-flatris = fetchFromGitHub {
-    owner = "haskell-miso";
-    repo = "miso-flatris";
-    rev = "36d7f2b77242beeccb0321a7b6092b7c04cf0291";
-    hash = "sha256-cQz3l1lWNsU4m/db1ARwk+IGX2rQGXwYEnWT2aD+/IU=";
-  };
-  miso-plane = fetchFromGitHub {
-    owner = "haskell-miso";
-    repo = "miso-plane";
-    rev = "e6199d87d9161b25daca434d679330366ad0b42a";
-    hash = "sha256-TEOjj2Bb76MCWGvIRN5NhwmjEV7MZQHXnEK5szd5IqU=";
-  };
-  miso-2048 = fetchFromGitHub {
-    owner = "haskell-miso";
-    repo = "miso-2048";
-    rev = "63e33d3751e3e6021d22983a08293f8c0a41cc9b";
-    hash = "sha256-pZwYdtDMZm/ptnw4kFWh0lKVxJB3C5kkq6CUZ7evIR0=";
-  };
-  miso-snake = fetchFromGitHub {
-    owner = "haskell-miso";
-    repo = "miso-snake";
-    rev = "46e61b0c43c2c9b61aa388418770172cdd8af8b4";
-    hash = "sha256-HihtEbAnyMfNzSvJkjZeAbY/b/fm66wc4G0YuOJYfEA=";
-  };
 }


### PR DESCRIPTION
Now that a `flake.nix` workflow has been incorporated per @juliendehos work, we can use that to host `more-examples` on github, instead of miso's nginx. This means `2048`, `flatris`, etc. are no longer being hosted by us

- [x] Remove building third-party examples from CI
- [x] Drop `more-examples` derivation (from `source.nix`, `default.nix`, etc.)