### PR TITLE
Specify color as `Int` in hexadecimal.

### DIFF
--- a/haskell-miso.org/shared/Common.hs
+++ b/haskell-miso.org/shared/Common.hs
@@ -633,13 +633,13 @@ footer =
                     , text " by "
                     , a_
                         [ href_ "https://github.com/dmjio/miso"
-                        , CSS.style_ [ CSS.color (CSS.hex "363636") ]
+                        , CSS.style_ [ CSS.color (CSS.hex 0x363636) ]
                         ]
                         [text "dmjio"]
                     , text ". BSD3"
                     , a_
                         [ href_ "https://opensource.org/licenses/BSD-3-Clause"
-                        , CSS.style_ [ CSS.color (CSS.hex "363636") ]
+                        , CSS.style_ [ CSS.color (CSS.hex 0x363636) ]
                         ]
                         [text " licensed."]
                     ]
@@ -648,7 +648,7 @@ footer =
                     [ text "The source code for this website is located "
                     , a_
                         [ href_ "https://github.com/dmjio/miso/tree/master/haskell-miso.org"
-                        , CSS.style_ [ CSS.color (CSS.hex "363636") ]
+                        , CSS.style_ [ CSS.color (CSS.hex 0x363636) ]
                         ]
                         [text " here."]
                     ]
@@ -701,7 +701,7 @@ newNav navMenuOpen' =
                         [ span_
                             [ class_ "icon"
                             , name_ "github"
-                            , CSS.style_ [ CSS.color (CSS.hex "333") ]
+                            , CSS.style_ [ CSS.color (CSS.hex 0x333) ]
                             ]
                             [ i_ [class_ "fa fa-github"] []
                             ]
@@ -715,7 +715,7 @@ newNav navMenuOpen' =
                         [ span_
                             [ class_ "icon"
                             , name_ "twitter"
-                            , CSS.style_ [ CSS.color (CSS.hex "55acee") ]
+                            , CSS.style_ [ CSS.color (CSS.hex 0x55acee) ]
                             ]
                             [ i_ [class_ "fa fa-twitter"] []
                             ]

--- a/src/Miso/Style/Color.hs
+++ b/src/Miso/Style/Color.hs
@@ -172,9 +172,10 @@ module Miso.Style.Color
   , yellowgreen
   ) where
 -----------------------------------------------------------------------------
-import           Miso.String (MisoString)
+import           Miso.String (MisoString, ms)
 import qualified Miso.String as MS
 -----------------------------------------------------------------------------
+import           Numeric (showHex)
 import           Language.Javascript.JSaddle (ToJSVal(..), MakeArgs(..))
 import           Prelude hiding (tan)
 -----------------------------------------------------------------------------
@@ -242,8 +243,13 @@ hsl = HSL
 hsla :: Int -> Int -> Int -> Double -> Color
 hsla = HSLA
 -----------------------------------------------------------------------------
-hex :: MisoString -> Color
-hex = Hex
+-- | Smart constructor for color in hexadecimal
+--
+-- > div [ style_ [ backgroundColor (hex 0xAABBCC) ] ] [ ]
+-- > -- "#aabbcc"
+--
+hex :: Int -> Color
+hex = Hex . ms . flip showHex ""
 -----------------------------------------------------------------------------
 transparent :: Color
 transparent = rgba 0 0 0 0


### PR DESCRIPTION
Allows users to specify `Color` as an `Int`

```haskell
λ> hex 0xAABBCC
Hex "aabbcc"
λ> renderColor (hex 0xAABBCC)
"#aabbcc"
```

This was inspired by [three.js](threejs.org)