### PR TITLE
Add additional properties

### DIFF
--- a/src/Miso/Html/Property.hs
+++ b/src/Miso/Html/Property.hs
@@ -108,6 +108,11 @@ module Miso.Html.Property
    , language_
    , scoped_
    , data_
+   , autocorrect_
+   , spellcheck_
+   , role_
+   , xmlns_
+   , aria_
    ) where
 -----------------------------------------------------------------------------
 import           Miso.Types
@@ -172,6 +177,18 @@ autocomplete_ b = textProp "autocomplete" (if b then "on" else "off")
 -- | <https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/autosave>
 autosave_ ::  MisoString -> Attribute action
 autosave_          = textProp "autosave"
+-----------------------------------------------------------------------------
+-- | <https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/autocorrect>
+autocorrect_ ::  Bool -> Attribute action
+autocorrect_ b = textProp "autocomplete" (if b then "on" else "off")
+-----------------------------------------------------------------------------
+-- | <https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/spellcheck>
+spellcheck_ ::  Bool -> Attribute action
+spellcheck_ b = textProp "autocomplete" (if b then "on" else "off")
+-----------------------------------------------------------------------------
+-- | <https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/role>
+role_ ::  MisoString -> Attribute action
+role_ = textProp "role"
 -----------------------------------------------------------------------------
 -- | <https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/disabled>
 disabled_ ::  Bool -> Attribute action
@@ -491,4 +508,12 @@ class_ = textProp "class"
 -- https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/data-*
 data_ ::  MisoString -> MisoString -> Attribute action
 data_ k v = textProp ("data-" <> k) v
+-----------------------------------------------------------------------------
+-- | @since 1.9.0.0
+xmlns_ :: MisoString -> Attribute action
+xmlns_ = textProp "xmlns"
+-----------------------------------------------------------------------------
+-- | @since 1.9.0.0
+aria_ :: MisoString -> MisoString -> Attribute action
+aria_ k = textProp ("aria-" <> k)
 -----------------------------------------------------------------------------

--- a/src/Miso/Mathml/Property.hs
+++ b/src/Miso/Mathml/Property.hs
@@ -56,7 +56,6 @@ module Miso.Mathml.Property
   , symmetric_
   , voffset_
   , width_
-  , xmlns_
   ) where
 
 import           Miso.Types
@@ -222,8 +221,4 @@ voffset_ = textProp "voffset"
 -- | @since 1.9.0.0
 width_ :: MisoString -> Attribute action
 width_ = textProp "width"
------------------------------------------------------------------------------
--- | @since 1.9.0.0
-xmlns_ :: MisoString -> Attribute action
-xmlns_ = textProp "xmlns"
 -----------------------------------------------------------------------------

--- a/src/Miso/Svg/Property.hs
+++ b/src/Miso/Svg/Property.hs
@@ -47,7 +47,6 @@ module Miso.Svg.Property
   , gradientTransform_
   , gradientUnits_
   , height_
-  , href_
   , id_
   , in_'
   , in2_
@@ -337,12 +336,6 @@ gradientUnits_ = attr "gradientUnits"
 -- | [height](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/height) attribute
 height_ ::  MisoString -> Attribute action
 height_ = attr "height"
------------------------------------------------------------------------------
--- | [href](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/href) attribute
---
--- @since 1.9.0.0
-href_ ::  MisoString -> Attribute action
-href_ = attr "href"
 -----------------------------------------------------------------------------
 -- | [id](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/id) attribute
 id_ ::  MisoString -> Attribute action


### PR DESCRIPTION
Adds some missing properties required by [basecoat](https://basecoatui.com/), shuffles some others around. Adds `aria` helper.