### PR TITLE
`component_` -> `mount_`. Allow mounting on any tag.

### DIFF
--- a/examples/components/Main.hs
+++ b/examples/components/Main.hs
@@ -55,12 +55,12 @@ server = component () update_ $ \() ->
   [ "Server component"
   , button_ [ onClick AddOne ] [ "+" ]
   , button_ [ onClick SubtractOne ] [ "-" ]
-  , component_
-    [ onMountedWith Mount
-    ] (client_ "client 1")
-  , component_
-    [ onMountedWith Mount
-    ] (client_ "client 2")
+  , mount_
+    (p_ [ onMountedWith Mount ])
+    (client_ "client 1")
+  , mount_
+    (p_ [ onMountedWith Mount ])
+    (client_ "client 2")
   ] where
       update_ :: Action -> Effect () Action
       update_ = \case

--- a/examples/components/Main.hs
+++ b/examples/components/Main.hs
@@ -55,12 +55,8 @@ server = component () update_ $ \() ->
   [ "Server component"
   , button_ [ onClick AddOne ] [ "+" ]
   , button_ [ onClick SubtractOne ] [ "-" ]
-  , mount
-    (p_ [ onMountedWith Mount ])
-    (client_ "client 1")
-  , mount
-    (p_ [ onMountedWith Mount ])
-    (client_ "client 2")
+  , p_ [ onMountedWith Mount ] @-> client_ "client 1"
+  , p_ [ onMountedWith Mount ] @-> client_ "client 2"
   ] where
       update_ :: Action -> Effect () Action
       update_ = \case

--- a/examples/components/Main.hs
+++ b/examples/components/Main.hs
@@ -55,10 +55,10 @@ server = component () update_ $ \() ->
   [ "Server component"
   , button_ [ onClick AddOne ] [ "+" ]
   , button_ [ onClick SubtractOne ] [ "-" ]
-  , mount_
+  , mount
     (p_ [ onMountedWith Mount ])
     (client_ "client 1")
-  , mount_
+  , mount
     (p_ [ onMountedWith Mount ])
     (client_ "client 2")
   ] where

--- a/examples/components/Main.hs
+++ b/examples/components/Main.hs
@@ -55,8 +55,8 @@ server = component () update_ $ \() ->
   [ "Server component"
   , button_ [ onClick AddOne ] [ "+" ]
   , button_ [ onClick SubtractOne ] [ "-" ]
-  , p_ [ onMountedWith Mount ] @-> client_ "client 1"
-  , p_ [ onMountedWith Mount ] @-> client_ "client 2"
+  , p_ [ onMountedWith Mount ] +> client_ "client 1"
+  , p_ [ onMountedWith Mount ] +> client_ "client 2"
   ] where
       update_ :: Action -> Effect () Action
       update_ = \case

--- a/src/Miso.hs
+++ b/src/Miso.hs
@@ -115,10 +115,10 @@ miso f = withJS $ do
   initialize app $ \snk -> do
     refs <- (++) <$> renderScripts scripts <*> renderStyles styles
     VTree (Object vtree) <- runView Hydrate (view model) snk logLevel events
-    mount <- FFI.getBody
-    FFI.hydrate (logLevel `elem` [DebugHydrate, DebugAll]) mount vtree
+    mount_ <- FFI.getBody
+    FFI.hydrate (logLevel `elem` [DebugHydrate, DebugAll]) mount_ vtree
     viewRef <- liftIO $ newIORef $ VTree (Object vtree)
-    pure (refs, mount, viewRef)
+    pure (refs, mount_, viewRef)
 -----------------------------------------------------------------------------
 -- | Alias for 'miso'.
 (🍜) :: Eq model => (URI -> Component model action) -> JSM ()
@@ -166,10 +166,10 @@ initComponent vcomp@Component{..} hooks = do
   initialize vcomp $ \snk -> do
     refs <- hooks
     vtree <- runView Draw (view model) snk logLevel events
-    mount <- mountElement (getMountPoint mountPoint)
-    diff Nothing (Just vtree) mount
+    mount_ <- mountElement (getMountPoint mountPoint)
+    diff Nothing (Just vtree) mount_
     viewRef <- liftIO (newIORef vtree)
-    pure (refs, mount, viewRef)
+    pure (refs, mount_, viewRef)
 -----------------------------------------------------------------------------
 #ifdef PRODUCTION
 #define MISO_JS_PATH "js/miso.prod.js"

--- a/src/Miso/Effect.hs
+++ b/src/Miso/Effect.hs
@@ -36,6 +36,7 @@ module Miso.Effect
   , issue
   , withSink
   , mapSub
+  , noop
   -- * Internal
   , runEffect
   -- * Deprecated
@@ -231,4 +232,11 @@ batchEff :: model -> [JSM action] -> Effect model action
 batchEff model actions = do
   put model
   batch actions
+-----------------------------------------------------------------------------
+-- | Helper for 'Component' construction, when you want to ignore the 'update'
+-- function temporarily, or permanently.
+--
+-- @since 1.9.0.0
+noop :: action -> Effect model action
+noop = const (pure ())
 -----------------------------------------------------------------------------

--- a/src/Miso/Runtime.hs
+++ b/src/Miso/Runtime.hs
@@ -532,7 +532,7 @@ runView
   -> LogLevel
   -> Events
   -> JSM VTree
-runView hydrate (VComp attrs (SomeComponent app)) snk _ _ = do
+runView hydrate (VComp ns tag attrs (SomeComponent app)) snk _ _ = do
   mountCallback <- do
     FFI.syncCallback2 $ \domRef continuation -> do
       ComponentState {..} <- initialize app (drawComponent hydrate domRef app)
@@ -546,7 +546,7 @@ runView hydrate (VComp attrs (SomeComponent app)) snk _ _ = do
         Nothing -> pure ()
         Just componentState ->
           unmount mountCallback app componentState
-  vcomp <- createNode "vcomp" HTML "div"
+  vcomp <- createNode "vcomp" ns tag
   setAttrs vcomp attrs snk (logLevel app) (events app)
   flip (FFI.set "children") vcomp =<< toJSVal ([] :: [MisoString])
   flip (FFI.set "mount") vcomp =<< toJSVal mountCallback

--- a/src/Miso/Types.hs
+++ b/src/Miso/Types.hs
@@ -40,7 +40,7 @@ module Miso.Types
   , component
   -- ** Component
   , mount
-  , (@->)
+  , (+>)
   -- ** Utils
   , getMountPoint
   -- *** Combinators
@@ -227,13 +227,13 @@ mount mkNode vcomp =
     _ ->
       error "Cannot mount on a Text node"
 -----------------------------------------------------------------------------
-(@->)
+(+>)
   :: forall model action a . Eq model
   => ([Miso.Types.View action] -> Miso.Types.View a)
   -> Component model action
   -> View a
-infixr 0 @->
-(@->) = mount
+infixr 0 +>
+(+>) = mount
 -----------------------------------------------------------------------------
 -- | For constructing type-safe links
 instance HasLink (View a) where

--- a/src/Miso/Types.hs
+++ b/src/Miso/Types.hs
@@ -40,6 +40,7 @@ module Miso.Types
   , component
   -- ** Component
   , mount
+  , (@->)
   -- ** Utils
   , getMountPoint
   -- *** Combinators
@@ -225,6 +226,14 @@ mount mkNode vcomp =
       VComp ns tag attrs vcomp_
     _ ->
       error "Cannot mount on a Text node"
+-----------------------------------------------------------------------------
+(@->)
+  :: forall model action a . Eq model
+  => ([Miso.Types.View action] -> Miso.Types.View a)
+  -> Component model action
+  -> View a
+infixr 0 @->
+(@->) = mount
 -----------------------------------------------------------------------------
 -- | For constructing type-safe links
 instance HasLink (View a) where

--- a/src/Miso/Types.hs
+++ b/src/Miso/Types.hs
@@ -38,8 +38,8 @@ module Miso.Types
   , ToKey            (..)
   -- ** Smart Constructors
   , component
-  -- ** Components
-  , mount_
+  -- ** Component
+  , mount
   -- ** Utils
   , getMountPoint
   -- *** Combinators
@@ -199,7 +199,7 @@ data SomeComponent
 --
 -- @
 --   mount_ (p_ [ key_ "component-1" ]) $ component $ \\m ->
---     div_ [ id_ "foo" ] [ text (ms m)
+--     div_ [ id_ "foo" ] [ text (ms m) ]
 -- @
 --
 -- Warning this *is* a partial function. Do not attempt to mount on a
@@ -211,12 +211,12 @@ data SomeComponent
 -- See usage above. In general, it's wise to only mount on `VNode`.
 --
 -- @since 1.9.0.0
-mount_
+mount
   :: forall model action a . Eq model
   => ([Miso.Types.View action] -> Miso.Types.View a)
   -> Component model action
   -> View a
-mount_ mkNode vcomp =
+mount mkNode vcomp =
   case mkNode [] of
     VNode ns tag attrs _ ->
       VComp ns tag attrs


### PR DESCRIPTION
Introduces `mount_`, renamed `component_`.

- [x] `component_` renamed because it conflicted in naming with `component`, was confusing
- [x] `mount_` is now able to mount on any tag, not just `div_` (`View` modified for this).
- [x] Updates examples to reflect new combinator
- [x] Adds infix combinator `+>` (`infixr 0`)
- [x] Adds `noop` helper (`const (pure ())`)

For usage,

```haskell
view m =
  p_ [ key_ "my-component" ] +> 
    component True noop $ \cond -> 
      if cond then "true" else "false"
```

This solves the rogue `<div>` issue as seen in https://github.com/dmjio/miso/pull/1043, by allowing users to specify any tag type, while preserving the ability to specify a `key_`.