### PR TITLE
Add `componentParentId` and `ComponentInfo`.

### DIFF
--- a/miso.cabal
+++ b/miso.cabal
@@ -37,7 +37,7 @@ common cpp
       -DWASM
   else
     cpp-options:
-      -DNATIVE
+      -DVANILLA
   if flag(production)
     cpp-options:
       -DPRODUCTION

--- a/src/Miso.hs
+++ b/src/Miso.hs
@@ -36,6 +36,7 @@ module Miso
   , mail
   , getComponentId
   , getParentComponentId
+  , getChildrenComponentId
   -- ** Subscriptions
   , startSub
   , stopSub
@@ -93,7 +94,7 @@ import           Miso.Diff
 import           Miso.Effect
 import           Miso.Event
 import           Miso.Fetch
-import           Miso.FFI hiding (getComponentId, getParentComponentId)
+import           Miso.FFI hiding (getComponentId, getParentComponentId, getChildrenComponentId)
 import qualified Miso.FFI.Internal as FFI
 import           Miso.Html
 import           Miso.Runtime

--- a/src/Miso/Effect.hs
+++ b/src/Miso/Effect.hs
@@ -25,6 +25,9 @@ module Miso.Effect
   , Sub
   , Sink
   , DOMRef
+  , ComponentInfo (..)
+  -- *** Smart constructors
+  , mkComponentInfo
     -- *** Combinators
   , (<#)
   , (#>)
@@ -127,7 +130,7 @@ batch_ actions = sequence_
 --   , ...
 --   }
 -- @
-type Effect model action = RWS DOMRef [Sink action -> JSM ()] model ()
+type Effect model action = RWS ComponentInfo [Sink action -> JSM ()] model ()
 -----------------------------------------------------------------------------
 -- | Type to represent a DOM reference
 type DOMRef = JSVal
@@ -141,7 +144,7 @@ instance Fail.MonadFail Identity where
 -- | Internal function used to unwrap an @EffectCore@
 runEffect
     :: Effect model action
-    -> DOMRef
+    -> ComponentInfo
     -> model
     -> (model, [Sink action -> JSM ()])
 runEffect = execRWS
@@ -239,4 +242,28 @@ batchEff model actions = do
 -- @since 1.9.0.0
 noop :: action -> Effect model action
 noop = const (pure ())
+-----------------------------------------------------------------------------
+mkComponentInfo
+  :: ComponentId
+  -- ^ Component ID
+  -> Maybe ComponentId
+  -- ^ Parent ID
+  -> DOMRef
+  -- ^ DOM Reference
+  -> ComponentInfo
+mkComponentInfo = ComponentInfo
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------
+-- | This is the 'Reader r' in 'Effect'. Accessible via 'ask'.
+--
+-- The 'Sink' callback is used to dispatch actions which are then fed
+-- back into the 'Miso.Types.update' function.
+data ComponentInfo
+  = ComponentInfo
+  { _componentId :: ComponentId
+  , _parentComponentId :: Maybe ComponentId
+  , _componentDOMRef :: DOMRef
+  }
+-----------------------------------------------------------------------------
+type ComponentId = Int
 -----------------------------------------------------------------------------

--- a/src/Miso/FFI/Internal.hs
+++ b/src/Miso/FFI/Internal.hs
@@ -94,6 +94,7 @@ module Miso.FFI.Internal
    -- * Component
    , getParentComponentId
    , getComponentId
+   , getChildrenComponentId
    ) where
 -----------------------------------------------------------------------------
 import           Control.Concurrent (ThreadId, forkIO)
@@ -598,4 +599,12 @@ getParentComponentId domRef =
 -- For use in `onMounted`, etc.
 getComponentId :: JSVal -> JSM Int
 getComponentId vtree = fromJSValUnchecked =<< vtree ! "componentId"
+-----------------------------------------------------------------------------
+-- | Get access to the 'ComponentId'
+-- N.B. you * must * call this on the DOMRef, otherwise, problems.
+-- For use in `onMounted`, etc.
+getChildrenComponentId :: JSVal -> JSM [Int]
+getChildrenComponentId domRef = do
+  fromJSValUnchecked =<< do
+    jsg "miso" # "getChildrenComponentId" $ [domRef]
 -----------------------------------------------------------------------------

--- a/ts/miso/util.ts
+++ b/ts/miso/util.ts
@@ -91,3 +91,23 @@ export function getParentComponentId (
     }
     return climb (vcomp['domRef']);
 }
+
+/*
+   'getChildrenComponentId'
+   dmj: Used to fetch the parent's componentId
+
+   Climbs up the tree, finds the immediate component ancestor (parent) and returns its componentId
+   This should be called on the DOMRef of a VComp, otherwise it will return the current componentId.
+
+*/
+export function getChildrenComponentId (
+  vcomp: VComp
+): Array<int> {
+    var componentIds : Array<int> = [];
+    for (const child of vcomp.children) {
+        if (child['type'] === 'vcomp') {
+          componentIds.push(child['componentId']);
+        }
+    }
+    return componentIds;
+}


### PR DESCRIPTION
This parameterizes `Effect` by `ComponentInfo`, allowing users to extract a parent's ComponentId (if it exists), for message passing. The parent ID is set during Component initialization by tree climbing w/ `miso.getParentComponentId`.

This makes it so both component ID and component mount DOMRef are avaialable to end users in `Effect` via `ask`, `asks`, or `view`.