### PR TITLE
Drop haddocks hosting on nixops.

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -52,10 +52,6 @@ with pkgs.haskell.lib;
   inherit (pkgs)
     coverage;
 
-  # haddocks
-  inherit (pkgs)
-    haddocks;
-
   # ci
   inherit (legacyPkgs)
     deploy

--- a/haskell-miso.org/nix/nginx.nix
+++ b/haskell-miso.org/nix/nginx.nix
@@ -27,15 +27,6 @@ with (import ../../default.nix {});
            };
          };
        };
-       "haddocks.haskell-miso.org" = {
-          forceSSL = true;
-          enableACME = true;
-          locations = {
-          "/" = {
-            root = haddocks;
-           };
-         };
-       };
      };
    };
 }

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -11,17 +11,6 @@ self: super: {
     '';
   };
 
-  # dmj: Ensure you call 'nix-shell --run 'cabal haddock-project'' first
-  # this happens in CI
-  haddocks = self.stdenv.mkDerivation {
-    name = "haddocks";
-    src = ../haddocks;
-    buildCommand = ''
-      mkdir -p $out
-      cp -rv $src/* $out
-    '';
-  };
-
   # haskell stuff
   haskell = super.haskell // {
     packages = super.haskell.packages // {


### PR DESCRIPTION
Host haddocks via flakes + github CI actions at https://github.com/haskell-miso/miso-haddocks.