### PR TITLE
Drop get* variant functions, prefer `parent`, use `ask`.

### DIFF
--- a/src/Miso.hs
+++ b/src/Miso.hs
@@ -34,8 +34,6 @@ module Miso
   , topic
   -- ** Component
   , mail
-  , getComponentId
-  , getParentComponentId
   -- ** Subscriptions
   , startSub
   , stopSub
@@ -93,7 +91,7 @@ import           Miso.Diff
 import           Miso.Effect
 import           Miso.Event
 import           Miso.Fetch
-import           Miso.FFI hiding (getComponentId, getParentComponentId)
+import           Miso.FFI
 import qualified Miso.FFI.Internal as FFI
 import           Miso.Html
 import           Miso.Runtime


### PR DESCRIPTION
These functions are no longer necessary because we put `ComponentId` in the `Reader` for `Effect` and the new `parent` function in #1047 will subsume `getParentComponentId` (and further it uses the `FFI.Internal` variant).