### PR TITLE
Adds `click`

### DIFF
--- a/src/Miso/FFI.hs
+++ b/src/Miso/FFI.hs
@@ -47,6 +47,8 @@ module Miso.FFI
   , getComponentId
   -- ** DOM
   , nextSibling
+  -- ** Element
+  , click
   ) where
 -----------------------------------------------------------------------------
 import           Miso.FFI.Internal

--- a/src/Miso/FFI/Internal.hs
+++ b/src/Miso/FFI/Internal.hs
@@ -96,6 +96,7 @@ module Miso.FFI.Internal
    -- * Component
    , getParentComponentId
    , getComponentId
+   , click
    ) where
 -----------------------------------------------------------------------------
 import           Control.Concurrent (ThreadId, forkIO)
@@ -614,4 +615,11 @@ getComponentId vtree = fromJSValUnchecked =<< vtree ! "componentId"
 -----------------------------------------------------------------------------
 nextSibling :: JSVal -> JSM JSVal
 nextSibling domRef = domRef ! "nextSibling"
+-----------------------------------------------------------------------------
+-- | Simulates a click event
+--
+-- > button & click ()
+--
+click :: () -> JSVal -> JSM ()
+click () domRef = void $ domRef # "click" $ ([] :: [MisoString])
 -----------------------------------------------------------------------------


### PR DESCRIPTION
```haskell
test (Action domRef) = io_ $ do
  domRef & click ()
```

This is useful when working with `FileReader` input.