### PR TITLE
Use `ToJSVal` w/ `console.log`

### DIFF
--- a/src/Miso/FFI.hs
+++ b/src/Miso/FFI.hs
@@ -12,7 +12,6 @@ module Miso.FFI
     set
   , now
   , consoleLog
-  , consoleLog'
   , consoleError
   , consoleWarn
   , getElementById

--- a/src/Miso/FFI/Internal.hs
+++ b/src/Miso/FFI/Internal.hs
@@ -251,7 +251,7 @@ now = fromJSValUnchecked =<< (jsg "performance" # "now" $ ())
 consoleLog :: ToJSVal jsval => jsval -> JSM ()
 consoleLog jsval = do
   v <- toJSVal jsval
-  _ <- jsg "console" # "log" $ [toJSString v]
+  _ <- jsg "console" # "log" $ [v]
   pure ()
 -----------------------------------------------------------------------------
 -- | Outputs a warning message to the web console

--- a/src/Miso/FFI/Internal.hs
+++ b/src/Miso/FFI/Internal.hs
@@ -248,8 +248,9 @@ now = fromJSValUnchecked =<< (jsg "performance" # "now" $ ())
 -- See <https://developer.mozilla.org/en-US/docs/Web/API/Console/log>
 --
 -- Console logging of JavaScript strings.
-consoleLog :: MisoString -> JSM ()
-consoleLog v = do
+consoleLog :: ToJSVal jsval => jsval -> JSM ()
+consoleLog jsval = do
+  v <- toJSVal jsval
   _ <- jsg "console" # "log" $ [toJSString v]
   pure ()
 -----------------------------------------------------------------------------
@@ -271,12 +272,6 @@ consoleWarn v = do
 consoleError :: MisoString -> JSM ()
 consoleError v = do
   _ <- jsg "console" # "error" $ [toJSString v]
-  pure ()
------------------------------------------------------------------------------
--- | Console-logging of JSVal
-consoleLog' :: JSVal -> JSM ()
-consoleLog' v = do
-  _ <- jsg "console" # "log" $ [v]
   pure ()
 -----------------------------------------------------------------------------
 -- | Encodes a Haskell object as a JSON string by way of a JavaScript object

--- a/src/Miso/FFI/Internal.hs
+++ b/src/Miso/FFI/Internal.hs
@@ -41,7 +41,6 @@ module Miso.FFI.Internal
    , consoleWarn
    , consoleLog
    , consoleError
-   , consoleLog'
    -- * JSON
    , jsonStringify
    , jsonParse


### PR DESCRIPTION
Makes `console` family of functions more generic