### PR TITLE
Stronger lens agnosticism

### DIFF
--- a/miso.cabal
+++ b/miso.cabal
@@ -137,6 +137,8 @@ library
     Miso.Html.Event
     Miso.Html.Property
     Miso.Lens
+    Miso.Lens.Binding
+    Miso.Lens.VL
     Miso.Mathml
     Miso.Mathml.Element
     Miso.Mathml.Property

--- a/src/Miso/Lens.hs
+++ b/src/Miso/Lens.hs
@@ -147,21 +147,14 @@ module Miso.Lens
   , this
   -- *** Re-exports
   , compose
-  -- *** Conversion
-  , Lens'
-  , toVL
-  , fromVL
   ) where
 ----------------------------------------------------------------------------
 import Control.Monad.Reader (MonadReader, asks)
 import Control.Monad.State (MonadState, modify, gets)
-import Control.Monad.Identity (Identity(..))
 import Control.Category (Category (..))
 import Control.Arrow ((<<<))
-import Data.Functor.Const (Const(..))
 import Data.Function ((&))
 import Data.Functor((<&>))
-import Data.Kind (Type)
 import Prelude hiding ((.))
 ----------------------------------------------------------------------------
 import Miso.Util (compose)
@@ -189,22 +182,6 @@ type Getter record field = record -> field
 ----------------------------------------------------------------------------
 -- | Type to express a setter on a @Lens@
 type Setter record field = field -> record -> record
-----------------------------------------------------------------------------
--- | Van Laarhoven formulation, used for conversion w/ 'miso' @Lens@.
-type Lens' s a = forall (f :: Type -> Type). Functor f => (a -> f a) -> s -> f s
-----------------------------------------------------------------------------
--- | Convert from `miso` @Lens@ to Van Laarhoven @Lens'@
-toVL :: Lens record field -> Lens' record field
-toVL Lens {..} = \f record -> flip _set record <$> f (_get record)
-----------------------------------------------------------------------------
--- | Convert from `miso` @Lens@ to Van Laarhoven @Lens'@
-fromVL
-  :: Lens' record field
-  -> Lens record field
-fromVL lens_ = Lens {..}
-  where
-    _get record = getConst (lens_ Const record)
-    _set field = runIdentity . lens_ (\_ -> Identity field)
 ----------------------------------------------------------------------------
 -- | Lens are Categories, and can therefore be composed.
 instance Category Lens where

--- a/src/Miso/Lens/Binding.hs
+++ b/src/Miso/Lens/Binding.hs
@@ -1,0 +1,11 @@
+module Miso.Lens.Binding where
+
+import Miso.Lens
+import Miso.Types
+
+(--->) :: Lens parent field -> Lens child field -> Binding parent child
+p ---> c = ParentToChild (_get p) (_set c)
+(<---) :: Lens parent field -> Lens child field -> Binding parent child
+p <--- c = ChildToParent (_set p) (_get c)
+(<--->) :: Lens parent field -> Lens child field -> Binding parent child
+p <---> c = Bidirectional (_get p) (_set p) (_get c) (_set c)

--- a/src/Miso/Lens/VL.hs
+++ b/src/Miso/Lens/VL.hs
@@ -1,0 +1,52 @@
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE RecordWildCards #-}
+
+module Miso.Lens.VL where
+
+import Control.Monad.Identity
+import Data.Functor.Contravariant
+import Data.Kind
+import Miso.Lens
+import Miso.Types
+import Control.Applicative
+
+-- | Van Laarhoven formulation, used for conversion w/ 'miso' @Lens@.
+type Lens' s a = forall (f :: Type -> Type). (Functor f) => (a -> f a) -> s -> f s
+type Getter' record field = forall (f :: Type -> Type). (Contravariant f, Functor f) => (field -> f field) -> record -> f record
+type Setter' record field = (field -> Identity field) -> record -> Identity record
+
+----------------------------------------------------------------------------
+
+-- | Convert from `miso` @Lens@ to Van Laarhoven @Lens'@
+lensFromVL ::
+    Lens' record field ->
+    Lens record field
+lensFromVL lens_ = Lens{..}
+  where
+    _get = getterFromVL lens_
+    _set = setterFromVL lens_
+getterFromVL ::
+    Getter' record field ->
+    Getter record field
+getterFromVL lens_ record = getConst (lens_ Const record)
+setterFromVL ::
+    Setter' record field ->
+    Setter record field
+setterFromVL lens_ field = runIdentity . lens_ (\_ -> Identity field)
+
+{- | Bidirectionally binds a child field to a parent field, using @Lens'@
+
+This is a bidirectional reactive combinator for a Van Laarhoven @Lens'@
+
+@since 1.9.0.0
+-}
+(<--->) :: Lens' parent field -> Lens' child field -> Binding parent child
+p <---> c = Bidirectional (_get p') (_set p') (_get c') (_set c')
+  where
+    p' = lensFromVL p
+    c' = lensFromVL c
+(--->) :: Getter' parent field -> Setter' child field -> Binding parent child
+p ---> c = ParentToChild (getterFromVL p) (setterFromVL c)
+(<---) :: Setter' parent field -> Getter' child field -> Binding parent child
+p <--- c = ChildToParent (setterFromVL p) (getterFromVL c)

--- a/src/Miso/Types.hs
+++ b/src/Miso/Types.hs
@@ -48,7 +48,6 @@ module Miso.Types
   , (-->)
   , (<--)
   , (<-->)
-  , (<--->)
   -- ** Component
   , mount
   , (+>)
@@ -82,7 +81,7 @@ import           Servant.API (HasLink(MkLink, toLink))
 import           Miso.Concurrent (Mail)
 import           Miso.Effect (Effect, Sub, Sink, DOMRef, ComponentId)
 import           Miso.Event.Types
-import           Miso.Lens (Getter, Setter, Lens(..), Lens', fromVL)
+import           Miso.Lens (Getter, Setter)
 import qualified Miso.String as MS
 import           Miso.String (MisoString, toMisoString, ms, fromMisoString)
 import           Miso.Style.Types (StyleSheet)
@@ -448,19 +447,5 @@ data Binding parent child
 (<--) :: Setter parent a -> Getter model a -> Binding parent model
 (<--) = ChildToParent
 -----------------------------------------------------------------------------
--- | Bidirectionally binds a child field to a parent field, using @Lens@
---
--- This is a bidirectional reactive combinator for a miso @Lens@.
---
--- @since 1.9.0.0
-(<-->) :: Lens parent field -> Lens child field -> Binding parent child
-p <--> c = Bidirectional (_get p) (_set p) (_get c) (_set c)
------------------------------------------------------------------------------
--- | Bidirectionally binds a child field to a parent field, using @Lens'@
---
--- This is a bidirectional reactive combinator for a Van Laarhoven @Lens'@
---
--- @since 1.9.0.0
-(<--->) :: Lens' parent field -> Lens' child field -> Binding parent child
-p <---> c = Bidirectional (_get (fromVL p)) (_set (fromVL p)) (_get (fromVL c)) (_set (fromVL c))
------------------------------------------------------------------------------
+(<-->) :: (Getter parent field, Setter parent field) -> (Getter model field, Setter model field) -> Binding parent model
+(gp, sp) <--> (gc, sc) = Bidirectional gp sp gc sc


### PR DESCRIPTION
A follow-up of sorts to #1088 ("lens atheism"?).

After using the new bindings stuff for a couple of days, I've come up with some slight modifications which IMO make for a cleaner API. My main motivation is creating a `miso-optics` library that's easy to use without fiddling with import hiding. This is just a suggestion, and thus code is in a messy PoC form.

With these changes:

- Users who don't want lenses at all can just not import `Miso.Lens`. The non-lens `<-->` is a bit unwieldy, but we could add a suggestion in the Haddocks saying "look at this other version which is more convenient, if you're comfortable with lenses". Anyway, presumably it's seen as less important than the unidirectional ones since it was removed completely for a while.
- Users who just want to use Miso lenses can import `Miso.Lens` and `Miso.Lens.Binding`. The latter would probably be better off in `Miso.Lens` itself, and I only haven't done that yet because it would require some slight rejigging to avoid cyclic modules.
- Users who want to use Van Laarhoven lenses can import `Miso.Lens.VL` for helpers and conversions from `lens`/`microlens`. We don't even really need to expose `lensFromVL` etc. given that bindings are the only part of the Miso API that actually uses a lens interface (we probably don't need conversions the other way regardless). In fact, `Miso.Lens.VL` could be a separate library, much like `miso-optics`, unless we want to hide the internals of Miso lenses (which maybe we should).
- Users who want to use `optics` (me), can depend on a `miso-optics` library. This doesn't exist yet, but the code would look very similar to `Miso.Lens.VL`.

One thing I haven't done here but would strongly consider is re-inlining the type synonyms for `Getter` and `Setter`. Without inheritance like the proper ones, they're not very useful and it feels like a bit of a false analogy.

As an alternative to all this, we _could_ drop `Miso.Lens` entirely in favour of `optics-core`, which would result in 4 new transitive dependencies, none of them big and all well-maintained...
