### PR TITLE
Add `wai-middleware-static` to `Miso.Run` debug `Middleware`.

### DIFF
--- a/miso.cabal
+++ b/miso.cabal
@@ -53,7 +53,11 @@ common string-selector
 common jsaddle
   if !(impl(ghcjs) || arch(javascript) || arch(wasm32))
     build-depends:
-      jsaddle-warp < 0.10
+      jsaddle-warp < 0.10,
+      wai-middleware-static < 0.10,
+      wai < 3.3,
+      warp < 3.5,
+      websockets < 0.14
 
   if !(impl(ghcjs) || arch(javascript))
     build-depends:


### PR DESCRIPTION
This means that usage of `CSS.url "mario.png"` w/ `Miso.Style` will "just work" when developing from GHCi. Assuming `'mario.png'` is in the same directory where GHCi is running.