### PR TITLE
Add resource finalization on Window `Sub`.

### DIFF
--- a/src/Miso/Subscription/History.hs
+++ b/src/Miso/Subscription/History.hs
@@ -92,7 +92,7 @@ uriSub = \f sink -> do
   void . FFI.forkJSM . forever $ do
     liftIO (wait chan)
     sink . f =<< getURI
-  FFI.windowAddEventListener (ms "popstate") $ \_ ->
+  void $ FFI.windowAddEventListener (ms "popstate") $ \_ ->
     sink . f =<< getURI
 -----------------------------------------------------------------------------
 pushStateNoModel :: URI -> JSM ()

--- a/src/Miso/Subscription/SSE.hs
+++ b/src/Miso/Subscription/SSE.hs
@@ -30,13 +30,14 @@ sseSub
   -> Sub action
 sseSub url f sink = do
   es <- JSaddle.new (jsg (ms "EventSource")) [url]
-  FFI.addEventListener es (ms "message") $ \v -> do
+  _ <- FFI.addEventListener es (ms "message") $ \v -> do
     dat <- FFI.jsonParse =<< v ! (ms "data")
     sink (f (SSEMessage dat))
-  FFI.addEventListener es (ms "error") $ \_ ->
+  _ <- FFI.addEventListener es (ms "error") $ \_ ->
     sink (f SSEError)
-  FFI.addEventListener es (ms "close") $ \_ ->
+  _ <- FFI.addEventListener es (ms "close") $ \_ ->
     sink (f SSEClose)
+  pure ()
 -----------------------------------------------------------------------------
 -- | Server-sent events data
 data SSE message


### PR DESCRIPTION
This introduces the `bracket` pattern to `Sub`, specifically on `window`, this allows resource finalization and works well with top-level, long running `Sub`, or dynamically-generated `Sub` (`startSub`, `stopSub`).

To accomplish this, we are now returning `Function` from `addEventListener` too.

- [x] Introduce `removeEventListener`, windowRemoveEventListener
- [x] Refactor `Subscription.Window`
- [x] Use empty `MVar` to block on processing portion of `Sub`
- [x] Use `bracket` pattern