### PR TITLE
Add `Miso.Subscription.Util.createSub`

### DIFF
--- a/miso.cabal
+++ b/miso.cabal
@@ -158,6 +158,7 @@ library
     Miso.Subscription.WebSocket
     Miso.Subscription.Window
     Miso.Subscription.SSE
+    Miso.Subscription.Util
     Miso.Svg
     Miso.Svg.Property
     Miso.Svg.Element

--- a/src/Miso/Canvas.hs
+++ b/src/Miso/Canvas.hs
@@ -97,7 +97,7 @@ module Miso.Canvas
   ) where
 -----------------------------------------------------------------------------
 import           Control.Monad.Reader (ReaderT, runReaderT, ask)
-import           Language.Javascript.JSaddle ( JSM, JSVal, (#), fromJSVal, MakeArgs (..)
+import           Language.Javascript.JSaddle ( JSVal, (#), fromJSVal, MakeArgs (..)
                                              , (<#), toJSVal, (!), fromJSValUnchecked
                                              , liftJSM, FromJSVal, Object (..)
                                              , ToJSVal, MakeObject, (<##)

--- a/src/Miso/Subscription/Keyboard.hs
+++ b/src/Miso/Subscription/Keyboard.hs
@@ -20,7 +20,6 @@ module Miso.Subscription.Keyboard
   , wasdSub
   ) where
 -----------------------------------------------------------------------------
-import           Control.Monad
 import           Control.Monad.IO.Class
 import           Data.IORef
 import           Data.IntSet
@@ -28,6 +27,7 @@ import qualified Data.IntSet as S
 import           Language.Javascript.JSaddle hiding (new)
 -----------------------------------------------------------------------------
 import           Miso.Effect (Sub)
+import           Miso.Subscription.Util (createSub)
 import qualified Miso.FFI.Internal as FFI
 -----------------------------------------------------------------------------
 -- | type for arrow keys currently pressed
@@ -77,31 +77,38 @@ directionSub dirs = keyboardSub . (. toArrows dirs)
 -- | Returns @Subscription@ for keyboard.
 -- The callback will be called with the Set of currently pressed @keyCode@s.
 keyboardSub :: (IntSet -> action) -> Sub action
-keyboardSub f sink = do
-  keySetRef <- liftIO (newIORef mempty)
-  _ <- FFI.windowAddEventListener "keyup" $ keyUpCallback keySetRef
-  _ <- FFI.windowAddEventListener "keydown" $ keyDownCallback keySetRef
-  void $ FFI.windowAddEventListener "blur" $ blurCallback keySetRef
-    where
-      keyDownCallback keySetRef = \keyDownEvent -> do
-          key <- fromJSValUnchecked =<< getProp "keyCode" (Object keyDownEvent)
-          newKeys <- liftIO $ atomicModifyIORef' keySetRef $ \keys ->
-             let !new = S.insert key keys
-             in (new, new)
-          sink (f newKeys)
-
-      keyUpCallback keySetRef = \keyUpEvent -> do
-          key <- fromJSValUnchecked =<< getProp "keyCode" (Object keyUpEvent)
-          newKeys <- liftIO $ atomicModifyIORef' keySetRef $ \keys ->
-             let !new = S.delete key keys
-             in (new, new)
-          sink (f newKeys)
-
-      -- Assume keys are released the moment focus is lost. Otherwise going
-      -- back and forth to the app can cause keys to get stuck.
-      blurCallback keySetRef = \_ -> do
-          newKeys <- liftIO $ atomicModifyIORef' keySetRef $ \_ ->
-            let !new = S.empty
-            in (new, new)
-          sink (f newKeys)
+keyboardSub f sink = createSub acquire release sink
+  where
+    release (cb1, cb2, cb3) = do
+      FFI.windowRemoveEventListener "keyup" cb1
+      FFI.windowRemoveEventListener "keydown" cb2
+      FFI.windowRemoveEventListener "blur" cb3
+    acquire = do
+      keySetRef <- liftIO (newIORef mempty)
+      cb1 <- FFI.windowAddEventListener "keyup" (keyUpCallback keySetRef)
+      cb2 <- FFI.windowAddEventListener "keydown" (keyDownCallback keySetRef)
+      cb3 <- FFI.windowAddEventListener "blur" (blurCallback keySetRef)
+      pure (cb1, cb2, cb3)
+        where
+          keyDownCallback keySetRef = \keyDownEvent -> do
+              key <- fromJSValUnchecked =<< getProp "keyCode" (Object keyDownEvent)
+              newKeys <- liftIO $ atomicModifyIORef' keySetRef $ \keys ->
+                 let !new = S.insert key keys
+                 in (new, new)
+              sink (f newKeys)
+    
+          keyUpCallback keySetRef = \keyUpEvent -> do
+              key <- fromJSValUnchecked =<< getProp "keyCode" (Object keyUpEvent)
+              newKeys <- liftIO $ atomicModifyIORef' keySetRef $ \keys ->
+                 let !new = S.delete key keys
+                 in (new, new)
+              sink (f newKeys)
+    
+          -- Assume keys are released the moment focus is lost. Otherwise going
+          -- back and forth to the app can cause keys to get stuck.
+          blurCallback keySetRef = \_ -> do
+              newKeys <- liftIO $ atomicModifyIORef' keySetRef $ \_ ->
+                let !new = S.empty
+                in (new, new)
+              sink (f newKeys)
 -----------------------------------------------------------------------------

--- a/src/Miso/Subscription/SSE.hs
+++ b/src/Miso/Subscription/SSE.hs
@@ -10,39 +10,52 @@
 module Miso.Subscription.SSE
  ( -- *** Subscription
    sseSub
-   -- *** Types
- , SSE (..)
  ) where
 -----------------------------------------------------------------------------
 import           Data.Aeson
+import qualified Data.Aeson as A
 import qualified Language.Javascript.JSaddle as JSaddle
 import           Language.Javascript.JSaddle hiding (new)
 -----------------------------------------------------------------------------
 import           Miso.Effect (Sub)
 import qualified Miso.FFI.Internal as FFI
 import           Miso.String
+import           Miso.Subscription.Util
 -----------------------------------------------------------------------------
 -- | Server-sent events Subscription
 sseSub
   :: FromJSON msg
-  => MisoString -- ^ EventSource URL
-  -> (SSE msg -> action)
+  => MisoString
+  -- ^ EventSource URL
+  -> (msg -> action)
+  -- ^ Succesful callback
+  -> (MisoString -> action)
+  -- ^ JSON decode failure callback
+  -> (JSVal -> action)
+  -- ^ SSE error callback
+  -> (JSVal -> action)
+  -- ^ SSE close callback
   -> Sub action
-sseSub url f sink = do
-  es <- JSaddle.new (jsg (ms "EventSource")) [url]
-  _ <- FFI.addEventListener es (ms "message") $ \v -> do
-    dat <- FFI.jsonParse =<< v ! (ms "data")
-    sink (f (SSEMessage dat))
-  _ <- FFI.addEventListener es (ms "error") $ \_ ->
-    sink (f SSEError)
-  _ <- FFI.addEventListener es (ms "close") $ \_ ->
-    sink (f SSEClose)
-  pure ()
------------------------------------------------------------------------------
--- | Server-sent events data
-data SSE message
-  = SSEMessage message
-  | SSEClose
-  | SSEError
-  deriving (Show, Eq)
+sseSub url successful errorful errorCb closeCb sink = createSub acquire release sink
+  where
+    release (es, cb1, cb2, cb3) = do
+      FFI.removeEventListener es (ms "message") cb1
+      FFI.removeEventListener es (ms "error") cb2
+      FFI.removeEventListener es (ms "close") cb3
+    acquire = do
+      es <- JSaddle.new (jsg (ms "EventSource")) [url]
+      cb1 <- FFI.addEventListener es (ms "message") $ \v -> do
+        maybeValue <- fromJSVal =<< v ! (ms "data")
+        case maybeValue of
+          Nothing ->
+            sink $ errorful (ms "sseSub: Could not parse 'data' as JSON")
+          Just value ->
+            case fromJSON value of
+              A.Success o ->
+                sink (successful o)
+              A.Error e ->
+                sink (errorful (ms e))
+      cb2 <- FFI.addEventListener es (ms "error") (sink . errorCb)
+      cb3 <- FFI.addEventListener es (ms "close") (sink . closeCb)
+      pure (es, cb1, cb2, cb3)
 -----------------------------------------------------------------------------

--- a/src/Miso/Subscription/Util.hs
+++ b/src/Miso/Subscription/Util.hs
@@ -1,0 +1,33 @@
+-----------------------------------------------------------------------------
+{-# LANGUAGE OverloadedStrings #-}
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Miso.Subscription.Util
+-- Copyright   :  (C) 2016-2025 David M. Johnson
+-- License     :  BSD3-style (see the file LICENSE)
+-- Maintainer  :  David M. Johnson <code@dmj.io>
+-- Stability   :  experimental
+-- Portability :  non-portable
+----------------------------------------------------------------------------
+module Miso.Subscription.Util
+   ( -- ** Utilities
+     createSub
+   ) where
+----------------------------------------------------------------------------
+import           Control.Monad.IO.Class (liftIO)
+import           Control.Concurrent.MVar (newEmptyMVar, takeMVar)
+import           Language.Javascript.JSaddle (JSM, bracket)
+-----------------------------------------------------------------------------
+import           Miso.Effect
+-----------------------------------------------------------------------------
+-- | Utility function to allow resource finalization on 'Sub'.
+createSub
+  :: JSM a
+  -- ^ Acquire resource
+  -> (a -> JSM b)
+  -- ^ Release resource
+  -> Sub action
+createSub acquire release = \_ -> do
+  mvar <- liftIO newEmptyMVar
+  bracket acquire release (\_ -> liftIO (takeMVar mvar))
+----------------------------------------------------------------------------

--- a/src/Miso/Types.hs
+++ b/src/Miso/Types.hs
@@ -38,6 +38,8 @@ module Miso.Types
   , DOMRef
   , ROOT
   , Transition
+  -- ** Re-exports
+  , JSM
   -- ** Classes
   , ToView           (..)
   , ToKey            (..)


### PR DESCRIPTION
This factors out the resource finalization of `createSub` into a `Utils` module so other `Sub` can benefit from it.

- [x] Refactor `keyboardSub`, `sseSub` to use resource finalization from `createSub`
- [x] Re-export `JSM`