### PR TITLE
Add `CustomEvent` to `miso` FFI.

### DIFF
--- a/src/Miso/FFI.hs
+++ b/src/Miso/FFI.hs
@@ -8,10 +8,8 @@
 -- Portability :  non-portable
 ----------------------------------------------------------------------------
 module Miso.FFI
-  ( -- ** Functions
-    set
-  , now
-  , consoleLog
+  ( -- ** Logging
+    consoleLog
   , consoleLog'
   , consoleError
   , consoleWarn
@@ -20,20 +18,27 @@ module Miso.FFI
   , blur
   , alert
   , reload
+  -- ** Styles
   , addStyle
   , addStyleSheet
+  -- ** Events
+  , customEvent
   , addEventListener
+  -- ** Callbacks
   , syncCallback
   , syncCallback1
   , asyncCallback
   , asyncCallback1
   , asyncCallback2
+  -- ** Misc.
   , flush
   , setDrawingContext
   , jsonStringify
   , jsonParse
   , windowInnerWidth
   , windowInnerHeight
+  , set
+  , now
   -- ** Image
   , Image (..)
   , newImage

--- a/src/Miso/FFI/Internal.hs
+++ b/src/Miso/FFI/Internal.hs
@@ -65,6 +65,7 @@ module Miso.FFI.Internal
    -- * Events
    , delegateEvent
    , undelegateEvent
+   , customEvent
    -- * Isomorphic
    , hydrate
    -- * Misc.
@@ -688,6 +689,7 @@ click () domRef = void $ domRef # "click" $ ([] :: [MisoString])
 --
 -- <https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia>
 --
+-- @since 1.9.0.0
 getUserMedia
   :: Bool
   -- ^ video
@@ -728,4 +730,15 @@ copyClipboard txt successful errorful = do
   void $ promise # "then" $ [successfulCallback]
   errorfulCallback <- asyncCallback1 errorful
   void $ promise # "catch" $ [errorfulCallback]
+-----------------------------------------------------------------------------
+-- | Custom events <https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/CustomEvent>
+--
+-- Raise custom events in JS, on any element.
+--
+-- @since 1.9.0.0
+-----------------------------------------------------------------------------
+customEvent :: MisoString -> JSVal -> JSM ()
+customEvent eventName element = do
+  event <- new (jsg "CustomEvent") [eventName]
+  (element <# "dispatchEvent") [event]
 -----------------------------------------------------------------------------


### PR DESCRIPTION
- [x] Adds `customEvent` function
- [x] Refactors `uriSub` to have deterministc resource handling via `createSub`
- [x] Adds custom `miso-replaceState` and `miso-pushState` events.

We emit custom `History` API events, because `pushState` and `replaceState` don't invoke `popstate` events, we raise our own custom ones, and write to the `Component` sink to make the application aware changes to the URI have been made.