### PR TITLE
Add `mailParent`.

### DIFF
--- a/src/Miso.hs
+++ b/src/Miso.hs
@@ -33,6 +33,7 @@ module Miso
   , mail
   , checkMail
   , parent
+  , mailParent
   , broadcast
   -- ** Subscriptions
   , startSub


### PR DESCRIPTION
Runtime primitive for message passing any `ToJSON msg => msg` to a parent `Component`.