### PR TITLE
Use `WeakPtr` for `Socket` in `Miso.Runtime`.

### DIFF
--- a/src/Miso/Runtime.hs
+++ b/src/Miso/Runtime.hs
@@ -1075,13 +1075,13 @@ websocketConnect url onOpen onClosed onError onMessage = do
   ComponentInfo {..} <- ask
   withSink $ \sink -> do
     webSocketId <- freshWebSocket
+    let key = webSocketId
     socket <- FFI.websocketConnect url
-      (sink $ onOpen webSocketId)
+      (sink $ onOpen key)
       (sink . onClosed <=< fromJSValUnchecked)
       (sink . onMessage)
       (sink . onError)
     ctx <- askJSM
-    let key = webSocketId
     weakPtr <- liftIO $ mkWeak key socket $ pure $ do
       flip runJSM ctx $ do
         FFI.consoleLog "in finalizer..."

--- a/src/Miso/Runtime.hs
+++ b/src/Miso/Runtime.hs
@@ -1083,7 +1083,9 @@ websocketConnect url onOpen onClosed onError onMessage = do
     ctx <- askJSM
     let key = webSocketId
     weakPtr <- liftIO $ mkWeak key socket $ pure $ do
-      flip runJSM ctx (websocketClose_ _componentId key)
+      flip runJSM ctx $ do
+        FFI.consoleLog "in finalizer..."
+        websocketClose_ _componentId key
     insertWebSocket _componentId key weakPtr
   where
     insertWebSocket :: ComponentId -> WebSocket -> Socket -> JSM ()

--- a/src/Miso/WebSocket.hs
+++ b/src/Miso/WebSocket.hs
@@ -21,7 +21,7 @@ module Miso.WebSocket
   -- *** Defaults
   , emptyWebSocket
   -- *** Types
-  , WebSocket   (..)
+  , WebSocket
   , URL
   , SocketState (..)
   , CloseCode   (..)


### PR DESCRIPTION
This ensures that connections are purged from the connection `IntMap` in `Miso.Runtime` when the connection token goes out of scope in the user's application code.