### PR TITLE
`Miso.Style` -> `Miso.CSS`.

### DIFF
--- a/miso.cabal
+++ b/miso.cabal
@@ -164,9 +164,9 @@ library
     Miso.Svg.Event
     Miso.Storage
     Miso.String
-    Miso.Style
-    Miso.Style.Color
-    Miso.Style.Types
+    Miso.CSS
+    Miso.CSS.Color
+    Miso.CSS.Types
     Miso.Types
     Miso.Util
     Miso.Util.Lexer

--- a/src/Miso/CSS.hs
+++ b/src/Miso/CSS.hs
@@ -2,16 +2,16 @@
 {-# LANGUAGE OverloadedStrings #-}
 -----------------------------------------------------------------------------
 -- |
--- Module      :  Miso.Style
+-- Module      :  Miso.CSS
 -- Copyright   :  (C) 2016-2025 David M. Johnson
 -- License     :  BSD3-style (see the file LICENSE)
 -- Maintainer  :  David M. Johnson <code@dmj.io>
 -- Stability   :  experimental
 -- Portability :  non-portable
 -----------------------------------------------------------------------------
-module Miso.Style
+module Miso.CSS
   ( -- *** Types
-    module Miso.Style.Types
+    module Miso.CSS.Types
   -- *** Smart Constructor
   , style_
   , styleInline_
@@ -200,7 +200,7 @@ module Miso.Style
   , xHandleSize
   , zIndex
   -- *** Colors
-  , module Miso.Style.Color
+  , module Miso.CSS.Color
   -- *** Units
   , px
   , ppx
@@ -228,8 +228,8 @@ module Miso.Style
 import qualified Data.Map as M
 import           Miso.String (MisoString)
 import qualified Miso.String as MS
-import           Miso.Style.Color
-import           Miso.Style.Types
+import           Miso.CSS.Color
+import           Miso.CSS.Types
 import           Miso.Property
 import           Miso.Types (Attribute)
 import qualified Miso.Types as MT

--- a/src/Miso/CSS/Color.hs
+++ b/src/Miso/CSS/Color.hs
@@ -9,14 +9,14 @@
 {-# OPTIONS_GHC -fno-warn-orphans  #-}
 -----------------------------------------------------------------------------
 -- |
--- Module      :  Miso.Style.Color
+-- Module      :  Miso.CSS.Color
 -- Copyright   :  (C) 2016-2025 David M. Johnson
 -- License     :  BSD3-style (see the file LICENSE)
 -- Maintainer  :  David M. Johnson <code@dmj.io>
 -- Stability   :  experimental
 -- Portability :  non-portable
 -----------------------------------------------------------------------------
-module Miso.Style.Color
+module Miso.CSS.Color
   ( -- *** Types
     Color (RGB, RGBA, HSL, HSLA, Hex)
     -- *** Smart constructor

--- a/src/Miso/CSS/Types.hs
+++ b/src/Miso/CSS/Types.hs
@@ -1,13 +1,13 @@
 -----------------------------------------------------------------------------
 -- |
--- Module      :  Miso.Style.Types
+-- Module      :  Miso.CSS.Types
 -- Copyright   :  (C) 2016-2025 David M. Johnson (@dmjio)
 -- License     :  BSD3-style (see the file LICENSE)
 -- Maintainer  :  David M. Johnson <code@dmj.io>
 -- Stability   :  experimental
 -- Portability :  non-portable
 ----------------------------------------------------------------------------
-module Miso.Style.Types
+module Miso.CSS.Types
   ( -- *** Types
     Style
   , Styles (..)

--- a/src/Miso/Canvas.hs
+++ b/src/Miso/Canvas.hs
@@ -106,7 +106,7 @@ import           Language.Javascript.JSaddle ( JSVal, (#), fromJSVal, MakeArgs (
 import qualified Miso.FFI as FFI
 import           Miso.FFI (Image)
 import           Miso.Types
-import           Miso.Style (Color, renderColor)
+import           Miso.CSS (Color, renderColor)
 -----------------------------------------------------------------------------
 -- | Another variant of canvas, this is not specialized to 'ReaderT'. This is
 -- useful when building applications w/ three.js, or other libraries where

--- a/src/Miso/Runtime.hs
+++ b/src/Miso/Runtime.hs
@@ -96,7 +96,7 @@ import qualified Miso.FFI.Internal as FFI
 import           Miso.String hiding (reverse)
 import           Miso.Types
 import           Miso.Util
-import           Miso.Style (renderStyleSheet)
+import           Miso.CSS (renderStyleSheet)
 import           Miso.Event (Events)
 import           Miso.Property (textProp)
 import           Miso.Effect (ComponentInfo(..), Sub, Sink, Effect, runEffect, io_, withSink)

--- a/src/Miso/Types.hs
+++ b/src/Miso/Types.hs
@@ -93,7 +93,7 @@ import           Miso.Event.Types
 import           Miso.Lens (Getter, Setter, Lens(..), Lens')
 import qualified Miso.String as MS
 import           Miso.String (ToMisoString, MisoString, toMisoString, ms, fromMisoString)
-import           Miso.Style.Types (StyleSheet)
+import           Miso.CSS.Types (StyleSheet)
 -----------------------------------------------------------------------------
 -- | Application entry point
 data Component parent model action
@@ -150,7 +150,7 @@ data CSS
   | Style MisoString
   -- ^ 'Style' is meant to be raw CSS in a 'style_' tag
   | Sheet StyleSheet
-  -- ^ 'Sheet' is meant to be CSS built with 'Miso.Style'
+  -- ^ 'Sheet' is meant to be CSS built with 'Miso.CSS'
   deriving (Show, Eq)
 -----------------------------------------------------------------------------
 -- | Allow users to express JS and append it to <head> before the first draw


### PR DESCRIPTION
Be more idiomatic. Now that we use `.WebSocket`, `.Fetch`, `.EventSource`, best to stick to true naming conventions for styling.