### PR TITLE
Drop re-exports for `.Property` on `.Svg`, `.Html` and `.Mathml`

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ module Main where
 ----------------------------------------------------------------------------
 import           Miso
 import qualified Miso.Html as H
+import qualified Miso.Html.Property as P
 import           Miso.Lens
 ----------------------------------------------------------------------------
 -- | Component model state

--- a/sample-app/Main.hs
+++ b/sample-app/Main.hs
@@ -7,6 +7,7 @@ module Main where
 ----------------------------------------------------------------------------
 import           Miso
 import qualified Miso.Html as H
+import qualified Miso.Html.Property as P
 import           Miso.Lens
 ----------------------------------------------------------------------------
 -- | Component model state
@@ -55,7 +56,7 @@ updateModel = \case
 viewModel :: Model -> View Model Action
 viewModel x =
   H.div_
-    [ H.className "counter"
+    [ P.className "counter"
     ]
     [ H.button_ [ H.onClick AddOne ] [ text "+" ]
     , text $ ms (x ^. counter)

--- a/src/Miso/Html.hs
+++ b/src/Miso/Html.hs
@@ -41,13 +41,10 @@
 module Miso.Html
    ( -- ** Elements
      module Miso.Html.Element
-     -- ** Attributes
-   , module Miso.Html.Property
      -- ** Events
    , module Miso.Html.Event
    ) where
 -----------------------------------------------------------------------------
-import Miso.Html.Element hiding (data_, title_) -- conflicts with helpers from Miso.Html.Property
+import Miso.Html.Element
 import Miso.Html.Event
-import Miso.Html.Property
 -----------------------------------------------------------------------------

--- a/src/Miso/Html/Property.hs
+++ b/src/Miso/Html/Property.hs
@@ -114,6 +114,7 @@ module Miso.Html.Property
    , role_
    , xmlns_
    , aria_
+   , label_
    ) where
 -----------------------------------------------------------------------------
 import           Miso.Types
@@ -522,4 +523,8 @@ xmlns_ = textProp "xmlns"
 -- | @since 1.9.0.0
 aria_ :: MisoString -> MisoString -> Attribute action
 aria_ k = textProp ("aria-" <> k)
+-----------------------------------------------------------------------------
+-- | @since 1.9.0.0
+label_ :: MisoString -> Attribute action
+label_ = textProp "label"
 -----------------------------------------------------------------------------

--- a/src/Miso/Mathml.hs
+++ b/src/Miso/Mathml.hs
@@ -26,10 +26,7 @@
 module Miso.Mathml
    ( -- * Elements
      module Miso.Mathml.Element
-     -- * Properties
-   , module Miso.Mathml.Property
    ) where
 -----------------------------------------------------------------------------
 import Miso.Mathml.Element
-import Miso.Mathml.Property hiding (align_)
 -----------------------------------------------------------------------------

--- a/src/Miso/Svg.hs
+++ b/src/Miso/Svg.hs
@@ -27,13 +27,10 @@
 module Miso.Svg
    ( -- ** Element
      module Miso.Svg.Element
-     -- ** Property
-   , module Miso.Svg.Property
      -- ** Event
    , module Miso.Svg.Event
    ) where
 -----------------------------------------------------------------------------
-import Miso.Svg.Property hiding (filter_, path_, mask_, clipPath_, cursor_)
 import Miso.Svg.Element
 import Miso.Svg.Event
 -----------------------------------------------------------------------------


### PR DESCRIPTION
Due to conflicts between properties and elements, require explicit imports for `.Property` modules when working with `Html`, `Svg` and `Mathml`