### PR TITLE
Define `hex` in terms of `MisoString`.

### DIFF
--- a/src/Miso/CSS/Color.hs
+++ b/src/Miso/CSS/Color.hs
@@ -270,11 +270,11 @@ hsla = HSLA
 -----------------------------------------------------------------------------
 -- | Smart constructor for color in hexadecimal
 --
--- > div [ style_ [ backgroundColor (hex 0xAABBCC) ] ] [ ]
+-- > div [ style_ [ backgroundColor (hex #ccc) ] ] [ ]
 -- > -- "#aabbcc"
 --
-hex :: Int -> Color
-hex = Hex . ms . flip showHex ""
+hex :: MisoString -> Color
+hex = Hex
 -----------------------------------------------------------------------------
 transparent :: Color
 transparent = rgba 0 0 0 0


### PR DESCRIPTION
Current `hex` is broken, things like `hex 0x000ccc` won't work (0-padding is stripped). Further, we can't just prepend the 0's because hex rules are different when using 3-digit hex vs. 6-digit hex, and we can't assume the user's intention.

Therefore, we will define `hex` in terms of `MisoString` and recommend its use with `OverloadedLabels`, which is identical to CSS syntax.

```haskell
grey :: Color
grey = hex #ccc
```