### PR TITLE
Drop `tagsoup`.

### DIFF
--- a/miso.cabal
+++ b/miso.cabal
@@ -177,6 +177,5 @@ library
     containers    < 0.9,
     jsaddle       < 0.10,
     mtl           < 2.4,
-    tagsoup       < 0.15,
     text          < 2.2,
     stm >= 2.4 && < 2.6

--- a/src/Miso/Html/Element.hs
+++ b/src/Miso/Html/Element.hs
@@ -556,7 +556,7 @@ link_ = flip (nodeHtml "link") []
 --
 -- @'style_' [] "\</style\>"@
 style_ :: [Attribute action] -> MisoString -> View model action
-style_ attrs rawText = node HTML "style" attrs [textRaw rawText]
+style_ attrs rawText = node HTML "style" attrs [text rawText]
 -----------------------------------------------------------------------------
 -- | [\<script\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/script)
 --
@@ -570,7 +570,7 @@ style_ attrs rawText = node HTML "style" attrs [textRaw rawText]
 --
 -- @'script_' [] "\</script\>"@
 script_ :: [Attribute action] -> MisoString -> View model action
-script_ attrs rawText = node HTML "script" attrs [textRaw rawText]
+script_ attrs rawText = node HTML "script" attrs [text rawText]
 -----------------------------------------------------------------------------
 -- | [\<doctype\>](https://developer.mozilla.org/en-US/docs/Glossary/Doctype)
 doctype_ :: View model action

--- a/src/Miso/Html/Render.hs
+++ b/src/Miso/Html/Render.hs
@@ -58,8 +58,6 @@ intercalate sep (x:xs) =
 renderBuilder :: View m a -> Builder
 renderBuilder (VText "")    = fromMisoString " "
 renderBuilder (VText s)     = fromMisoString s
-renderBuilder (VTextRaw "") = fromMisoString " "
-renderBuilder (VTextRaw s)  = fromMisoString s
 renderBuilder (VNode _ "doctype" [] []) = "<!doctype html>"
 renderBuilder (VNode _ tag attrs children) =
   mconcat

--- a/src/Miso/String.hs
+++ b/src/Miso/String.hs
@@ -39,7 +39,6 @@ import qualified Data.Text.Lazy          as LT
 import qualified Data.Text.Lazy.Encoding as LT
 import           Language.Javascript.JSaddle (MakeArgs (..), toJSVal)
 import           Prelude                 hiding (foldr)
-import           Text.StringLike         (StringLike(..))
 ----------------------------------------------------------------------------
 -- | String type swappable based on compiler
 type MisoString = JS.JSString
@@ -168,15 +167,4 @@ parseInt   :: MisoString -> Either String Int
 parseInt s = case JS.uncons s of
                Just ('-',s') -> ((-1)*) . fromIntegral <$> parseWord s'
                _             ->           fromIntegral <$> parseWord s
-----------------------------------------------------------------------------
-instance StringLike MisoString where
-  uncons = JS.uncons
-  toString = JS.unpack
-  fromChar = JS.singleton
-  strConcat = JS.concat
-  empty = JS.empty
-  strNull = JS.null
-  cons = JS.cons
-  append = JS.append
-  strMap = JS.map
 ----------------------------------------------------------------------------

--- a/src/Miso/Types.hs
+++ b/src/Miso/Types.hs
@@ -64,8 +64,6 @@ module Miso.Types
   , node
   , text
   , text_
-  , textRaw
-  , rawHtml
   -- *** MisoString
   , MisoString
   , toMisoString
@@ -230,7 +228,6 @@ data LogLevel
 data View model action
   = VNode NS MisoString [Attribute action] [View model action]
   | VText MisoString
-  | VTextRaw MisoString
   | VComp NS MisoString [Attribute action] (SomeComponent model)
   deriving Functor
 -----------------------------------------------------------------------------
@@ -373,17 +370,6 @@ newtype VTree = VTree { getTree :: Object }
 instance ToJSVal VTree where
   toJSVal (VTree (Object vtree)) = pure vtree
 -----------------------------------------------------------------------------
--- | Create a new @Miso.Types.TextRaw@.
---
--- @expandable@
--- a 'rawHtml' node takes raw HTML and attempts to convert it to a 'VTree'
--- at runtime. This is a way to dynamically populate the virtual DOM from
--- HTML received at runtime. If rawHtml cannot parse the HTML it will not render.
-rawHtml
-  :: MisoString
-  -> View model action
-rawHtml = VTextRaw
------------------------------------------------------------------------------
 -- | Create a new @Miso.Types.VNode@.
 --
 -- @node ns tag key attrs children@ creates a new node with tag @tag@
@@ -403,10 +389,6 @@ text = VText
 -- | Create a new @Text@ with the given content.
 text_ :: [MisoString] -> View model action
 text_ = VText . MS.concat
------------------------------------------------------------------------------
--- | `TextRaw` creation. Don't use directly
-textRaw :: MisoString -> View model action
-textRaw = VTextRaw
 -----------------------------------------------------------------------------
 -- | Utility function to make it easy to specify conditional attributes
 --


### PR DESCRIPTION
Now that `miso-from-html` can parse HTML into miso view syntax, we can recommend that over handling the "raw" text node case.

This also allows us to drop another inefficient dependency.