### PR TITLE
Expose `Miso.FFI.Internal.fetch`.

### DIFF
--- a/src/Miso/FFI.hs
+++ b/src/Miso/FFI.hs
@@ -69,6 +69,8 @@ module Miso.FFI
   -- ** FileReader
   , FileReader (..)
   , newFileReader
+  -- ** Fetch API
+  , fetch
   ) where
 -----------------------------------------------------------------------------
 import           Miso.FFI.Internal

--- a/src/Miso/FFI/Internal.hs
+++ b/src/Miso/FFI/Internal.hs
@@ -574,6 +574,7 @@ fetch
   -> (MisoString -> JSM ())
   -- ^ errorful callback
   -> MisoString
+  -- ^ content type
   -> JSM ()
 fetch url method maybeBody headers successful errorful type_ = do
   successful_ <- toJSVal =<< asyncCallback1 successful


### PR DESCRIPTION
This exposes the internal `fetch` function for use in downstream integration libraries. Updates parameter content type.