### PR TITLE
Add `componentParentId`, `rootComponentId`.

### DIFF
--- a/src/Miso/Effect.hs
+++ b/src/Miso/Effect.hs
@@ -64,7 +64,9 @@ import           Miso.FFI.Internal (JSM)
 -----------------------------------------------------------------------------
 mkComponentInfo
   :: ComponentId
-  -- ^ Component ID
+  -- ^ Component Id
+  -> ComponentId
+  -- ^ Parent Component Id
   -> DOMRef
   -- ^ DOM Reference
   -> ComponentInfo parent
@@ -76,6 +78,7 @@ mkComponentInfo = ComponentInfo
 data ComponentInfo parent
   = ComponentInfo
   { _componentId :: ComponentId
+  , _componentParentId :: ComponentId
   , _componentDOMRef :: DOMRef
   }
 -----------------------------------------------------------------------------

--- a/src/Miso/Runtime.hs
+++ b/src/Miso/Runtime.hs
@@ -145,7 +145,7 @@ initialize Component {..} getView = do
       currentModel <- liftIO (readTVarIO componentModelCurrent)
       newModel <- liftIO (readTVarIO componentModelNew)
       let
-        info = ComponentInfo componentId componentDOMRef
+        info = ComponentInfo componentId componentParentId componentDOMRef
       as <- liftIO $ atomicModifyIORef' componentActions $ \actions -> (S.empty, actions)
       updatedModel <- foldEffects update Async info componentSink (toList as) newModel
       currentName <- liftIO $ currentModel `seq` makeStableName currentModel
@@ -181,14 +181,14 @@ initialize Component {..} getView = do
 
   componentParentToChildThreadId <-
     synchronizeParentToChild
-      componentDOMRef
+      componentParentId
       componentModelNew
       parentToChild
       serve
 
   componentChildToParentThreadId <-
     synchronizeChildToParent
-      componentDOMRef
+      componentParentId
       componentModelNew
       componentDiffs
       childToParent
@@ -204,32 +204,27 @@ initialize Component {..} getView = do
   pure vcomp
 -----------------------------------------------------------------------------
 synchronizeChildToParent
-  :: DOMRef
+  :: ComponentId
   -> TVar model
   -> Mailbox
   -> [ Binding parent model ]
   -> JSM (Maybe ThreadId)
 synchronizeChildToParent _ _ _ [] = pure Nothing
-synchronizeChildToParent componentDOMRef componentModelNew componentDiffs bindings = do
+synchronizeChildToParent parentId componentModelNew componentDiffs bindings = do
   -- Get parent's componentNotify, subscribe to it, on notification
   -- update the current Component model using the user-specified lenses
-  FFI.getParentComponentId componentDOMRef >>= \case
-    Nothing ->
-      -- dmj: impossible case, parent always mounted
+  IM.lookup parentId <$> liftIO (readIORef components) >>= \case
+    Nothing -> do
+      -- dmj: another impossible case, parent always mounted in children
       pure Nothing
-    Just parentId -> do
-      IM.lookup parentId <$> liftIO (readIORef components) >>= \case
-        Nothing -> do
-          -- dmj: another impossible case, parent always mounted in children
-          pure Nothing
-        Just parentComponentState -> do
-          bindProperty parentComponentState          
-          -- dmj: ^ parent assumes child state on initialization
-          fmap Just $ FFI.forkJSM $ do
-            forever $ do
-              _ <- liftIO (readMail =<< copyMailbox componentDiffs)
-              -- dmj: ^ listen on child this time
-              bindProperty parentComponentState
+    Just parentComponentState -> do
+      bindProperty parentComponentState          
+      -- dmj: ^ parent assumes child state on initialization
+      fmap Just $ FFI.forkJSM $ do
+        forever $ do
+          _ <- liftIO (readMail =<< copyMailbox componentDiffs)
+          -- dmj: ^ listen on child this time
+          bindProperty parentComponentState
   where
     bindProperty parentComponentState = do
       forM_ bindings (bindChildToParent parentComponentState componentModelNew)
@@ -258,30 +253,25 @@ bindChildToParent ComponentState {..} childRef = \case
       modifyTVar' componentModelNew newParent
 -----------------------------------------------------------------------------
 synchronizeParentToChild
-  :: DOMRef
+  :: ComponentId
   -> TVar model
   -> [ Binding type_ model ]
   -> IO ()
   -> JSM (Maybe ThreadId)
 synchronizeParentToChild _ _ [] _ = pure Nothing
-synchronizeParentToChild componentDOMRef componentModel_ bindings serve = do
+synchronizeParentToChild parentId componentModel_ bindings serve = do
   -- Get parent's componentNotify, subscribe to it, on notification
   -- update the current Component model using the user-specified lenses
-  FFI.getParentComponentId componentDOMRef >>= \case
-    Nothing ->
-      -- dmj: impossible case, parent always mounted
+  IM.lookup parentId <$> liftIO (readIORef components) >>= \case
+    Nothing -> do
+      -- dmj: another impossible case, parent always mounted
       pure Nothing
-    Just parentId -> do
-      IM.lookup parentId <$> liftIO (readIORef components) >>= \case
-        Nothing -> do
-          -- dmj: another impossible case, parent always mounted
-          pure Nothing
-        Just parentComponentState -> do
-          bindProperty parentComponentState
-          -- dmj: ^ assume parent state on initialization
-          fmap Just $ FFI.forkJSM $ forever $ do
-            Null <- liftIO $ readMail =<< copyMailbox (componentDiffs parentComponentState)
-            bindProperty parentComponentState
+    Just parentComponentState -> do
+      bindProperty parentComponentState
+      -- dmj: ^ assume parent state on initialization
+      fmap Just $ FFI.forkJSM $ forever $ do
+        Null <- liftIO $ readMail =<< copyMailbox (componentDiffs parentComponentState)
+        bindProperty parentComponentState
   where
     bindProperty parentComponentState = do
       forM_ bindings (bindParentToChild parentComponentState componentModel_)
@@ -677,7 +667,7 @@ drain
   -> JSM ()
 drain app@Component{..} cs@ComponentState {..} = do
   actions <- liftIO $ atomicModifyIORef' componentActions $ \actions -> (S.empty, actions)
-  let info = ComponentInfo componentId componentDOMRef
+  let info = ComponentInfo componentId componentParentId componentDOMRef
   if S.null actions then pure () else go info actions
   unloadScripts cs
       where
@@ -955,18 +945,15 @@ mailParent
   => message
   -> Effect parent model action
 mailParent message = do
-  domRef <- asks _componentDOMRef
+  vcompId <- asks _componentParentId
   io_ $ do
-    FFI.getParentComponentId domRef >>= \case
+    IM.lookup vcompId <$> liftIO (readIORef components) >>= \case
       Nothing ->
+        -- dmj: TODO add DebugMail here, if '0' then you're at the root
+        -- w/o a parent, so no message can be sent.
         pure ()
-      Just vcompId ->
-        IM.lookup vcompId <$> liftIO (readIORef components) >>= \case
-          Nothing ->
-            -- dmj: TODO add DebugMail here
-            pure ()
-          Just ComponentState {..} ->
-            liftIO $ sendMail componentMailbox (toJSON message)
+      Just ComponentState {..} ->
+        liftIO $ sendMail componentMailbox (toJSON message)
 ----------------------------------------------------------------------------
 -- | Helper function for processing 'Mail' from 'mail'.
 --
@@ -1002,15 +989,11 @@ parent
 parent successful errorful = do
   ComponentInfo {..} <- ask
   withSink $ \sink -> do
-    FFI.getParentComponentId _componentDOMRef >>= \case
-      Nothing ->
-        sink errorful
-      Just parentId -> do
-        IM.lookup parentId <$> liftIO (readIORef components) >>= \case
-          Nothing -> sink errorful
-          Just ComponentState {..} -> do
-            model <- liftIO (readTVarIO componentModelCurrent)
-            sink (successful model)
+    IM.lookup _componentParentId <$> liftIO (readIORef components) >>= \case
+      Nothing -> sink errorful
+      Just ComponentState {..} -> do
+        model <- liftIO (readTVarIO componentModelCurrent)
+        sink (successful model)
 -----------------------------------------------------------------------------
 -- | Sends a message to all @Component@ 'mailbox', excluding oneself.
 --


### PR DESCRIPTION
This is necessary for native development API calls.

- [x] Add `componentParentId` to `ComponentState`
- [x] Adds `rootComponentId`