### PR TITLE
Use strong types for `fetch` `Content-Type`

### DIFF
--- a/src/Miso/FFI/Internal.hs
+++ b/src/Miso/FFI/Internal.hs
@@ -86,6 +86,7 @@ module Miso.FFI.Internal
    , addScriptImportMap
    -- * XHR
    , fetch
+   , CONTENT_TYPE(..)
    , shouldSync
    -- * Drawing
    , requestAnimationFrame
@@ -586,7 +587,7 @@ fetch
   -- ^ successful callback
   -> (Response error -> JSM ())
   -- ^ errorful callback
-  -> MisoString
+  -> CONTENT_TYPE
   -- ^ content type
   -> JSM ()
 fetch url method maybeBody requestHeaders successful errorful type_ = do
@@ -610,6 +611,33 @@ fetch url method maybeBody requestHeaders successful errorful type_ = do
     , errorful_
     , typ
     ]
+-----------------------------------------------------------------------------
+data CONTENT_TYPE
+  = JSON
+  | ARRAY_BUFFER
+  | TEXT
+  | BLOB
+  | BYTES
+  | FORM_DATA
+  | NONE
+  deriving (Show, Eq)
+-----------------------------------------------------------------------------
+instance ToJSVal CONTENT_TYPE where
+  toJSVal = \case
+    JSON ->
+      toJSVal "json"
+    ARRAY_BUFFER ->
+      toJSVal "arrayBuffer"
+    TEXT ->
+      toJSVal "text"
+    BLOB ->
+      toJSVal "blob"
+    BYTES ->
+      toJSVal "bytes"
+    FORM_DATA ->
+      toJSVal "formData"
+    NONE ->
+      toJSVal "none"
 -----------------------------------------------------------------------------
 -- | shouldSync
 --

--- a/src/Miso/Fetch.hs
+++ b/src/Miso/Fetch.hs
@@ -69,7 +69,7 @@ import qualified Miso.FFI.Internal as FFI
 import           Miso.Effect (Effect, withSink)
 import           Miso.String (MisoString, ms)
 import           Miso.Util ((=:))
-import           Miso.FFI.Internal (Response(..), Blob, FormData, ArrayBuffer, Uint8Array, Image, fetch)
+import           Miso.FFI.Internal (Response(..), Blob, FormData, ArrayBuffer, Uint8Array, Image, fetch, CONTENT_TYPE(..))
 ----------------------------------------------------------------------------
 -- | See <https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API>
 --
@@ -105,7 +105,7 @@ getJSON url headers_ successful errorful =
     FFI.fetch url "GET" Nothing jsonHeaders
       (handleJSON sink)
       (sink . errorful)
-      "json" -- dmj: expected return type
+      JSON -- dmj: expected return type
   where
     jsonHeaders = biasHeaders headers_ [accept =: applicationJSON]
     handleJSON sink resp@Response {..} =
@@ -146,7 +146,7 @@ postJSON url body_ headers_ successful errorful =
     FFI.fetch url "POST" (Just bodyVal) jsonHeaders_
       (sink . successful)
       (sink . errorful)
-      "none"
+      NONE
   where
     jsonHeaders_ = biasHeaders headers_ [contentType =: applicationJSON]
 ----------------------------------------------------------------------------
@@ -169,7 +169,7 @@ putJSON url body_ headers_ successful errorful =
     FFI.fetch url "PUT" (Just bodyVal) jsonHeaders_
       (sink . successful)
       (sink . errorful)
-      "none"
+      NONE
   where
     jsonHeaders_ = biasHeaders headers_ [contentType =: applicationJSON]
 ----------------------------------------------------------------------------
@@ -189,7 +189,7 @@ getText url headers_ successful errorful =
     FFI.fetch url "GET" Nothing textHeaders_
       (sink . successful)
       (sink . errorful)
-      "text" -- dmj: expected return type
+      TEXT -- dmj: expected return type
   where
     textHeaders_ = biasHeaders headers_ [accept =: textPlain]
 ----------------------------------------------------------------------------
@@ -212,7 +212,7 @@ postText url body_ headers_ successful errorful =
     FFI.fetch url "POST" (Just bodyVal) textHeaders_
       (sink . successful)
       (sink . errorful)
-      "none"
+      NONE
   where
     textHeaders_ = biasHeaders headers_ [contentType =: textPlain]
 ----------------------------------------------------------------------------
@@ -235,7 +235,7 @@ putText url imageBody headers_ successful errorful =
     FFI.fetch url "PUT" (Just body_) textHeaders_
       (sink . successful)
       (sink . errorful)
-      "none"
+      NONE
   where
     textHeaders_ = biasHeaders headers_ [contentType =: textPlain]
 ----------------------------------------------------------------------------
@@ -255,7 +255,7 @@ getBlob url headers_ successful errorful =
     FFI.fetch url "GET" Nothing blobHeaders_
       (sink . successful)
       (sink . errorful)
-      "blob" -- dmj: expected return type
+      BLOB -- dmj: expected return type
   where
     blobHeaders_ = biasHeaders headers_ [accept =: octetStream]
 ----------------------------------------------------------------------------
@@ -278,7 +278,7 @@ postBlob url body_ headers_ successful errorful =
     FFI.fetch url "POST" (Just bodyVal) blobHeaders_
       (sink . successful)
       (sink . errorful)
-      "none"
+      NONE
   where
     blobHeaders_ = biasHeaders headers_ [contentType =: octetStream]
 ----------------------------------------------------------------------------
@@ -301,7 +301,7 @@ putBlob url imageBody headers_ successful errorful =
     FFI.fetch url "PUT" (Just body_) blobHeaders_
       (sink . successful)
       (sink . errorful)
-      "none"
+      NONE
   where
     blobHeaders_ = biasHeaders headers_ [contentType =: octetStream]
 ----------------------------------------------------------------------------
@@ -321,7 +321,7 @@ getFormData url headers_ successful errorful =
     FFI.fetch url "GET" Nothing formDataHeaders_
       (sink . successful)
       (sink . errorful)
-      "formData" -- dmj: expected return type
+      FORM_DATA -- dmj: expected return type
   where
     formDataHeaders_ = biasHeaders headers_ [accept =: formData]
 ----------------------------------------------------------------------------
@@ -344,7 +344,7 @@ postFormData url body_ headers_ successful errorful =
     FFI.fetch url "POST" (Just bodyVal) formDataHeaders_
       (sink . successful)
       (sink . errorful)
-      "none"
+      NONE
   where
     formDataHeaders_ = biasHeaders headers_ [contentType =: formData]
 ----------------------------------------------------------------------------
@@ -367,7 +367,7 @@ putFormData url imageBody headers_ successful errorful =
     FFI.fetch url "PUT" (Just body_) formDataHeaders_
       (sink . successful)
       (sink . errorful)
-      "none"
+      NONE
   where
     formDataHeaders_ = biasHeaders headers_ [contentType =: formData]
 ----------------------------------------------------------------------------
@@ -387,7 +387,7 @@ getArrayBuffer url headers_ successful errorful =
     FFI.fetch url "GET" Nothing arrayBufferHeaders_
       (sink . successful)
       (sink . errorful)
-      "arrayBuffer" -- dmj: expected return type
+      ARRAY_BUFFER -- dmj: expected return type
   where
     arrayBufferHeaders_ = biasHeaders headers_ [accept =: octetStream]
 ----------------------------------------------------------------------------
@@ -410,7 +410,7 @@ postArrayBuffer url body_ headers_ successful errorful =
     FFI.fetch url "POST" (Just bodyVal) arrayBufferHeaders_
       (sink . successful)
       (sink . errorful)
-      "none"
+      NONE
   where
     arrayBufferHeaders_ = biasHeaders headers_ [contentType =: octetStream]
 ----------------------------------------------------------------------------
@@ -433,7 +433,7 @@ putArrayBuffer url arrayBuffer_ headers_ successful errorful =
     FFI.fetch url "PUT" (Just body_) arrayBufferHeaders_
       (sink . successful)
       (sink . errorful)
-      "none"
+      NONE
   where
     arrayBufferHeaders_ = biasHeaders headers_ [contentType =: octetStream]
 ----------------------------------------------------------------------------
@@ -453,7 +453,7 @@ getUint8Array url headers_ successful errorful =
     FFI.fetch url "GET" Nothing uint8ArrayHeaders_
       (sink . successful)
       (sink . errorful)
-      "bytes" -- dmj: expected return type
+      BYTES -- expected return type
   where
     uint8ArrayHeaders_ = biasHeaders headers_ [accept =: octetStream]
 ----------------------------------------------------------------------------
@@ -476,7 +476,7 @@ postUint8Array url body_ headers_ successful errorful =
     FFI.fetch url "POST" (Just bodyVal) uint8ArrayHeaders_
       (sink . successful)
       (sink . errorful)
-      "none"
+      NONE
   where
     uint8ArrayHeaders_ = biasHeaders headers_ [contentType =: octetStream]
 ----------------------------------------------------------------------------
@@ -499,7 +499,7 @@ putUint8Array url uint8Array_ headers_ successful errorful =
     FFI.fetch url "PUT" (Just body_) uint8ArrayHeaders_
       (sink . successful)
       (sink . errorful)
-      "none"
+      NONE
   where
     uint8ArrayHeaders_ = biasHeaders headers_ [contentType =: octetStream]
 ----------------------------------------------------------------------------
@@ -522,7 +522,7 @@ postImage url body_ headers_ successful errorful =
     FFI.fetch url "POST" (Just bodyVal) headers_
       (sink . successful)
       (sink . errorful)
-      "none"
+      NONE
 ----------------------------------------------------------------------------
 putImage
   :: FromJSVal error
@@ -543,7 +543,7 @@ putImage url imageBody headers_ successful errorful =
     FFI.fetch url "PUT" (Just body_) headers_
       (sink . successful)
       (sink . errorful)
-      "none"
+      NONE
 ----------------------------------------------------------------------------
 type Body = JSVal
 ----------------------------------------------------------------------------

--- a/src/Miso/Fetch.hs
+++ b/src/Miso/Fetch.hs
@@ -57,6 +57,7 @@ module Miso.Fetch
     -- ** Types
   , Body
   , Response (..)
+  , CONTENT_TYPE (..)
     -- ** Internal
   , fetch
   ) where


### PR DESCRIPTION
Drops stringly-typed identifiers.

- [x] Adds `CONTENT_TYPE` in the Haskell layer