### PR TITLE
Add `ShadowRoot` support.

### DIFF
--- a/src/Miso/FFI/Internal.hs
+++ b/src/Miso/FFI/Internal.hs
@@ -135,8 +135,10 @@ module Miso.FFI.Internal
    -- * FileReader
    , FileReader (..)
    , newFileReader
-   -- * fetch API
+   -- * Fetch API
    , Response (..)
+   -- * Shadow
+   , attachShadow
    ) where
 -----------------------------------------------------------------------------
 import           Control.Monad (foldM)
@@ -725,6 +727,17 @@ nextSibling domRef = domRef ! "nextSibling"
 -- @since 1.9.0.0
 previousSibling :: JSVal -> JSM JSVal
 previousSibling domRef = domRef ! "previousSibling"
+-----------------------------------------------------------------------------
+-- | Calls 'node.attachShadow({ mode : \"open\" })'
+--
+-- <https://developer.mozilla.org/en-US/docs/Web/API/Element/attachShadow>
+--
+-- @since 1.9.0.0
+attachShadow :: JSVal -> JSM JSVal
+attachShadow domRef = do
+  args <- create
+  set (ms "mode") "open" args
+  (domRef # "attachShadow") [args]
 -----------------------------------------------------------------------------
 -- | When working with /<input>/ of type="file", this is useful for
 -- extracting out the selected files.

--- a/src/Miso/Runtime.hs
+++ b/src/Miso/Runtime.hs
@@ -70,6 +70,8 @@ module Miso.Runtime
   , json
   , blob
   , arrayBuffer
+  -- ** ShadowRoot
+  , getShadowRoot
   ) where
 -----------------------------------------------------------------------------
 import           Control.Concurrent.STM
@@ -654,7 +656,7 @@ drawComponent
   -> Sink action
   -> JSM ([DOMRef], DOMRef, IORef VTree)
 drawComponent hydrate mountElement Component {..} snk = do
-  refs <- (++) <$> renderScripts scripts <*> renderStyles styles
+  refs <- (++) <$> renderScripts mountElement scripts <*> renderStyles mountElement styles
   vtree <- runView hydrate (view model) snk logLevel events
   case hydrate of
     Draw ->
@@ -716,6 +718,12 @@ killSubscribers componentId =
   mapM_ (flip unsubscribe_ componentId) =<<
     M.keys <$> liftIO (readIORef mailboxes)
 -----------------------------------------------------------------------------
+-- | If shadowRoot is enabled
+getShadowRoot :: DOMRef -> Bool -> JSM DOMRef
+getShadowRoot domRef = \case
+  True -> pure domRef
+  False -> FFI.attachShadow domRef
+-----------------------------------------------------------------------------
 -- | Internal function for construction of a Virtual DOM.
 --
 -- Component mounting should be synchronous.
@@ -730,13 +738,14 @@ runView
   -> LogLevel
   -> Events
   -> JSM VTree
-runView hydrate (VComp ns tag attrs (SomeComponent app)) snk _ _ = do
+runView hydrate (VComp ns tag attrs (SomeComponent comp)) snk _ _ = do
   mountCallback <- do
     FFI.syncCallback2 $ \domRef continuation -> do
-      ComponentState {..} <- initialize app (drawComponent hydrate domRef app)
+      shadow <- getShadowRoot domRef (shadowRoot comp)
+      ComponentState {..} <- initialize comp (drawComponent hydrate shadow comp)
       vtree <- toJSVal =<< liftIO (readIORef componentVTree)
       vcompId <- toJSVal componentId
-      FFI.set "componentId" vcompId (Object domRef)
+      FFI.set "componentId" vcompId (Object shadow)
       void $ call continuation global [vcompId, vtree]
   unmountCallback <- toJSVal =<< do
     FFI.syncCallback1 $ \domRef -> do
@@ -744,9 +753,9 @@ runView hydrate (VComp ns tag attrs (SomeComponent app)) snk _ _ = do
       IM.lookup componentId <$> liftIO (readIORef components) >>= \case
         Nothing -> pure ()
         Just componentState ->
-          unmount mountCallback app componentState
+          unmount mountCallback comp componentState
   vcomp <- createNode "vcomp" ns tag
-  setAttrs vcomp attrs snk (logLevel app) (events app)
+  setAttrs vcomp attrs snk (logLevel comp) (events comp)
   flip (FFI.set "children") vcomp =<< toJSVal ([] :: [MisoString])
   flip (FFI.set "mount") vcomp =<< toJSVal mountCallback
   FFI.set "unmount" unmountCallback vcomp
@@ -825,8 +834,8 @@ registerComponent componentState = liftIO
 -- Meant for development purposes
 -- Appends CSS to <head>
 --
-renderStyles :: [CSS] -> JSM [DOMRef]
-renderStyles styles =
+renderStyles :: DOMRef -> [CSS] -> JSM [DOMRef]
+renderStyles _ styles =
   forM styles $ \case
     Href url -> FFI.addStyleSheet url
     Style css -> FFI.addStyle css
@@ -837,8 +846,8 @@ renderStyles styles =
 -- Meant for development purposes
 -- Appends JS to <head>
 --
-renderScripts :: [JS] -> JSM [DOMRef]
-renderScripts scripts =
+renderScripts :: DOMRef -> [JS] -> JSM [DOMRef]
+renderScripts _ scripts =
   forM scripts $ \case
     Src src ->
       FFI.addSrc src

--- a/src/Miso/Types.hs
+++ b/src/Miso/Types.hs
@@ -130,6 +130,13 @@ data Component parent model action
   --
   -- @since 1.9.0.0
   , bindings :: [ Binding parent model ]
+  -- ^ Use data binding between the parent model and Component model
+  --
+  -- @since 1.9.0.0
+  , shadowRoot :: Bool
+  -- ^ Use ShadowRoot for DOM encapsulation of events and styling
+  --
+  -- @since 1.9.0.0
   }
 -----------------------------------------------------------------------------
 -- | @mountPoint@ for @Component@, e.g "body"
@@ -192,6 +199,7 @@ component m u v = Component
   , initialAction = Nothing
   , mailbox = const Nothing
   , bindings = []
+  , shadowRoot = False
   }
 -----------------------------------------------------------------------------
 -- | A top-level 'Component' can have no 'parent'


### PR DESCRIPTION
For truly encapsulated styles (breaks the cascade in CSS), this PR introduces `shadowRoot :: Bool`.

This will allow users to nest Component without style inheritance

- [x] Add `shadowRoot`
- [x] Define and call `attachShadow` on `Component` mount element.
- [ ] Wire-up to styles
- [ ] Wire-up to scripts