### PR TITLE
Move calling unsafe hydrateModel to toView

### DIFF
--- a/miso.cabal
+++ b/miso.cabal
@@ -50,8 +50,7 @@ common jsaddle
       wai < 3.3,
       warp < 3.5,
       websockets < 0.14
-
-  if flag (jsaddle)
+  else
     cpp-options:
       -DJSADDLE
 
@@ -75,12 +74,6 @@ common client
     else
       js-sources:
         js/miso.js
-
-flag jsaddle
-  manual:
-    True
-  default:
-    True
 
 flag production
   manual:

--- a/src/Miso/Html/Render.hs
+++ b/src/Miso/Html/Render.hs
@@ -5,7 +5,6 @@
 {-# LANGUAGE OverloadedStrings     #-}
 {-# LANGUAGE RecordWildCards       #-}
 {-# LANGUAGE LambdaCase            #-}
-{-# LANGUAGE CPP                   #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Miso.Html.Render
@@ -20,10 +19,6 @@ module Miso.Html.Render
     ToHtml (..)
   ) where
 ----------------------------------------------------------------------------
-#ifndef JSADDLE
-import           System.IO.Unsafe (unsafePerformIO)
-import           Control.Exception (catch, SomeException)
-#endif
 import           Data.Aeson
 import           Data.ByteString.Builder
 import qualified Data.ByteString.Lazy as L
@@ -47,19 +42,8 @@ instance ToHtml [View m a] where
   toHtml = foldMap renderView
 ----------------------------------------------------------------------------
 -- | Render a @Component parent model action@ to a @L.ByteString@
-#ifndef JSADDLE
 instance ToHtml (Component parent model action) where
-  toHtml Component {..} = do
-    case hydrateModel of
-      Nothing ->
-        renderView (view model)
-      Just action -> unsafePerformIO $ do
-        m <- action `catch` (\(e :: SomeException) -> do
-          putStrLn "Encountered exception during model hydration, falling back to default model"
-          print e
-          pure model)
-        pure $ renderView (view m)
-#endif
+  toHtml Component {..} = renderView (view model)
 ----------------------------------------------------------------------------
 renderView :: View m a -> L.ByteString
 renderView = toLazyByteString . renderBuilder

--- a/src/Miso/Runtime.hs
+++ b/src/Miso/Runtime.hs
@@ -128,7 +128,12 @@ initialize hydrate Component {..} getView = do
   componentDiffs <- liftIO newMailbox
   initializedModel <-
     case (hydrate, hydrateModel) of
-      (Hydrate, Just action) -> action
+      (Hydrate, Just action) ->
+#ifdef JSADDLE
+          action
+#else
+          liftIO action
+#endif
       _ -> pure model
   (componentScripts, componentDOMRef, componentVTree) <- getView initializedModel componentSink
   componentDOMRef <# ("componentId" :: MisoString) $ componentId


### PR DESCRIPTION
- This fixes the behaviour of component rendering
- This is is motivated by an example usage seen in [my-miso-example@hydrate_with_bindings](https://github.com/Zer0-/my-miso-example/tree/44671ea70b45231d1b25f7270af2a43732bbe32b)