### PR TITLE
hydrateModel always in IO

### DIFF
--- a/src/Miso/Runtime.hs
+++ b/src/Miso/Runtime.hs
@@ -129,11 +129,7 @@ initialize hydrate Component {..} getView = do
   initializedModel <-
     case (hydrate, hydrateModel) of
       (Hydrate, Just action) ->
-#ifdef JSADDLE
-          action
-#else
           liftIO action
-#endif
       _ -> pure model
   (componentScripts, componentDOMRef, componentVTree) <- getView initializedModel componentSink
   componentDOMRef <# ("componentId" :: MisoString) $ componentId

--- a/src/Miso/Types.hs
+++ b/src/Miso/Types.hs
@@ -107,11 +107,7 @@ data Component parent model action
   = Component
   { model :: model
   -- ^ initial model
-#ifdef JSADDLE
-  , hydrateModel :: Maybe (JSM model)
-#else
   , hydrateModel :: Maybe (IO model)
-#endif
   -- ^ Perform action to load component state, such as reading data from page
   --   The resulting model is only used during initial hydration, not on remounts.
   , update :: action -> Effect parent model action


### PR DESCRIPTION
- There isn't a good reason to force the user to introduce CPP just to use this this functionality, it should be sufficient to have all implementations using IO