### PR TITLE
Make `Component` mounting asynchronous.

### DIFF
--- a/sample-app/app.cabal
+++ b/sample-app/app.cabal
@@ -4,7 +4,7 @@ version: 0.1.0.0
 synopsis: Sample miso app
 category: Web
 
-common wasm
+common options
   if arch(wasm32)
     ghc-options:
       -no-hs-main
@@ -13,9 +13,13 @@ common wasm
     cpp-options:
       -DWASM
 
+  if arch(javascript)
+     ld-options:
+       -sEXPORTED_RUNTIME_METHODS=HEAP8
+
 executable app
   import:
-    wasm
+    options
   main-is:
     Main.hs
   build-depends:

--- a/src/Miso/Runtime.hs
+++ b/src/Miso/Runtime.hs
@@ -729,7 +729,7 @@ runView
   -> JSM VTree
 runView hydrate (VComp ns tag attrs (SomeComponent app)) snk _ _ = do
   mountCallback <- do
-    FFI.syncCallback2 $ \domRef continuation -> do
+    FFI.asyncCallback2 $ \domRef continuation -> do
       ComponentState {..} <- initialize hydrate app (pure domRef)
       vtree <- toJSVal =<< liftIO (readIORef componentVTree)
       vcompId <- toJSVal componentId


### PR DESCRIPTION
This fixes a bug in JS-backend builds where `Component` mounting was happening eagerly and necesary parent `Component` state was not accessible to child `Component` for setting up `Binding` synchronization.

Async mounting is fine for now, it's more important that `unmount` is synchronous, since we need the determinism when removing `Component` from the global `components` `IntMap`. native also uses async `Component` mounting by default.

This was tested w/ `ghcjs86`, `ghcjs9122` and vanilla GHC.

The WASM build is async by default since it uses `jsaddle` (like vanilla GHC does), so there is no change in behavior there.

This fixes a bug in `miso-lynx` where `Binding` were not being initialized correctly.

- [x] `syncCallback` -> `asyncCallback` for `mount()`
- [x] Add `ld-options` to `sample-app` (`wasm` -> `options` renaming)