### PR TITLE
Add `component` and `+>` mount combinator to exports in Miso.hs

### DIFF
--- a/src/Miso.hs
+++ b/src/Miso.hs
@@ -26,10 +26,12 @@ module Miso
     -- ** Component
   , Component
   , startComponent
+  , component
+  , (+>)
     -- ** Sink
   , withSink
   , Sink
-    -- ** Component
+    -- ** Mail
   , mail
   , checkMail
   , parent


### PR DESCRIPTION
Additional top-level exports for `Component` (mounting and smart constructor).