### PR TITLE
Use static file `Middleware` w/ `cabal run`

### DIFF
--- a/src/Miso/Run.hs
+++ b/src/Miso/Run.hs
@@ -45,7 +45,14 @@ run = id
 #else
 run action = do
   port <- fromMaybe 8008 . (readMaybe =<<) <$> lookupEnv "PORT"
-  debugMiso port action  
+  isGhci <- (== "<interactive>") <$> getProgName
+  putStrLn $ "Running on port " <> show port <> "..."
+  if isGhci
+    then debugMiso port action
+    else
+      runSettings (setPort port (setTimeout 3600 defaultSettings)) =<<
+        jsaddleOr defaultConnectionOptions (action >> syncPoint)
+        (static J.jsaddleApp)
 -----------------------------------------------------------------------------
 -- | Start or restart the server, with a static Middleware policy.
 --


### PR DESCRIPTION
When using `cabal run` static file `Middleware` is currently not used. This PR makes both `cabal repl` and `cabal run` host static files from the current working directory.

```bash
dmjios-MacBook-Pro:miso-todomvc dmjio$ cabal repl
Configuration is affected by the following files:                                                                                                       - cabal.project
Build profile: -w ghc-9.12.2 -O1
In order, the following will be built (use -v for more details):
 - miso-todomvc-0.1 (interactive) (exe:app) (configuration changed)
Configuring executable 'app' for miso-todomvc-0.1...
Preprocessing executable 'app' for miso-todomvc-0.1...
GHCi, version 9.12.2: https://www.haskell.org/ghc/  :? for help
[1 of 2] Compiling Main             ( src/Main.hs, interpreted )
Ok, one module loaded.
ghci> main
Running on port 8008...
ghci> :! curl localhost:8008/cabal.project
packages:                                                                                                                                                 .

allow-newer:
  all:base

flags: +template-haskell

source-repository-package
  type: git
  location: https://github.com/dmjio/miso
  tag: 9e4806fc1b1736821122401a0bf47aae470f3033
```