### PR TITLE
Properly escape `HTML` on the server.

### DIFF
--- a/src/Miso/Html/Element.hs
+++ b/src/Miso/Html/Element.hs
@@ -575,7 +575,7 @@ style_ attrs rawText = node HTML "style" attrs [text rawText]
 --
 -- @'script_' [] "\</script\>"@
 script_ :: [Attribute action] -> MisoString -> View model action
-script_ attrs rawText = node HTML "script" attrs [text rawText]
+script_ attrs rawText = node HTML "script" attrs [textRaw rawText]
 -----------------------------------------------------------------------------
 -- | [\<doctype\>](https://developer.mozilla.org/en-US/docs/Glossary/Doctype)
 doctype_ :: View model action

--- a/src/Miso/Html/Render.hs
+++ b/src/Miso/Html/Render.hs
@@ -21,8 +21,6 @@
 module Miso.Html.Render
   ( -- *** Classes
     ToHtml (..)
-    -- Util
-  , htmlEncode
   ) where
 ----------------------------------------------------------------------------
 import           Data.Aeson
@@ -63,20 +61,6 @@ intercalate sep (x:xs) =
   , sep
   , intercalate sep xs
   ]
-----------------------------------------------------------------------------
--- |
--- HTML-encodes the given text.
---
--- >>> Data.Text.IO.putStrLn $ text "<a href=\"\">"
--- &lt;a href=&quot;&quot;&gt;
-htmlEncode :: MisoString -> MisoString
-htmlEncode = MS.concatMap $ \case
-  '<' -> "&lt;"
-  '>' -> "&gt;"
-  '&' -> "&amp;"
-  '"' -> "&quot;"
-  '\'' -> "&#39;"
-  x -> MS.singleton x
 ----------------------------------------------------------------------------
 renderBuilder :: Miso.Types.View m a -> Builder
 renderBuilder (VText "")    = fromMisoString " "


### PR DESCRIPTION
When serializing templates on the server using `text` we now automatically escape HTML (this is when the `jsaddle` flag is not in use).

The only exception is when serializing `script_` contents. For that we introduce the `textRaw` combinator which doesn't escape HTML.

- [x] Use `htmlEncode` in `text`, move to `Miso.Types`
- [x] Expose `textRaw` and use in `script_`
- [x] `CPP` around `text` w/ `htmlEncode`