### PR TITLE
Use `ssr` flag, drop `jsaddle` flag.

### DIFF
--- a/miso.cabal
+++ b/miso.cabal
@@ -43,9 +43,9 @@ common cpp
     cpp-options:
       -DPRODUCTION
 
-  if flag(jsaddle)
+  if flag(ssr)
     cpp-options:
-      -DJSADDLE
+      -DSSR
 
 common jsaddle
   if !(impl(ghcjs) || arch(javascript) || arch(wasm32))
@@ -86,14 +86,14 @@ flag production
     Uses miso's production quality JS (miso.prod.js).
     This is built from calling "bun build --production"
 
-flag jsaddle
+flag ssr
   manual:
     True
   default:
-    True
+    False
   description:
-    Used to indicate if jsaddle should be used. Defaults to true.
-    Disable when performing hydration / server rendering of Html using ToHtml.
+    Used to indicate if SSR (server-side rendering) is being used. Defaults to false.
+    Enable when performing hydration / server rendering of Html using ToHtml.
 
 flag template-haskell
   manual:

--- a/src/Miso/Html/Render.hs
+++ b/src/Miso/Html/Render.hs
@@ -28,7 +28,7 @@ import           Data.ByteString.Builder
 import qualified Data.ByteString.Lazy as L
 import qualified Data.Map.Strict as M
 import           Unsafe.Coerce (unsafeCoerce)
-#ifndef JSADDLE
+#ifdef SSR
 import Control.Exception (SomeException, catch)
 import System.IO.Unsafe (unsafePerformIO)
 #endif
@@ -84,10 +84,10 @@ renderBuilder (VNode _ tag attrs children) =
 renderBuilder (VComp ns tag attrs (SomeComponent vcomp)) =
   renderBuilder (VNode ns tag attrs vkids)
     where
-#ifdef JSADDLE
-      vkids = [ unsafeCoerce $ (view vcomp) (model vcomp) ]
-#else
+#ifdef SSR
       vkids = [ unsafeCoerce $ (view vcomp) $ getInitialComponentModel vcomp ]
+#else
+      vkids = [ unsafeCoerce $ (view vcomp) (model vcomp) ]
 #endif
 ----------------------------------------------------------------------------
 renderAttrs :: Attribute action -> Builder
@@ -136,7 +136,7 @@ toHtmlFromJSON Null         = "null"
 toHtmlFromJSON (Object o)   = fromMisoString $ ms (show o)
 toHtmlFromJSON (Array a)    = fromMisoString $ ms (show a)
 -----------------------------------------------------------------------------
-#ifndef JSADDLE
+#ifdef SSR
 -- | Used for server-side model hydration, internally only in 'renderView'.
 --
 -- We use 'unsafePerformIO' here because @servant@'s 'MimeRender' is a pure function

--- a/src/Miso/Runtime.hs
+++ b/src/Miso/Runtime.hs
@@ -127,10 +127,10 @@ initialize hydrate Component {..} getComponentMountPoint = do
   initializedModel <-
     case (hydrate, hydrateModel) of
       (Hydrate, Just action) ->
-#ifdef JSADDLE
-         action
-#else
+#ifdef SSR
          liftIO action
+#else
+         action
 #endif
       _ -> pure model
   componentScripts <- (++) <$> renderScripts scripts <*> renderStyles styles

--- a/src/Miso/Types.hs
+++ b/src/Miso/Types.hs
@@ -98,7 +98,7 @@ data Component parent model action
   = Component
   { model :: model
   -- ^ initial model
-#ifndef JSADDLE
+#ifdef SSR
   , hydrateModel :: Maybe (IO model)
 #else
   , hydrateModel :: Maybe (JSM model)
@@ -382,10 +382,10 @@ node = VNode
 -----------------------------------------------------------------------------
 -- | Create a new v'VText' with the given content.
 text :: MisoString -> View model action
-#ifdef JASDDLE
-text = VText
-#else
+#ifdef SSR
 text = VText . htmlEncode
+#else
+text = VText
 #endif
 ----------------------------------------------------------------------------
 -- | Create a new v'VText', not subject to HTML escaping.


### PR DESCRIPTION
When doing SSR (server-side rendering), users must now opt-in, instead of opt-out, to html escaping.

This should avoid unintuitive situations where `cabal.project` required `+jsaddle` to be enabled to exhibit the default behavior of /not/ escaping all `text` on the client. Despite the fact the flag was enabled by default in the cabal file, `cabal.project` overrode the default behavior, requiring users to explicitly enable it. Introducing `ssr` and requiring users to enable is more intuitive.

cc @ners @Zer0- 