### PR TITLE
Remove excessive calls to `unloadScripts`.

### DIFF
--- a/src/Miso/Runtime.hs
+++ b/src/Miso/Runtime.hs
@@ -686,7 +686,6 @@ drain app@Component{..} cs@ComponentState {..} = do
   actions <- liftIO $ atomicModifyIORef' componentActions $ \actions -> (S.empty, actions)
   let info = ComponentInfo componentId componentParentId componentDOMRef
   if S.null actions then pure () else go info actions
-  unloadScripts cs
       where
         go info actions = do
           x <- liftIO (readTVarIO componentModel)


### PR DESCRIPTION
This was being called multiple times during Component unmount. This led to a situation where `.removeChild(null)` was being invoked.

As described in https://github.com/dmjio/miso/issues/1208.

Fix is to remove redundant calls to `unloadScripts` and just rely on a single call in `unmount`.