### PR TITLE
Refactor lifecycle hooks to remove underscored variants

### DIFF
--- a/src/Miso/Event.hs
+++ b/src/Miso/Event.hs
@@ -42,7 +42,7 @@ import           Language.Javascript.JSaddle
 import           Miso.Event.Decoder
 import           Miso.Event.Types
 import qualified Miso.FFI.Internal as FFI
-import           Miso.Types (Attribute (Event), LogLevel(..), DOMRef, VTree(..), ComponentId)
+import           Miso.Types (Attribute (Event), LogLevel(..), DOMRef, VTree(..))
 import           Miso.String (MisoString, unpack)
 -----------------------------------------------------------------------------
 -- | Convenience wrapper for @onWithOptions defaultOptions@.


### PR DESCRIPTION
Removed unused event handlers `onMountedWith_`, `onCreatedWith_`, and `onUnmountedWith_`. Updated their counterparts to use `DOMRef` instead of `ComponentId`.

Now that `ComponentId` is available via `ask`, these variants can be removed in favor of passing along the `DOMRef`