### PR TITLE
Add `VFrag`, `group_` primitive.

### DIFF
--- a/src/Miso/Html/Render.hs
+++ b/src/Miso/Html/Render.hs
@@ -62,6 +62,7 @@ intercalate sep (x:xs) =
   ]
 ----------------------------------------------------------------------------
 renderBuilder :: Miso.Types.View m a -> Builder
+renderBuilder (VFrag vs)    = mconcat $ renderBuilder <$> vs
 renderBuilder (VText "")    = fromMisoString " "
 renderBuilder (VText s)     = fromMisoString s
 renderBuilder (VNode _ "doctype" [] []) = "<!doctype html>"

--- a/src/Miso/Types.hs
+++ b/src/Miso/Types.hs
@@ -75,6 +75,8 @@ module Miso.Types
   , toMisoString
   , fromMisoString
   , ms
+  -- *** Fragment
+  , group_
   ) where
 -----------------------------------------------------------------------------
 import           Data.Aeson (Value, ToJSON)
@@ -253,6 +255,7 @@ data View model action
   = VNode NS MisoString [Attribute action] [View model action]
   | VText MisoString
   | VComp NS MisoString [Attribute action] (SomeComponent model)
+  | VFrag [ View model action ]
   deriving Functor
 -----------------------------------------------------------------------------
 -- | Existential wrapper used to allow the nesting of t'Miso.Types.Component' in t'Miso.Types.Component'
@@ -500,4 +503,33 @@ prettyQueryString URI {..} = queries <> flags
         [ "?" <> k
         | (k, Nothing) <- M.toList uriQueryString
         ]
+-----------------------------------------------------------------------------
+-- | Smart constructor for working with t'View model action' fragments.
+--
+-- This is a primitive and convenience function for inlining children nodes
+-- into a t'View m a'. This is meant to avoid situations where it can be
+-- unwieldy to append child node lists together with '++'.
+--
+-- This should be used in the child list of a t'VNode', see below.
+--
+-- If 'group_' is as a top-level node in a t'Component' it will be
+-- wrapped with a `<div>`.
+--
+-- If 'group_' are nested they will be recursively flattened.
+--
+-- @
+--
+-- someView :: View m a
+-- someView =
+--   div_
+--   [ id_ "container" ]
+--   [ "text goes here"
+--   , group_ [ "test", p_ [] [ "foo" ], group_ [ "bar" ] ]
+--   , div_ [ key_ "component-id" ] +> someComponent
+--   ]
+--
+-- @
+--
+group_ :: [ View model action ] -> View model action
+group_ = VFrag
 -----------------------------------------------------------------------------


### PR DESCRIPTION
This is a primitive and convenience function for inlining children nodes into a `View m a`. This is meant to avoid situations where it can be unwieldy to append child node lists together with '++', as shown below.

```haskell
view m =
  div_
  [] $
  [ "foo"
  ] ++
  [ "bar"
  , view1
  ] ++
  [ "baz"
  | shouldInclude
  ]
```

When `group_` is used it inlines all of the nodes into the child lists.

```haskell
view m =
  div_
  []
  [ group_ [ "foo", "bar", "baz", group_ [ "baz" | shouldInclude ] ]
  ]
```

The `group_` has no DOM representation and is erased when `View m a` is converted into a JS `VTree<DOMRef>`, with a single exception.

If 'group_' is used a top-level node in a `Component` it will be wrapped with a `<div>`. This is a current limitation. So its wise to only use `group_` in DOM child lists to avoid an additional DOM node being appended.

Note: This is *not* a full implementation of [React Fragments](https://react.dev/reference/react/Fragment), hence why the combinator is called 'group_', and only operates at the level of the Haskell DSL.

React allows components to return child fragments into other components, while keeping each state separate in its own closure. This means a child node list could contain nodes from two different components, and event delegation would need to be adjusted accordingly to account for this. This is would be a somewhat significant change to accomplish in `miso`. It would entail adding event listeners to all top-level child nodes in the fragment.

Because we operate between two heaps (JS and Haskell), and component state lives in the Haskell heap, it is not as straightforward to implement Fragments in the same way as React (albeit not impossible).

Further work on React-style fragments is being done by [@ners](https://github.com/ners) in his [branch](https://github.com/ners/miso).

But this serves as a good base and first approximation for the feature and solves a major pain point during view templating.