### PR TITLE
Additional logic for self-closing tags

### DIFF
--- a/src/Miso/Html/Render.hs
+++ b/src/Miso/Html/Render.hs
@@ -34,7 +34,6 @@ import System.IO.Unsafe (unsafePerformIO)
 #endif
 ----------------------------------------------------------------------------
 import           Miso.String hiding (intercalate)
-import qualified Miso.String as MS
 import           Miso.Types
 ----------------------------------------------------------------------------
 -- | Class for rendering HTML
@@ -72,7 +71,7 @@ renderBuilder (VNode ns tag attrs children) = mconcat
   , mconcat [ " " <> intercalate " " (renderAttrs <$> attrs)
             | not (Prelude.null attrs)
             ]
-  , ">"
+  , if tag `elem` selfClosing then "/>" else ">"
   , mconcat
     [ mconcat
       [ foldMap renderBuilder (collapseSiblingTextNodes children)


### PR DESCRIPTION
Ensure self-closing tags use `/>` and not `>`, while the latter is allowed, former is more explicit, and makes it easier for the browser to parse. 

https://html.spec.whatwg.org/multipage/syntax.html#start-tags

> Then, if the element is one of the void elements, or if the element is a foreign element, then there may be a single "/" (U+002F) character. This character has no effect on void elements, but on foreign elements it marks the start tag as self-closing.