### PR TITLE
Set `parent` on `VTree` (1/3)

### DIFF
--- a/ts/miso/smart.ts
+++ b/ts/miso/smart.ts
@@ -9,6 +9,7 @@ export function vtext<T>(input: string) : VText<T> {
       type: 'vtext',
       domRef : null,
       key : null,
+      parent : null,
     };
 }
 
@@ -64,6 +65,7 @@ function mkVNode<T>() : VNode<T> {
     onBeforeCreated: () => {},
     type : 'vnode',
     nextSibling: null,
+    parent : null,
   };
 }
 

--- a/ts/miso/types.ts
+++ b/ts/miso/types.ts
@@ -18,6 +18,7 @@ export type VComp<T> = {
   props: Props;
   css: CSS;
   events: Events<T>;
+  parent: Parent;
   children: Array<VTree<T>>;
   onBeforeMounted: () => void;
   onMounted: (domRef: T) => void;
@@ -43,6 +44,7 @@ export type VNode<T> = {
   onCreated: () => void;
   onBeforeCreated: () => void;
   draw?: (T) => void;
+  parent: Parent;
   nextSibling: VNode<T>;
 };
 
@@ -52,7 +54,10 @@ export type VText<T> = {
   domRef: T;
   ns: NS;
   key: string;
+  parent: Parent;
 };
+
+export type Parent = VNode<T> | VComp<T>;
 
 export type NodeId = {
   nodeId: number;


### PR DESCRIPTION
This will be used in the `Component` PR which entails removing intermediate DOM nodes and refactoring event delegation.

This is PR 1/3, for removing the intermediate DOM node caused by `+>`

- [x] Adds `parent : VNode<T> | VComp<T>` to TypeScript types
- [x] Default smart constructors to `null` for `parent`
- [x] Set `parent` in `buildVTree` during construction.
- [x] Adds test to check that `.parent` is set and not `null` or `undefined`.