### PR TITLE
Expose event related functions.

### DIFF
--- a/src/Miso/FFI.hs
+++ b/src/Miso/FFI.hs
@@ -87,10 +87,13 @@ module Miso.FFI
   , Response (..)
     -- ** Event
   , addEventListener
+  , removeEventListener
   , dispatchEvent
   , newEvent
   , newCustomEvent
   , Event (..)
+  , eventPreventDefault
+  , eventStopPropagation
   ) where
 -----------------------------------------------------------------------------
 import           Miso.FFI.Internal

--- a/src/Miso/FFI/Internal.hs
+++ b/src/Miso/FFI/Internal.hs
@@ -238,7 +238,7 @@ addEventListener
   -- the event will be passed to it as a parameter.
   -> JSM Function
 addEventListener self name cb = do
-  cb_ <- asyncFunction handle
+  cb_ <- function handle
   void $ self # "addEventListener" $ (name, cb_)
   pure cb_
     where


### PR DESCRIPTION
- [x] Expose `removeEventListener`, `eventPreventDefault`, `eventStopPropagation`.
- [x] `asyncFunction` -> `function` for `addEventListener`.

This also uses `function` instead of `asyncFunction` for `addEventListener`. An issue arises in the JavaScript backend where async functions are not executed timely enough to `.preventDefault()` behavior. This issue does not occur w/ the WASM backend.

Note: miso event delegation uses `function`.