### PR TITLE
Remove use of global `IORef` for storing virtual DOM and global mount point

### DIFF
--- a/src/Miso.hs
+++ b/src/Miso.hs
@@ -89,8 +89,6 @@ module Miso
   ) where
 -----------------------------------------------------------------------------
 import           Control.Monad (void)
-import           Control.Monad.IO.Class (liftIO)
-import           Data.IORef (atomicWriteIORef)
 #ifndef GHCJS_BOTH
 #ifdef WASM
 import qualified Language.Javascript.JSaddle.Wasm.TH as JSaddle.Wasm.TH
@@ -132,7 +130,6 @@ miso :: Eq model => (URI -> App model action) -> JSM ()
 miso f = withJS $ do
   vcomp <- f <$> getURI
   body <- FFI.getBody
-  liftIO (atomicWriteIORef globalMountPoint body)
   initialize Hydrate isRoot vcomp (pure body)
 -----------------------------------------------------------------------------
 -- | Synonym for 'startComponent'.
@@ -183,7 +180,6 @@ initComponent
   -> JSM (ComponentState model action)
 initComponent vcomp@Component {..} = do
   mount <- mountElement (getMountPoint mountPoint)
-  liftIO (atomicWriteIORef globalMountPoint mount)
   initialize Draw isRoot vcomp (pure mount)
 ----------------------------------------------------------------------------
 isRoot :: Bool


### PR DESCRIPTION
A global `VTree` was introduced in #1254. This is used for global event delegation, but was incorrectly not being updated post-diffing. This caused drawing issues detected by @terrorjack in the [ghc-wasm-meta](https://github.com/haskell-wasm/ghc-wasm-meta) playwright integration tests.

This PR addresses the previous issue by removing the global references, instead choosing to conditionally start event delegation when the root `Component` is being rendered. This ensures the same `VTree` is used during event delegation and is updated post diffing.

Tested against `miso-todomvc`.

- [x] Add hardcoded top-level `ComponentId`.
- [x] In `initialize` conditionally append events when `isRoot` is `False`.
- [x] Invoke `delegator` when `isRoot` true.
- [x] Adds `componentEvents` used for appending in `addToDelegatedEvents`

Addresses https://github.com/dmjio/miso/issues/1258