### PR TITLE
Generalize `console.log`

### DIFF
--- a/src/Miso/FFI/Internal.hs
+++ b/src/Miso/FFI/Internal.hs
@@ -347,9 +347,10 @@ consoleError v = do
   pure ()
 -----------------------------------------------------------------------------
 -- | Console-logging of JSVal
-consoleLog' :: JSVal -> JSM ()
-consoleLog' v = do
-  _ <- jsg "console" # "log" $ [v]
+consoleLog' :: MakeArgs a => a -> JSM ()
+consoleLog' args' = do
+  args <- makeArgs args'
+  _ <- jsg "console" # "log" $ args
   pure ()
 -----------------------------------------------------------------------------
 -- | Encodes a Haskell object as a JSON string by way of a JavaScript object


### PR DESCRIPTION
Generalizes `consoleLog'` to any `MakeArgs`

```haskell
consoleLog' (1 :: Int, "foo" :: MisoString)
```