### PR TITLE
Change focus event default to Capture

### DIFF
--- a/src/Miso/Event/Types.hs
+++ b/src/Miso/Event/Types.hs
@@ -161,7 +161,7 @@ defaultEvents = M.fromList
   , ("click", False)
   , ("contextmenu", False)
   , ("dblclick", False)
-  , ("focus", False)
+  , ("focus", True)
   , ("input", False)
   , ("select", False)
   , ("submit", False)


### PR DESCRIPTION
`focus` doesn't bubble