### PR TITLE
Don't set `componentId` on `DOMRef`.

### DIFF
--- a/src/Miso/Runtime.hs
+++ b/src/Miso/Runtime.hs
@@ -172,7 +172,6 @@ initialize componentParentId hydrate isRoot Component {..} getComponentMountPoin
             liftIO (atomicWriteIORef ref newTree)
             Diff.diff Nothing (Just newTree) componentDOMRef
         pure ref
-  componentDOMRef <# ("componentId" :: MisoString) $ componentId
   componentSubThreads <- liftIO (newIORef M.empty)
   forM_ subs $ \sub -> do
     threadId <- FFI.forkJSM (sub componentSink)


### PR DESCRIPTION
`ComponentId` are now all managed in the Haskell layer. This is dead code.