### PR TITLE
Add `setValue`.

### DIFF
--- a/src/Miso/FFI.hs
+++ b/src/Miso/FFI.hs
@@ -63,6 +63,7 @@ module Miso.FFI
   , previousSibling
     -- ** Element
   , click
+  , setValue
     -- ** File Input
   , files
     -- ** Navigator

--- a/src/Miso/FFI/Internal.hs
+++ b/src/Miso/FFI/Internal.hs
@@ -56,6 +56,7 @@ module Miso.FFI.Internal
    , eventJSON
    -- * Object
    , set
+   , setValue
    -- * DOM
    , getBody
    , getDocument
@@ -167,6 +168,7 @@ import           Language.Javascript.JSaddle hiding (Success)
 import           Prelude hiding ((!!))
 -----------------------------------------------------------------------------
 import           Miso.String
+import           Miso.Effect (DOMRef)
 ----------------------------------------------------------------------------
 -- | Run given t'JSM' action asynchronously, in a separate thread.
 forkJSM :: JSM () -> JSM ThreadId
@@ -593,6 +595,17 @@ addScript useModule js_ = do
   when useModule $ (script <# "type") "module"
   (script <# "innerHTML") js_
   jsg "document" ! "head" # "appendChild" $ [script]
+-----------------------------------------------------------------------------
+-- | Sets the @.value@ property on a 'DOMRef'.
+--
+-- Useful for resetting the @value@ property on an input element.
+--
+-- @
+--   setValue domRef ("" :: MisoString)
+-- @
+--
+setValue :: DOMRef -> MisoString -> JSM ()
+setValue domRef = domRef <# "value"
 -----------------------------------------------------------------------------
 -- | Appends a 'Miso.Html.Element.script_' element containing a JS import map.
 --


### PR DESCRIPTION
Useful for resetting the `value` property on an input element from the `update` function.

Using `value_` and `onInput` together can cause race conditions, so this is a one way to avoid that.

```haskell
updateModel
  :: Msg
  -> Transition Model Msg
updateModel = \case
  Add domRef -> do
    model@Model{..} <- get
    put model
      { uid = uid + 1
      , field = mempty
      , entries = entries <> [newEntry field uid | not $ S.null field]
      }
    sync_ (domRef & setValue "")
```

Equivalent to

```js
domRef.value = '';
```