### PR TITLE
Add `oneshot` to `Miso.Concurrent`

### DIFF
--- a/src/Miso/Concurrent.hs
+++ b/src/Miso/Concurrent.hs
@@ -10,9 +10,11 @@
 -- Portability :  non-portable
 ----------------------------------------------------------------------------
 module Miso.Concurrent
-  ( -- * Synchronization primitives
+  ( -- ** Synchronization primitives
     Waiter (..)
   , waiter
+  , oneshot
+  -- ** Mailbox
   , Mailbox
   , Mail
   , newMailbox
@@ -36,6 +38,10 @@ data Waiter
   }
 -----------------------------------------------------------------------------
 -- | Creates a new @Waiter@
+--
+-- Useful for multiple threads to wake-up / notify a single thread running in an
+-- infinite loop, waiting for work (e.g. to process an event queue).
+--
 waiter :: IO Waiter
 waiter = do
   mvar <- newEmptyMVar
@@ -44,6 +50,19 @@ waiter = do
     , notify = do
         _ <- tryPutMVar mvar ()
         pure ()
+    }
+-----------------------------------------------------------------------------
+-- | Creates a new @Waiter@
+--
+-- Useful for a single thread to wake-up multiple threads that are waiting 
+-- to run a oneshot task (e.g. like forking a thread).
+--
+oneshot :: IO Waiter
+oneshot = do
+  mvar <- newEmptyMVar
+  pure Waiter
+    { wait = readMVar mvar
+    , notify = putMVar mvar ()
     }
 -----------------------------------------------------------------------------
 -- | Type for expressing @Mail@ (or message payloads) put into a 'Mailbox' for delivery


### PR DESCRIPTION
Useful for a single thread to wake-up multiple threads that are waiting to run a oneshot task (e.g. like forking a thread).