### PR TITLE
Reset `components` global state on hydration failure.

### DIFF
--- a/src/Miso/Runtime.hs
+++ b/src/Miso/Runtime.hs
@@ -170,7 +170,7 @@ initialize componentParentId hydrate isRoot Component {..} getComponentMountPoin
           when (not hydrated) $ do
             liftIO $ do
               atomicWriteIORef components IM.empty
-              atomicWriteIORef componentIds initialComponentId
+              atomicWriteIORef componentIds topLevelComponentId
               atomicWriteIORef subscribers mempty
               atomicWriteIORef mailboxes mempty
             newTree <- buildVTree componentParentId componentId Draw componentSink logLevel events (view initializedModel)
@@ -710,10 +710,7 @@ topLevelComponentId = 1
 --
 componentIds :: IORef Int
 {-# NOINLINE componentIds #-}
-componentIds = unsafePerformIO $ liftIO (newIORef initialComponentId)
------------------------------------------------------------------------------
-initialComponentId :: Int
-initialComponentId = 1
+componentIds = unsafePerformIO $ liftIO (newIORef topLevelComponentId)
 -----------------------------------------------------------------------------
 freshComponentId :: IO ComponentId
 freshComponentId = atomicModifyIORef' componentIds $ \y -> (y + 1, y)


### PR DESCRIPTION
When hydration fails, clear the global state, fallback to `diff`