### PR TITLE
Transfer `load`, `unload` to `HTML` namespace.

### DIFF
--- a/src/Miso/Html/Event.hs
+++ b/src/Miso/Html/Event.hs
@@ -84,6 +84,8 @@ module Miso.Html.Event
   , onEndedWith
   , onError
   , onErrorWith
+  , onLoad
+  , onUnload
   , onLoadedData
   , onLoadedDataWith
   , onLoadedMetadata
@@ -433,6 +435,14 @@ onError action = on "error" emptyDecoder $ \() _ -> action
 -- | https://www.w3schools.com/tags/av_event_error.asp
 onErrorWith :: (Media -> action) -> Attribute action
 onErrorWith action = on "error" emptyDecoder $ \() -> action . Media
+-----------------------------------------------------------------------------
+-- | https://www.w3schools.com/jsref/event_onload.asp
+onLoad :: action -> Attribute action
+onLoad action = on "load" emptyDecoder $ \() _ -> action
+-----------------------------------------------------------------------------
+-- | onUnload event
+onUnload :: action -> Attribute action
+onUnload action = on "unload" emptyDecoder $ \() _ -> action
 -----------------------------------------------------------------------------
 -- | https://www.w3schools.com/tags/av_event_loadeddata.asp
 onLoadedData :: action -> Attribute action

--- a/src/Miso/Svg/Event.hs
+++ b/src/Miso/Svg/Event.hs
@@ -23,8 +23,6 @@ module Miso.Svg.Event
   , onError
   , onResize
   , onScroll
-  , onLoad
-  , onUnload
   , onZoom
     -- *** Graphical
   , onActivate
@@ -69,14 +67,6 @@ onResize action = on "resize" emptyDecoder $ \() _ -> action
 -- | onScroll event
 onScroll :: action -> Attribute action
 onScroll action = on "scroll" emptyDecoder $ \() _ -> action
------------------------------------------------------------------------------
--- | onLoad event
-onLoad :: action -> Attribute action
-onLoad action = on "load" emptyDecoder $ \() _ -> action
------------------------------------------------------------------------------
--- | onUnload event
-onUnload :: action -> Attribute action
-onUnload action = on "unload" emptyDecoder $ \() _ -> action
 -----------------------------------------------------------------------------
 -- | onZoom event
 onZoom :: action -> Attribute action


### PR DESCRIPTION
It's more appropriate they live here given `script`, `body`, `img` all use it, and it will be automatically in scope via `import Miso.Html`.

- [x] Transfers `onLoad`, `onUnload` to the HTML module namespace.