### PR TITLE
Refactor `requestAnimationFrame`.

### DIFF
--- a/ffi/ghc/Miso/DSL/FFI.hs
+++ b/ffi/ghc/Miso/DSL/FFI.hs
@@ -98,8 +98,11 @@ isUndefined_ffi = undefined
 freeFunction_ffi :: JSVal -> IO ()
 freeFunction_ffi = undefined
 -----------------------------------------------------------------------------
-waitForAnimationFrame_ffi :: IO Double
-waitForAnimationFrame_ffi = undefined
+requestAnimationFrame :: JSVal -> IO Int
+requestAnimationFrame = undefined
+-----------------------------------------------------------------------------
+cancelAnimationFrame :: Int -> IO ()
+cancelAnimationFrame = undefined
 -----------------------------------------------------------------------------
 toJSVal_JSString :: Text -> IO JSVal
 toJSVal_JSString = undefined

--- a/ffi/js/Miso/DSL/FFI.hs
+++ b/ffi/js/Miso/DSL/FFI.hs
@@ -65,8 +65,9 @@ module Miso.DSL.FFI
   , isNull_ffi
   , jsNull
   , freeFunction_ffi
-  , waitForAnimationFrame_ffi
   , listProps_ffi
+  , requestAnimationFrame
+  , cancelAnimationFrame
   ) where
 -----------------------------------------------------------------------------
 import           Data.Aeson
@@ -74,7 +75,6 @@ import           Data.JSString
 import           Data.JSString.Text
 import           Data.Text
 import qualified GHCJS.Marshal as Marshal
-import           JavaScript.Web.AnimationFrame (waitForAnimationFrame)
 -----------------------------------------------------------------------------
 import           GHCJS.Types
 -----------------------------------------------------------------------------
@@ -177,8 +177,21 @@ isUndefined_ffi = isUndefined
 freeFunction_ffi :: JSVal -> IO ()
 freeFunction_ffi _ = pure ()
 -----------------------------------------------------------------------------
-waitForAnimationFrame_ffi :: IO Double
-waitForAnimationFrame_ffi = waitForAnimationFrame
+foreign import javascript unsafe
+#if GHCJS_NEW
+  "(($1) => { return requestAnimationFrame($1); })"
+#else
+  "$r = requestAnimationFrame($1);"
+#endif
+  requestAnimationFrame :: JSVal -> IO Int
+-----------------------------------------------------------------------------
+foreign import javascript unsafe
+#if GHCJS_NEW
+  "(($1) => { return cancelAnimationFrame($1); })"
+#else
+  "cancelAnimationFrame($1);"
+#endif
+  cancelAnimationFrame :: Int -> IO ()
 -----------------------------------------------------------------------------
 toJSVal_JSString :: JSString -> IO JSVal
 toJSVal_JSString = Marshal.toJSVal

--- a/ffi/wasm/Miso/DSL/FFI.hs
+++ b/ffi/wasm/Miso/DSL/FFI.hs
@@ -67,7 +67,8 @@ module Miso.DSL.FFI
   , isNull_ffi
   , jsNull
   , freeFunction_ffi
-  , waitForAnimationFrame_ffi
+  , requestAnimationFrame
+  , cancelAnimationFrame
   , listProps_ffi
   ) where
 -----------------------------------------------------------------------------
@@ -76,7 +77,6 @@ import qualified Data.Aeson.Key as K
 import qualified Data.Aeson.KeyMap as KM
 import           Data.Scientific
 import           Control.Monad.Trans.Maybe
-import           Control.Exception
 import           Control.Monad
 import           Data.Aeson
 import           Data.JSString (textFromJSString, textToJSString)
@@ -462,26 +462,15 @@ foreign import javascript unsafe "return $2[$1]"
 freeFunction_ffi :: JSVal -> IO ()
 freeFunction_ffi = freeJSVal
 -----------------------------------------------------------------------------
-waitForAnimationFrame_ffi :: IO Double
-waitForAnimationFrame_ffi = do
-  h <- makeHandle
-  waitForFrame h `onException` cancelFrame h
+foreign import javascript unsafe
+  """
+  return requestAnimationFrame($1);
+  """ requestAnimationFrame :: JSVal -> IO Int
 -----------------------------------------------------------------------------
 foreign import javascript unsafe
   """
-  return { handle: null, callback: null };
-  """ makeHandle :: IO JSVal
------------------------------------------------------------------------------
-foreign import javascript unsafe
-  """
-  "(($1,$2) => { return $1.handle = requestAnimationFrame($2); })"
-  """ waitForFrame :: JSVal -> IO Double
------------------------------------------------------------------------------
-foreign import javascript unsafe
-  """
-   if ($1.handle) cancelAnimationFrame($1.handle);
-   if ($1.callback) { $1.callback = null; }
-  """ cancelFrame :: JSVal -> IO ()
+  return cancelAnimationFrame($1);
+  """ cancelAnimationFrame :: Int -> IO ()
 -----------------------------------------------------------------------------
 foreign import javascript unsafe
   """

--- a/src/Miso/DSL.hs
+++ b/src/Miso/DSL.hs
@@ -45,7 +45,8 @@ module Miso.DSL
   , setProp
   , getProp
   , eval
-  , waitForAnimationFrame
+  , requestAnimationFrame
+  , cancelAnimationFrame
   , freeFunction
   , (!!)
   , isUndefined
@@ -405,10 +406,6 @@ instance (ToJSVal arg1, ToJSVal arg2, ToJSVal arg3, ToJSVal arg4, ToJSVal arg5, 
     rarg5 <- toJSVal arg5
     rarg6 <- toJSVal arg6
     return [rarg1, rarg2, rarg3, rarg4, rarg5, rarg6]
-----------------------------------------------------------------------------
--- | Retrieves the next animation frame
-waitForAnimationFrame :: IO Double
-waitForAnimationFrame = waitForAnimationFrame_ffi
 ----------------------------------------------------------------------------
 -- | Frees references to a callback
 freeFunction :: Function -> IO ()


### PR DESCRIPTION
- [x] Remove `waitForAnimationFrame`
- [x] Adds explicit `requestAnimationFrame` / `cancelAnimationFrame`

Uses `asyncCallback` to block on fetching the next animation frame. Also stores the timestamp inside an `MVar` for use post-callback, and the frame itself is avaialble for cancelation.