### PR TITLE
Use FFI for integral / floating `FromMisoString` instances.

### DIFF
--- a/ffi/ghc/Miso/DSL/FFI.hs
+++ b/ffi/ghc/Miso/DSL/FFI.hs
@@ -180,3 +180,15 @@ syncCallback2' = undefined
 syncCallback3' :: (JSVal -> JSVal -> JSVal -> IO JSVal) -> IO JSVal
 syncCallback3' = undefined
 -----------------------------------------------------------------------------
+parseInt :: Text -> Maybe Int
+parseInt = undefined
+-----------------------------------------------------------------------------
+parseDouble :: Text -> Maybe Double
+parseDouble = undefined
+-----------------------------------------------------------------------------
+parseWord :: Text -> Maybe Word
+parseWord = undefined
+-----------------------------------------------------------------------------
+parseFloat :: Text -> Maybe Float
+parseFloat = undefined
+-----------------------------------------------------------------------------

--- a/ffi/js/Miso/DSL/FFI.hs
+++ b/ffi/js/Miso/DSL/FFI.hs
@@ -68,6 +68,11 @@ module Miso.DSL.FFI
   , listProps_ffi
   , requestAnimationFrame
   , cancelAnimationFrame
+  -- *** String FFI
+  , parseInt
+  , parseDouble
+  , parseWord
+  , parseFloat
   ) where
 -----------------------------------------------------------------------------
 import           Data.Aeson
@@ -316,4 +321,38 @@ instance FromJSON JSString where
 -----------------------------------------------------------------------------
 instance ToJSON JSString where
   toJSON = String . textFromJSString
+-----------------------------------------------------------------------------
+foreign import javascript unsafe
+#if GHCJS_NEW
+  "(($1) => { return parseInt($1); })"
+#else
+  "$r = parseInt($1)"
+#endif
+  parseInt_Unchecked :: JSString -> Double
+-----------------------------------------------------------------------------
+parseWord :: JSString -> Maybe Word
+parseWord string = fromIntegral <$> parseInt string
+-----------------------------------------------------------------------------
+parseInt :: JSString -> Maybe Int
+parseInt string =
+  case parseInt_Unchecked string of
+    double | isNaN double -> Nothing
+           | otherwise -> Just (round double)
+-----------------------------------------------------------------------------
+foreign import javascript unsafe
+#if GHCJS_NEW
+  "(($1) => { return parseFloat($1); })"
+#else
+  "$r = parseFloat($1)"
+#endif
+  parseDouble_Unchecked :: JSString -> Double
+-----------------------------------------------------------------------------
+parseDouble :: JSString -> Maybe Double
+parseDouble string =
+  case parseDouble_Unchecked string of
+    double | isNaN double -> Nothing
+           | otherwise -> Just double
+-----------------------------------------------------------------------------
+parseFloat :: JSString -> Maybe Float
+parseFloat string = realToFrac <$> parseDouble string
 -----------------------------------------------------------------------------

--- a/ffi/wasm/Miso/DSL/FFI.hs
+++ b/ffi/wasm/Miso/DSL/FFI.hs
@@ -70,6 +70,11 @@ module Miso.DSL.FFI
   , requestAnimationFrame
   , cancelAnimationFrame
   , listProps_ffi
+  -- *** String FFI
+  , parseInt
+  , parseDouble
+  , parseWord
+  , parseFloat
   ) where
 -----------------------------------------------------------------------------
 import           Data.Text    (Text)
@@ -493,3 +498,34 @@ fromJSValUnchecked_Maybe jsval = do
   if isNullOrUndefined jsval
     then pure Nothing
     else pure (Just jsval)
+-----------------------------------------------------------------------------
+foreign import javascript unsafe
+  """
+  return parseInt($1);
+  """
+  parseInt_Unchecked :: JSString -> Double
+-----------------------------------------------------------------------------
+parseWord :: JSString -> Maybe Word
+parseWord string = fromIntegral <$> parseInt string
+-----------------------------------------------------------------------------
+parseInt :: JSString -> Maybe Int
+parseInt string = do
+  case parseInt_Unchecked string of
+    double | isNaN double -> Nothing
+           | otherwise -> Just (round double)
+-----------------------------------------------------------------------------
+foreign import javascript unsafe
+  """
+  return parseFloat($1);
+  """
+  parseDouble_Unchecked :: JSString -> Double
+-----------------------------------------------------------------------------
+parseDouble :: JSString -> Maybe Double
+parseDouble string = do
+  case parseDouble_Unchecked string of
+    double | isNaN double -> Nothing
+           | otherwise -> Just double
+-----------------------------------------------------------------------------
+parseFloat :: JSString -> Maybe Float
+parseFloat string = realToFrac <$> parseDouble string
+-----------------------------------------------------------------------------

--- a/src/Miso/String.hs
+++ b/src/Miso/String.hs
@@ -43,6 +43,8 @@ import qualified Data.Text.Encoding as T
 import qualified Data.Text.Lazy as LT
 import qualified Data.Text.Lazy.Encoding as LT
 ----------------------------------------------------------------------------
+import           Miso.DSL.FFI
+----------------------------------------------------------------------------
 -- | An efficient string type when building miso applications
 --
 -- t'MisoString' is t'Text' when prerendering
@@ -68,7 +70,7 @@ class FromMisoString t where
 fromMisoString :: FromMisoString a => MisoString -> a
 fromMisoString s =
   case fromMisoStringEither s of
-    Left err -> error err
+    Left error_ -> error ("fromMisoString: " <> error_)
     Right x  -> x
 ----------------------------------------------------------------------------
 -- | Convenience function, shorthand for `toMisoString`
@@ -158,4 +160,28 @@ instance FromMisoString BL.ByteString where
 ----------------------------------------------------------------------------
 instance FromMisoString B.Builder where
   fromMisoStringEither = fmap B.byteString . fromMisoStringEither
+----------------------------------------------------------------------------
+instance FromMisoString Word where
+  fromMisoStringEither string =
+    case parseWord string of
+      Nothing -> Left ("fromMisoString Word: could not parse " <> unpack string)
+      Just x -> Right x
+----------------------------------------------------------------------------
+instance FromMisoString Double where
+  fromMisoStringEither string =
+    case parseDouble string of
+      Nothing -> Left ("fromMisoString Double: could not parse " <> unpack string)
+      Just x -> Right x
+----------------------------------------------------------------------------
+instance FromMisoString Int where
+  fromMisoStringEither string =
+    case parseInt string of
+      Nothing -> Left ("fromMisoString Int: could not parse " <> unpack string)
+      Just x -> Right x
+----------------------------------------------------------------------------
+instance FromMisoString Float where
+  fromMisoStringEither string =
+    case parseFloat string of
+      Nothing -> Left ("fromMisoString Float: could not parse " <> unpack string)
+      Just x -> Right x
 ----------------------------------------------------------------------------

--- a/tests/miso-tests.cabal
+++ b/tests/miso-tests.cabal
@@ -14,6 +14,10 @@ build-type:         Simple
 extra-doc-files:    CHANGELOG.md
 extra-source-files:
 
+flag interactive
+  default: False
+  manual: True
+
 common warnings
   ghc-options: -Wall
 
@@ -23,6 +27,10 @@ common options
       -no-hs-main -optl-mexec-model=reactor "-optl-Wl,--export=hs_start"
     cpp-options:
       -DWASM
+
+  if flag (interactive)
+    cpp-options:
+      -DINTERACTIVE
 
   if arch(javascript)
      ld-options:

--- a/tests/src/Miso/Test.hs
+++ b/tests/src/Miso/Test.hs
@@ -35,6 +35,7 @@ module Miso.Test
   , beforeEach
   , afterEach
   , shouldBe
+  , shouldSatisfy
   , shouldNotBe
   , runTests
   -- * Utils
@@ -194,6 +195,38 @@ expect f x y = do
           [ "Expecting: "
           , yellow
           , ms (show y)
+          , "\n"
+          , reset
+          , "      "
+          , cyan <> "↳ " <> reset <> "Received:  "
+          , red
+          , ms (show x)
+          , " \n"
+          , reset
+          ]
+-----------------------------------------------------------------------------
+-- | Primitive for performing expectations in an 'it' block.
+shouldSatisfy
+  :: (Eq a, Show a)
+  => a
+  -> (a -> Bool)
+  -> Test ()
+shouldSatisfy x f = do
+  let succeeded = f x
+  name <- use currentTestName
+  start <- use currentTestTime
+  groupName <- use currentTestGroup
+  expects += 1
+  currentTestResult %= (&& succeeded)
+  when (not succeeded) $ liftIO $ do
+    stop <- now
+    prettyTest (CurrentTest groupName name succeeded expectationMessage (stop - start))
+      where
+        expectationMessage = mconcat
+          [ "Expecting: "
+          , yellow
+          , ms (show x)
+          , " to satisfy predicate"
           , "\n"
           , reset
           , "      "


### PR DESCRIPTION
- [x] Reinstates `Word`, `Int`, `Double`, `Float` instances using FFI
- [x] Adds `shouldSatisfy` to test API
- [x] Adds tests for conversion success and failure