### PR TITLE
Add `ghciwatch` to WASM `flake.nix` `devShell`.

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -105,6 +105,7 @@
                  http-server
                  cabal-install
                  tailwindcss_4
+                 ghciwatch
                ];
               shellHook = ''
                 function build () {
@@ -119,6 +120,9 @@
                 function repl () {
                    wasm32-wasi-cabal repl $1 -finteractive \
                      --repl-options='-fghci-browser -fghci-browser-port=8080'
+                }
+                function repl-watch () {
+                   ghciwatch --after-reload-ghci :main --watch . --debounce 50ms --command 'wasm32-wasi-cabal repl app -finteractive --repl-options="-fghci-browser -fghci-browser-port=8080"'
                 }
               '';
             };

--- a/sample-app/Makefile
+++ b/sample-app/Makefile
@@ -19,6 +19,9 @@ optim:
 	wasm-opt -all -O2 public/app.wasm -o public/app.wasm
 	wasm-tools strip -o public/app.wasm public/app.wasm
 
+watch:
+	ghciwatch --after-reload-ghci :main --watch . --debounce 50ms --command 'wasm32-wasi-cabal repl app -finteractive --repl-options="-fghci-browser -fghci-browser-port=8080"'
+
 serve:
 	http-server public
 


### PR DESCRIPTION
- [x] Adds `Makefile` target for WASM browser mode integration w/ `ghciwatch` (`make watch`)
- [x] Adds `repl watch` bash function in `flake.nix` WASM `devShell.`

cc @georgefst 