### PR TITLE
Use `toMisoString` for `ToJSVal String`.

### DIFF
--- a/src/Miso/DSL.hs
+++ b/src/Miso/DSL.hs
@@ -178,7 +178,7 @@ instance FromJSVal a => FromJSVal [a] where
       Nothing -> pure Nothing
       Just xs -> sequence <$> mapM fromJSVal xs
 -----------------------------------------------------------------------------
-instance ToJSVal a => ToJSVal [a] where
+instance {-# OVERLAPPABLE #-} ToJSVal a => ToJSVal [a] where
   toJSVal = toJSVal_List <=< mapM toJSVal
 -----------------------------------------------------------------------------
 instance ToJSVal String where


### PR DESCRIPTION
This should overlap `ToJSVal a => ToJSVal [a]`