### PR TITLE
Use `syncCallback` for JS backend, `asyncCallback` for WASM backend w/ `addEventListener`

### DIFF
--- a/src/Miso/FFI/Internal.hs
+++ b/src/Miso/FFI/Internal.hs
@@ -192,7 +192,11 @@ addEventListener
   -- the event will be passed to it as a parameter.
   -> IO Function
 addEventListener self name cb = do
+#ifdef GHCJS_BOTH
+  cb_ <- Function <$> syncCallback1 cb
+#else
   cb_ <- Function <$> asyncCallback1 cb
+#endif
   void $ self # "addEventListener" $ (name, cb_)
   pure cb_
 -----------------------------------------------------------------------------


### PR DESCRIPTION
The semantics of callbacks are different per backend.

- [x] Uses `syncCallback1` for JS backend w/ `addEventListener`
- [x] Uses `asyncCallback1` for WASM backend w/ `addEventListener`

More investigation is needed.