### PR TITLE
Add `OVERLAPPABLE` pragma to `To` / `FromJSVal [Char]` instances.

### DIFF
--- a/src/Miso/DSL.hs
+++ b/src/Miso/DSL.hs
@@ -172,13 +172,19 @@ instance ToJSVal a => ToJSVal (Maybe a) where
     Nothing -> pure jsNull
     Just x -> toJSVal x
 -----------------------------------------------------------------------------
-instance FromJSVal a => FromJSVal [a] where
+instance {-# OVERLAPPABLE #-} FromJSVal a => FromJSVal [a] where
   fromJSVal jsval_ = do
     fromJSVal_List jsval_ >>= \case
       Nothing -> pure Nothing
       Just xs -> sequence <$> mapM fromJSVal xs
 -----------------------------------------------------------------------------
-instance ToJSVal a => ToJSVal [a] where
+instance FromJSVal [Char] where
+  fromJSVal jsval_ = fmap unpack <$> fromJSVal jsval_
+-----------------------------------------------------------------------------
+instance ToJSVal [Char] where
+  toJSVal = toJSVal . toMisoString
+-----------------------------------------------------------------------------
+instance {-# OVERLAPPABLE #-} ToJSVal a => ToJSVal [a] where
   toJSVal = toJSVal_List <=< mapM toJSVal
 -----------------------------------------------------------------------------
 instance ToJSVal JSVal where

--- a/tests/app/Main.hs
+++ b/tests/app/Main.hs
@@ -732,7 +732,7 @@ main = withJS $ do
       it "Should marshal a (Bool,Double)" $ do
         (`shouldBe` Just (True,pi)) =<< liftIO (fromJSVal =<< toJSVal (True,pi))
       it "Should marshal a [Double]" $ do
-        (`shouldBe` Just [pi,pi]) =<< liftIO (fromJSVal =<< toJSVal [pi,pi])
+        (`shouldBe` Just [pi,pi :: Double]) =<< liftIO (fromJSVal =<< toJSVal [pi,pi :: Double])
         (`shouldBe` Just ([] :: [Bool])) =<< liftIO (fromJSVal =<< toJSVal ([] :: [Bool]))
       it "Should marshal a Char" $ do
         (`shouldBe` Just ('o' :: Char)) =<< liftIO (fromJSVal =<< toJSVal ('o' :: Char))


### PR DESCRIPTION
This is required to preserve `FromJSVal String` semantics.

- [x] Adds `OVERLAPPABLE` to `ToJSVal` / `FromJSVal` list instances