### PR TITLE
Add custom `Miso.Prelude`.

### DIFF
--- a/miso.cabal
+++ b/miso.cabal
@@ -133,6 +133,7 @@ library
     Miso.Mathml.Property
     Miso.Media
     Miso.Navigator
+    Miso.Prelude
     Miso.Property
     Miso.PubSub
     Miso.Router

--- a/sample-app/Main.hs
+++ b/sample-app/Main.hs
@@ -5,7 +5,6 @@
 ----------------------------------------------------------------------------
 module Main where
 ----------------------------------------------------------------------------
-import           Miso
 import           Miso.Run
 import qualified Miso.Html as H
 import qualified Miso.Html.Property as P

--- a/sample-app/app.cabal
+++ b/sample-app/app.cabal
@@ -36,5 +36,9 @@ executable app
     Main.hs
   build-depends:
     base, miso
+  mixins:
+    miso,
+    miso (Miso.Prelude as Prelude),
+    base hiding (Prelude)
   default-language:
     Haskell2010

--- a/src/Miso/Prelude.hs
+++ b/src/Miso/Prelude.hs
@@ -1,0 +1,47 @@
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Miso.Prelude
+-- Copyright   :  (C) 2016-2025 David M. Johnson
+-- License     :  BSD3-style (see the file LICENSE)
+-- Maintainer  :  David M. Johnson <code@dmj.io>
+-- Stability   :  experimental
+-- Portability :  non-portable
+--
+-- A custom Prelude for [miso](https://github.com/dmjio/miso).
+--
+-- Can consume via @NoImplicitPrelude@ or using Cabal mixins.
+--
+-- @
+-- import Miso.Prelude
+-- @
+--
+-- Almost identical to the existing @Prelude@, except we re-export the
+-- @Miso@ module, along with @Control.Category@.
+--
+-- @
+-- executable app
+--   import:
+--     options
+--   main-is:
+--     Main.hs
+--   build-depends:
+--     base, miso
+--   mixins:
+--     miso,
+--     miso (Miso.Prelude as Prelude),
+--     base hiding (Prelude)
+--   default-language:
+--     Haskell2010
+-- @
+--
+----------------------------------------------------------------------------
+module Miso.Prelude
+  ( module Miso
+  , module Prelude
+  , (.)
+  ) where
+----------------------------------------------------------------------------
+import Control.Category ((.))
+import Prelude hiding ((.), (!!))
+import Miso
+----------------------------------------------------------------------------


### PR DESCRIPTION
This remaps `(.)` to `Control.Category.((.))` for use with `Miso.Lens`.

- [x] Adds `Miso.Prelude` module
- [x] Re-exports `Miso`, `Control.Category.(.)`, hides `Prelude.(.)`

Able to be used as follows:

```haskell
executable app
  import:
    options
  main-is:
    Main.hs
  build-depends:
    base, miso
  mixins:
    miso,
    miso (Miso.Prelude as Prelude),
    base hiding (Prelude)
  default-language:
    Haskell2010
```

Specifying `miso` twice, once with the remapping is required for some reason.