### PR TITLE
Add `MonadFail Parser` to `Miso.JSON`.

### DIFF
--- a/src/Miso/JSON.hs
+++ b/src/Miso/JSON.hs
@@ -86,6 +86,9 @@ import qualified GHCJS.Marshal as Marshal
 #endif
 ----------------------------------------------------------------------------
 import           Control.Applicative
+#ifndef GHCJS_OLD
+import           Control.Monad.Fail
+#endif
 import           Control.Monad
 import           Data.Char
 import qualified Data.Map.Strict as M


### PR DESCRIPTION
Per https://github.com/dmjio/miso/issues/1359.

- [x] Add `MonadFail` instance for GHC >8.6 to `Miso.JSON`