### PR TITLE
Address differences in callback semantics across backends for event delegation

### DIFF
--- a/src/Miso/FFI/Internal.hs
+++ b/src/Miso/FFI/Internal.hs
@@ -460,7 +460,11 @@ diff (Object a) (Object b) c = do
 delegateEvent :: JSVal -> JSVal -> Bool -> IO JSVal -> IO ()
 delegateEvent mountPoint events debug getVTree = do
   ctx <- getEventContext
+#ifdef WASM
   cb <- asyncCallback1 $ \continuation -> void (call continuation global =<< getVTree)
+#else
+  cb <- syncCallback1 $ \continuation -> void (call continuation global =<< getVTree)
+#endif
   delegate mountPoint events debug (Function cb) ctx
 -----------------------------------------------------------------------------
 -- | Call 'delegateEvent' JavaScript function


### PR DESCRIPTION
To normalize over the differences we can allow `syncCallback` in JS and `asyncCallback` w/ WASM via CPP for handling event delegation as done in #1338. As described by @Reijix.