### PR TITLE
Fix hydration fallback.

### DIFF
--- a/src/Miso/Runtime.hs
+++ b/src/Miso/Runtime.hs
@@ -465,9 +465,6 @@ initialDraw initializedModel events hydrate isRoot Component {..} ComponentState
         if hydrated
           then atomicWriteIORef _componentVTree vtree
           else do
-            liftIO $ do -- dmj: reset state
-              atomicWriteIORef components IM.empty
-              atomicWriteIORef componentIds topLevelComponentId
             newTree <-
               buildVTree events _componentParentId _componentId Draw
                 _componentSink logLevel (view initializedModel)


### PR DESCRIPTION
When page hydration fails we fallback to diffing, we also attempt to reset the global component state. Resetting the entire state is unnecessary because we just need to update the virtual DOM reference.

This component state reset causes errors during the fallback edge case. It can be observed by using the `miso` function with `miso-sampler`. This fixes that issue.