### PR TITLE
Drop `stm` usage from `miso-test`.

### DIFF
--- a/tests/app/Main.hs
+++ b/tests/app/Main.hs
@@ -25,7 +25,6 @@ import           Prelude hiding ((!!))
 import           GHC.Generics
 import           Control.Monad
 import           Control.Concurrent
-import           Control.Concurrent.STM
 import           Data.Either
 import           Data.IORef
 import           Data.Text (Text)

--- a/tests/miso-tests.cabal
+++ b/tests/miso-tests.cabal
@@ -58,7 +58,7 @@ executable component-tests
   main-is:
     Main.hs
   build-depends:
-    base, miso, miso-tests, containers, mtl, stm, text
+    base, miso, miso-tests, containers, mtl, text
   hs-source-dirs:
     app
 
@@ -79,4 +79,4 @@ library
   exposed-modules:
     Miso.Test
   build-depends:
-    base, miso, containers, mtl, stm
+    base, miso, containers, mtl


### PR DESCRIPTION
No longer required.