### PR TITLE
Make `FromJSVal ()` more liberal.

### DIFF
--- a/src/Miso/DSL.hs
+++ b/src/Miso/DSL.hs
@@ -268,10 +268,10 @@ instance ToJSVal Text where
   toJSVal = toJSVal_Text
 -----------------------------------------------------------------------------
 instance FromJSVal () where
-  fromJSVal x =
-    if isUndefined_ffi x || isNull_ffi x
-      then pure (Just ())
-      else pure Nothing
+  fromJSVal _ = pure (Just ())
+    -- if isUndefined_ffi x || isNull_ffi x
+    --   then pure (Just ())
+    --   else pure Nothing
 -----------------------------------------------------------------------------
 instance (ToJSVal a, ToJSVal b) => ToJSVal (a,b) where
   toJSVal (y,z) = do


### PR DESCRIPTION
If a user returns `()` while using `inline-js` it must be exact (either `null` or `undefined`).

This PR liberalizes the return type so anything (`boolean`, etc.) can be returned and cast to `()` without raising a `fromJSValUnchecked` exception.