### PR TITLE
Drop unmounted `Component` queue from runtime state.

### DIFF
--- a/src/Miso/Runtime.hs
+++ b/src/Miso/Runtime.hs
@@ -534,8 +534,9 @@ dequeue q =
     S.Empty -> Nothing
     sched@(vcompId S.:<| leftover) ->
       case q ^. queue . at vcompId of
-        Nothing -> -- dmj: if unmount occurred, just pop the schedule
-          Just (vcompId, [], q & queueSchedule .~ leftover)
+        Nothing -> -- dmj: if unmount occurred, pop the schedule, drop the empty queue.
+          Just (vcompId, [], q & queueSchedule .~ leftover
+                               & queue . at vcompId .~ Nothing)
         Just actions ->
           case S.spanl (==vcompId) sched of
             (scheduled, remaining) ->


### PR DESCRIPTION
If the `scheduler` dequeues and finds an already unmounted `Component` it should drop it from the runtime state. This addresses an edge case where unmounted `Component` can build up empty `Seq` in the runtime.

- [x] Drop unmounted `Component` `queue`.

```haskell
queue . at vcompId .~ Nothing
```