### PR TITLE
Drop empty queue of `Component`

### DIFF
--- a/src/Miso/Runtime.hs
+++ b/src/Miso/Runtime.hs
@@ -543,7 +543,7 @@ dequeue q =
                 (process, rest) -> do
                   let updated =
                         q & queueSchedule .~ remaining
-                          & queue.at vcompId ?~ rest
+                          & queue.at vcompId .~ do if null rest then Nothing else Just rest
                   Just (vcompId, toList process, updated)
 -----------------------------------------------------------------------------
 -- | Dequeus everything from the Queue at a specific t'ComponentId', draining


### PR DESCRIPTION
If the `scheduler` dequeues and finds an already unmounted `Component` it should drop it from the runtime state. Likewise, on all `dequeue` events, if the `queue` becomes empty it should be dropped from the `IntMap`. 

This addresses an edge case where unmounted `Component` can build up empty `Seq` in the runtime.

- [x] Drop empty `Component` `queue` from the `queue` `IntMap`