### PR TITLE
Empty `globalQueue` on `resetComponentState`.

### DIFF
--- a/src/Miso/Runtime.hs
+++ b/src/Miso/Runtime.hs
@@ -941,6 +941,7 @@ unmountComponent cs@ComponentState {..} = do
 -----------------------------------------------------------------------------
 resetComponentState :: IO ()
 resetComponentState = do
+  atomicWriteIORef globalQueue mempty
   cs <- readIORef components
   forM_ cs unmountComponent
   atomicWriteIORef components mempty


### PR DESCRIPTION
Empties out the `globalQueue` on application reload.