### PR TITLE
Update `resetComponentState`

### DIFF
--- a/src/Miso/Reload.hs
+++ b/src/Miso/Reload.hs
@@ -42,10 +42,10 @@ reload
   :: IO ()
   -- ^ An t'IO' action typically created using 'Miso.miso' or 'Miso.startApp'
   -> IO ()
-reload = (clear >>)
+reload action = clear >> action
   where
     clear :: IO ()
-    clear = resetComponentState >> do
+    clear = resetComponentState $ do
       body_ <- jsg "document" ! ("body" :: MisoString)
       setField body_ "innerHTML" ("" :: MisoString)
       head_ <- jsg "document" ! ("head" :: MisoString)

--- a/src/Miso/Runtime.hs
+++ b/src/Miso/Runtime.hs
@@ -939,14 +939,14 @@ unmountComponent cs@ComponentState {..} = do
     children.at _componentId .= Nothing
   liftIO $ atomicModifyIORef' components $ \m -> (IM.delete _componentId m, ())
 -----------------------------------------------------------------------------
-resetComponentState :: IO ()
-resetComponentState = do
+resetComponentState :: IO () -> IO ()
+resetComponentState clear = do
+  cs <- atomicModifyIORef' components $ \vcomps -> (mempty, vcomps)
   atomicWriteIORef globalQueue mempty
-  cs <- readIORef components
-  forM_ cs unmountComponent
-  atomicWriteIORef components mempty
   atomicWriteIORef componentIds topLevelComponentId
   atomicWriteIORef subIds 0
+  forM_ cs unmountComponent
+  clear
 -----------------------------------------------------------------------------
 -- | Internal function for construction of a Virtual DOM.
 --


### PR DESCRIPTION
Update `resetComponentState`
This avoids the need to kill the scheduler thread when performing hot reloading.

- [x] Clear `components` map first.