### PR TITLE
Address `toString_Word` issue in WASM FFI.

### DIFF
--- a/ffi/wasm/Data/JSString.hs
+++ b/ffi/wasm/Data/JSString.hs
@@ -848,6 +848,6 @@ foreign import javascript unsafe "return ($1).toString()"
 foreign import javascript unsafe "return ($1).toString()"
   toString_Float :: Float -> JSString
 -----------------------------------------------------------------------------
-foreign import javascript unsafe "return ($1).toString()"
-  toString_Word :: Word -> JSString
+toString_Word :: Word -> JSString
+toString_Word = toJSString . show
 -----------------------------------------------------------------------------


### PR DESCRIPTION
```haskell
foreign import javascript unsafe "return ($1).toString()"
  toString_Word :: Word -> JSString
```

^ This causes overflowing where none should happen.

```
ghci> ms (4000000000 :: Word)
"-294967296"
```

Revert to using `ms . show`

N.B. the JS backend does exhibit the same behavior for `ToMisoString Word`