### PR TITLE
Drop `ToJSON`/`FromJSON` constraints in `Miso.Storage`, add tests.

### DIFF
--- a/src/Miso/Html/Render.hs
+++ b/src/Miso/Html/Render.hs
@@ -131,13 +131,13 @@ renderBuilder (VNode ns tag attrs children) = mconcat
               , ns == MATHML
               ]
 
-renderBuilder (VComp _ (SomeComponent vcomp)) =
+renderBuilder (VComp _ (SomeComponent vcomp_)) =
   foldMap renderBuilder vkids
     where
 #ifdef SSR
-      vkids = [ unsafeCoerce $ (view vcomp) $ getInitialComponentModel vcomp ]
+      vkids = [ unsafeCoerce $ (view vcomp_) $ getInitialComponentModel vcomp_ ]
 #else
-      vkids = [ unsafeCoerce $ (view vcomp) (model vcomp) ]
+      vkids = [ unsafeCoerce $ (view vcomp_) (model vcomp_) ]
 #endif
 ----------------------------------------------------------------------------
 renderAttrs :: Attribute action -> Builder

--- a/src/Miso/Storage.hs
+++ b/src/Miso/Storage.hs
@@ -31,68 +31,43 @@ module Miso.Storage
 import           Control.Monad (void)
 -----------------------------------------------------------------------------
 import           Miso.DSL
-import           Miso.JSON
 import           Miso.String (MisoString)
------------------------------------------------------------------------------
--- | Helper for retrieving either local or session storage.
-getStorageCommon
-  :: FromJSON b
-  => (t -> IO (Maybe JSVal))
-  -> t
-  -> IO (Either MisoString b)
-getStorageCommon f key = do
-  result <- f key
-  case result of
-    Nothing ->
-      pure (Left "Not Found")
-    Just v -> do
-      s <- fromJSValUnchecked v
-      pure (eitherDecode s)
 -----------------------------------------------------------------------------
 -- | Retrieves a value stored under the given key in session storage.
 getSessionStorage
-  :: FromJSON model
-  => MisoString
-  -> IO (Either MisoString model)
-getSessionStorage =
-  getStorageCommon $ \t -> do
-    s <- sessionStorage
-    r <- getItem s t
-    fromJSVal r
+  :: MisoString
+  -> IO (Maybe MisoString)
+getSessionStorage key = do
+  fromJSValUnchecked =<< flip getItem key =<< sessionStorage
 -----------------------------------------------------------------------------
 -- | Retrieves a value stored under the given key in local storage.
 getLocalStorage
-  :: FromJSON model
-  => MisoString
-  -> IO (Either MisoString model)
-getLocalStorage = getStorageCommon $ \t -> do
-    s <- localStorage
-    r <- getItem s t
-    fromJSVal r
+  :: MisoString
+  -> IO (Maybe MisoString)
+getLocalStorage key =
+  fromJSValUnchecked =<< flip getItem key =<< localStorage
 -----------------------------------------------------------------------------
 -- | Sets the value of a key in local storage.
 --
 -- @setLocalStorage key value@ sets the value of @key@ to @value@.
 setLocalStorage
-  :: ToJSON model
-  => MisoString
-  -> model
+  :: MisoString
+  -> MisoString
   -> IO ()
-setLocalStorage key model = do
+setLocalStorage key value = do
   s <- localStorage
-  setItem s key (encode model)
+  setItem s key value
 -----------------------------------------------------------------------------
 -- | Sets the value of a key in session storage.
 --
 -- @setSessionStorage key value@ sets the value of @key@ to @value@.
 setSessionStorage
-  :: ToJSON model
-  => MisoString
-  -> model
+  :: MisoString
+  -> MisoString
   -> IO ()
-setSessionStorage key model = do
+setSessionStorage key value = do
   s <- sessionStorage
-  setItem s key (encode model)
+  setItem s key value
 -----------------------------------------------------------------------------
 -- | Removes an item from local storage.
 --

--- a/tests/app/Main.hs
+++ b/tests/app/Main.hs
@@ -47,6 +47,7 @@ import           Miso.DSL
 import           Miso.FFI.QQ (js)
 #endif
 import           Miso.Lens
+import           Miso.Storage
 import           Miso.Test
 import           Miso.Html
 import           Miso.JSON.Parser (decodePure)
@@ -125,6 +126,33 @@ square n = [js|
 main :: IO ()
 main = withJS $ do
   runTests $ beforeEach clearBody $ afterEach clearComponentState $ do
+    describe "Miso.Storage tests" $ do
+      it "Should get and set in localStorage" $ do
+        (`shouldBe` 0) =<< liftIO localStorageLength
+        liftIO (setLocalStorage "key1" "value1")
+        (`shouldBe` (Just "value1")) =<< liftIO (getLocalStorage "key1")
+        liftIO (setLocalStorage "key2" "value2")
+        (`shouldBe` (Just "value2")) =<< liftIO (getLocalStorage "key2")
+        (`shouldBe` Nothing) =<< liftIO (getLocalStorage "key3")
+        (`shouldBe` 2) =<< liftIO localStorageLength
+        liftIO (removeLocalStorage "key2")
+        (`shouldBe` Nothing) =<< liftIO (getLocalStorage "key2")
+        liftIO clearLocalStorage
+        (`shouldBe` 0) =<< liftIO localStorageLength
+
+      it "Should get and set in sessionStorage" $ do
+        (`shouldBe` 0) =<< liftIO sessionStorageLength
+        liftIO (setSessionStorage "key1" "value1")
+        (`shouldBe` (Just "value1")) =<< liftIO (getSessionStorage "key1")
+        liftIO (setSessionStorage "key2" "value2")
+        (`shouldBe` (Just "value2")) =<< liftIO (getSessionStorage "key2")
+        (`shouldBe` Nothing) =<< liftIO (getSessionStorage "key3")
+        (`shouldBe` 2) =<< liftIO sessionStorageLength
+        liftIO (removeSessionStorage "key2")
+        (`shouldBe` Nothing) =<< liftIO (getSessionStorage "key2")
+        liftIO clearSessionStorage
+        (`shouldBe` 0) =<< liftIO sessionStorageLength
+
     describe "Miso.Data.Array tests" $ do
       it "Should create a new array" $ do
         (`shouldBe` 0) =<< liftIO (Array.size =<< (Array.new :: IO (Array.Array Int)))
@@ -559,9 +587,9 @@ main = withJS $ do
         S.compareLength "" (-1) `shouldBe`
           T.compareLength "" (-1)
         S.compareLength "foo" 0 `shouldBe`
-          T.compareLength "foo" 0 
+          T.compareLength "foo" 0
         S.compareLength "foo" 2 `shouldBe`
-          T.compareLength "foo" 2 
+          T.compareLength "foo" 2
         S.compareLength "foo" 4 `shouldBe`
           T.compareLength "foo" 4
 


### PR DESCRIPTION
It's a little presumptuous to enforce the JSON constraint, the API is also a string-based API.

- [x] Add `localStorage` / `sessionStorage` integration tests.
- [x] Drop `ToJSON` / `FromJSON` constraint