### PR TITLE
hls: 2.10 -> 2.12

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -43,11 +43,11 @@
       },
       "locked": {
         "host": "gitlab.haskell.org",
-        "lastModified": 1772669130,
-        "narHash": "sha256-uomiPFFhHOzYU/2t3iAczlUOczDfJWYMdyqjOPKNnig=",
+        "lastModified": 1773434424,
+        "narHash": "sha256-1RHP174kGsVVVjEXHN/Kf6S7Uy8uGWZt8fRu7X9MvRk=",
         "owner": "haskell-wasm",
         "repo": "ghc-wasm-meta",
-        "rev": "21db26e158d9bc4f37ebfa95697d7af7a6c6eede",
+        "rev": "c662c34d608dc9d2ff599b007f2e3c46138efaab",
         "type": "gitlab"
       },
       "original": {
@@ -59,33 +59,33 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1772598333,
-        "narHash": "sha256-YaHht/C35INEX3DeJQNWjNaTcPjYmBwwjFJ2jdtr+5U=",
+        "lastModified": 1773282714,
+        "narHash": "sha256-at2PNNVNoTfXBe3bA6pgff+CKOwdBWUZCUBIfXGrXsU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fabb8c9deee281e50b1065002c9828f2cf7b2239",
+        "rev": "a8556879c286b4a40a717a416ae61818c26d1ac8",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-25.11",
+        "ref": "nixpkgs-25.11-darwin",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1751996040,
-        "narHash": "sha256-DOjNE+DYZ/YZo1UkXcJNlvSKEBowWATX6o4s0WuAzuA=",
+        "lastModified": 1770195405,
+        "narHash": "sha256-FTUS9GSw4KiOjAOmsarvRhTGEECUVd3NhBfzUytCuhE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9e2e8a7878573d312db421d69e071690ec34e98c",
+        "rev": "bc16855ba53f3cb6851903a393e7073d1b5911e7",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9e2e8a7878573d312db421d69e071690ec34e98c",
+        "rev": "bc16855ba53f3cb6851903a393e7073d1b5911e7",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -21,7 +21,7 @@
     # Miso's nixpkgs hash, this is used for acquiring the GHCJS-9122 backend
     # and native backend
     nixpkgs.url =
-      "github:nixos/nixpkgs?rev=9e2e8a7878573d312db421d69e071690ec34e98c";
+      "github:nixos/nixpkgs?rev=bc16855ba53f3cb6851903a393e7073d1b5911e7";
 
     # Some light utils
     flake-utils.url = "github:numtide/flake-utils";


### PR DESCRIPTION
Hi,

I tried dev env `nix develop .#hls` and noticed that emacs lsp-mode cannot work with hls-2.10. 
