### PR TITLE
Drop `MisoString` argument from `textarea_`.

### DIFF
--- a/src/Miso/Html/Element.hs
+++ b/src/Miso/Html/Element.hs
@@ -1,5 +1,6 @@
 -----------------------------------------------------------------------------
 {-# LANGUAGE CPP               #-}
+{-# LANGUAGE LambdaCase        #-}
 {-# LANGUAGE OverloadedStrings #-}
 -----------------------------------------------------------------------------
 -- |
@@ -147,7 +148,9 @@ module Miso.Html.Element
     , svg_
     ) where
 -----------------------------------------------------------------------------
+#ifdef VANILLA
 import           Miso.Property
+#endif
 import           Miso.Types
 -----------------------------------------------------------------------------
 import           Miso.Svg.Element (svg_)
@@ -500,18 +503,21 @@ option_ = nodeHtml "option"
 -- | [\<textarea\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/textarea)
 --
 -- @
--- textarea_ [ id_ "txt" ] 
---    """
---    text goes here
---    """
+-- textarea_ [ id_ "txt", P.value_ (model ^. txt) ]
 -- @
 --
+-- When compiling on the server, this combinator will render HTML as \<textarea\>text\<\/textarea\>.
+--
 -- @since 1.9.0.0
-textarea_ :: [Attribute action] -> MisoString -> View model action
+textarea_ :: [Attribute action] -> View model action
 #ifdef VANILLA
-textarea_ attrs txt = nodeHtml "textarea" attrs [ text txt ] 
+textarea_ attrs = nodeHtml "textarea" newAttrs [ text x | Property "value" x <- attrs ]
+  where
+    newAttrs = filter attrs <&> \case
+      Property "value" _ -> False
+      _ -> True
 #else
-textarea_ attrs txt = nodeHtml "textarea" (textProp "value" txt : attrs) []
+textarea_ = flip (nodeHtml "textarea") []
 #endif
 -----------------------------------------------------------------------------
 -- | [\<sub\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/sub)

--- a/src/Miso/Html/Element.hs
+++ b/src/Miso/Html/Element.hs
@@ -149,7 +149,7 @@ module Miso.Html.Element
     ) where
 -----------------------------------------------------------------------------
 #ifdef VANILLA
-import           Miso.Property
+import           Miso.JSON (Value(String))
 #endif
 import           Miso.Types
 -----------------------------------------------------------------------------
@@ -511,11 +511,13 @@ option_ = nodeHtml "option"
 -- @since 1.9.0.0
 textarea_ :: [Attribute action] -> View model action
 #ifdef VANILLA
-textarea_ attrs = nodeHtml "textarea" newAttrs [ text x | Property "value" x <- attrs ]
-  where
-    newAttrs = filter attrs <&> \case
-      Property "value" _ -> False
-      _ -> True
+textarea_ attrs = nodeHtml "textarea" newAttrs
+  [ text x
+  | Property "value" (String x) <- attrs
+  ] where
+      newAttrs = flip filter attrs $ \case
+        Property "value" _ -> False
+        _ -> True
 #else
 textarea_ = flip (nodeHtml "textarea") []
 #endif

--- a/src/Miso/Types.hs
+++ b/src/Miso/Types.hs
@@ -69,6 +69,7 @@ module Miso.Types
   -- ** Utils
   , getMountPoint
   , optionalAttrs
+  , optionalVoidAttrs
   , optionalChildren
   , prettyURI
   , prettyQueryString
@@ -570,6 +571,27 @@ optionalAttrs
 optionalAttrs element attrs condition opts kids =
   case element attrs kids of
     VNode ns name _ _ -> do
+      let newAttrs = concat [ opts | condition ] ++ attrs
+      VNode ns name newAttrs kids
+    x -> x
+-----------------------------------------------------------------------------
+-- | Utility function to make it easy to specify conditional attributes for void elements.
+--
+-- @
+-- view :: Bool -> View model action
+-- view shouldClear = optionalVoidAttrs textarea_ [ value_ "" ] shouldClear [ id_ "text-area-id" ]
+-- @
+--
+-- @since 1.9.0.0
+optionalVoidAttrs
+  :: ([Attribute action] -> View model action)
+  -> [Attribute action] -- ^ Attributes to be added unconditionally
+  -> Bool -- ^ A condition
+  -> [Attribute action] -- ^ Additional attributes to add if the condition is True
+  -> View model action
+optionalVoidAttrs element attrs condition opts =
+  case element attrs of
+    VNode ns name _ kids -> do
       let newAttrs = concat [ opts | condition ] ++ attrs
       VNode ns name newAttrs kids
     x -> x


### PR DESCRIPTION
Instead of using the `MisoString` argument to set `value`, normalize `value_` property to set `text` argument when rendering HTML on the server.