### PR TITLE
Add `onInputWith`.

### DIFF
--- a/src/Miso/Html/Event.hs
+++ b/src/Miso/Html/Event.hs
@@ -35,6 +35,7 @@ module Miso.Html.Event
   , onEnter
   -- *** Form
   , onInput
+  , onInputWith
   , onChange
   , onChangeWith
   , onChecked
@@ -199,6 +200,10 @@ onDoubleClickWithOptions options action =
 -- | https://developer.mozilla.org/en-US/docs/Web/Events/input
 onInput :: (MisoString -> action) -> Attribute action
 onInput f = on "input" valueDecoder (\action _ -> f action)
+-----------------------------------------------------------------------------
+-- | https://developer.mozilla.org/en-US/docs/Web/Events/input
+onInputWith :: (MisoString -> DOMRef -> action) -> Attribute action
+onInputWith = on "input" valueDecoder
 -----------------------------------------------------------------------------
 -- | https://developer.mozilla.org/en-US/docs/Web/Events/change
 onChange :: (MisoString -> action) -> Attribute action


### PR DESCRIPTION
Passes along the `DOMRef` for `input` events.

- [x] Adds `onInputWith` event handler