### PR TITLE
Inherit parent `model` state on `Component` `mount`.

### DIFF
--- a/src/Miso/Binding.hs
+++ b/src/Miso/Binding.hs
@@ -32,11 +32,16 @@
 module Miso.Binding
   ( -- ** Types
     Binding (..)
+  , Precedence (..)
     -- ** Combinators
   , (<-->)
+  , (<<-->)
+  , (<-->>)
   , (<--)
   , (-->)
   , (<--->)
+  , (<<--->)
+  , (<--->>)
   , (<---)
   , (--->)
   ) where
@@ -62,7 +67,12 @@ import Miso.Lens (Lens, Lens', LensCore(..))
 data Binding parent child
   = forall field . ParentToChild (parent -> field) (field -> child -> child)
   | forall field . ChildToParent (field -> parent -> parent) (child -> field)
-  | forall field . Bidirectional (parent -> field) (field -> parent -> parent) (child -> field) (field -> child -> child)
+  | forall field . Bidirectional Precedence (parent -> field) (field -> parent -> parent) (child -> field) (field -> child -> child)
+-----------------------------------------------------------------------------
+-- | Data type used to express if the Child state should take precendence
+-- over the parent state during 'Component' mount.
+data Precedence = Child | Parent
+  deriving (Eq, Show)
 -----------------------------------------------------------------------------
 -- | Unidirectionally binds a parent field to a child field
 --
@@ -85,7 +95,7 @@ parent <-- child = ChildToParent (_set parent) (_get child)
 -- @since 1.9.0.0
 infix 0 <-->
 (<-->) :: Lens parent field -> Lens child field -> Binding parent child
-p <--> c = Bidirectional (_get p) (_set p) (_get c) (_set c)
+p <--> c = Bidirectional Parent (_get p) (_set p) (_get c) (_set c)
 -----------------------------------------------------------------------------
 -- | Bidirectionally binds a child field to a parent field, using @Lens'@
 --
@@ -94,10 +104,34 @@ p <--> c = Bidirectional (_get p) (_set p) (_get c) (_set c)
 -- @since 1.9.0.0
 infix 0 <--->
 (<--->) :: Lens' parent field -> Lens' child field -> Binding parent child
-p <---> c = Bidirectional (get_ p) (set_ p) (get_ c) (set_ c)
+p <---> c = Bidirectional Parent (get_ p) (set_ p) (get_ c) (set_ c)
   where
     get_ lens_ record = getConst (lens_ Const record)
     set_ lens_ field = runIdentity . lens_ (\_ -> Identity field)
+-----------------------------------------------------------------------------
+-- | Like '<--->' but biases to inherit 'Parent' state on 'Component' 'mount'.
+--
+-- @since 1.10.0.0
+(<--->>)
+  :: Lens' parent field
+  -> Lens' child field
+  -> Binding parent child
+l <--->> r =
+  case l <---> r of
+    Bidirectional _ w x y z -> Bidirectional Parent w x y z
+    _ -> error "impossible"
+-----------------------------------------------------------------------------
+-- | Like '<--->' but biases to inherit 'Child' state on 'Component' 'mount'.
+--
+-- @since 1.10.0.0
+(<<--->)
+  :: Lens' parent field
+  -> Lens' child field
+  -> Binding parent child
+l <<---> r =
+  case l <---> r of
+    Bidirectional _ w x y z -> Bidirectional Child w x y z
+    _ -> error "impossible"
 -----------------------------------------------------------------------------
 -- | Unidirectionally binds a parent field to a child field, for van Laarhoven
 -- style @Lens'@
@@ -109,6 +143,30 @@ p ---> c = ParentToChild (get_ p) (set_ c)
   where
     get_ lens_ record = getConst (lens_ Const record)
     set_ lens_ field = runIdentity . lens_ (\_ -> Identity field)
+-----------------------------------------------------------------------------
+-- | Like '<-->' but biases to inherit 'Parent' state on 'Component' 'mount'.
+--
+-- @since 1.10.0.0
+(<-->>)
+  :: Lens parent field
+  -> Lens child field
+  -> Binding parent child
+l <-->> r =
+  case l <--> r of
+    Bidirectional _ w x y z -> Bidirectional Parent w x y z
+    _ -> error "impossible"
+-----------------------------------------------------------------------------
+-- | Like '<-->' but biases to inherit 'Child' state on 'Component' 'mount'.
+--
+-- @since 1.10.0.0
+(<<-->)
+  :: Lens parent field
+  -> Lens child field
+  -> Binding parent child
+l <<--> r =
+  case l <--> r of
+    Bidirectional _ w x y z -> Bidirectional Child w x y z
+    _ -> error "impossible"
 -----------------------------------------------------------------------------
 -- | Unidirectionally binds a child field to a parent field, for van Laarhoven
 -- style @Lens'@

--- a/src/Miso/Runtime.hs
+++ b/src/Miso/Runtime.hs
@@ -184,7 +184,6 @@ initialize events _componentParentId hydrate isRoot comp@Component {..} getCompo
   _componentSubThreads <- liftIO (newIORef M.empty)
 
   frame <- newEmptyMVar :: IO (MVar Double)
-  _componentModel <- liftIO (pure initializedModel)
   _componentMailbox <- pure S.empty
 
   rAFCallback <-
@@ -222,16 +221,61 @@ initialize events _componentParentId hydrate isRoot comp@Component {..} getCompo
         , _componentTopics = mempty
         , _componentModelDirty = modelCheck
         , _componentChildren = mempty
+        , _componentModel = initializedModel
         , ..
         }
 
   when isRoot (delegator _componentDOMRef _componentVTree events (logLevel `elem` [DebugEvents, DebugAll]))
   registerComponent vcomponent
+
+  -- Inherit bindings state (if applicable)
+  _componentModel <- inheritParentBindings _componentParentId initializedModel bindings
+  modifyComponent _componentId (componentModel .= _componentModel)
+
   initSubs subs _componentSubThreads _componentSink
-  initialDraw initializedModel events hydrate isRoot comp vcomponent
+  initialDraw _componentModel events hydrate isRoot comp vcomponent
   forM_ mount _componentSink
   FFI.mountComponent _componentId =<< toObject jsNull
   pure vcomponent
+-----------------------------------------------------------------------------
+inheritParentBindings
+  :: ComponentId
+  -- ^ ParentId
+  -> child
+  -- ^ Child model
+  -> [ Binding parent child ]
+  -> IO child
+inheritParentBindings compParentId childModel bindings = do
+  inheritChildBindings compParentId childModel bindings
+  foldM (\m -> \case
+            ParentToChild getParentField setChildField -> do
+              ComponentState {..} <- (IM.! compParentId) <$> readIORef components
+              pure (setChildField (getParentField _componentModel) m)
+            _ -> pure m
+        ) childModel bindings
+-----------------------------------------------------------------------------
+inheritChildBindings
+  :: ComponentId
+  -- ^ ParentId
+  -> child
+  -- ^ Child component
+  -> [ Binding parent child ]
+  -> IO ()
+inheritChildBindings compParentId childState bindings = do
+  forM_ bindings $ \case
+     ChildToParent setParentField getChildField -> do
+       modifyComponent compParentId $ do
+         componentModel %= setParentField (getChildField childState)
+         isDirty .= True
+     _ -> do
+       pure ()
+  when (any isChildToParent bindings) $ do
+    renderComponents (IS.singleton compParentId)
+  where
+    isChildToParent :: Binding parent model -> Bool
+    isChildToParent = \case
+      ChildToParent {} -> True
+      _ -> False
 -----------------------------------------------------------------------------
 initSubs :: [Sub action] -> IORef (Map MisoString ThreadId) -> Sink action -> IO ()
 initSubs subs_ _componentSubThreads _componentSink = do
@@ -293,20 +337,20 @@ scheduler =
           pure dirtySet
         else
           pure mempty
-    -----------------------------------------------------------------------------
-    -- | Perform a top-down rendering of the 'Component' tree.
-    --
-    -- We lookup the components each time to account for unmounting.
-    -- Reset the dirty bit if a render occurs
-    --
-    renderComponents :: ComponentIds -> IO ()
-    renderComponents dirtySet = do
-      forM_ (IS.toAscList dirtySet) $ \vcompId ->
-        IM.lookup vcompId <$> liftIO (readIORef components) >>= mapM \ComponentState {..} -> do
-          when _componentIsDirty $ do
-            _componentDraw _componentModel
-            FFI.modelHydration _componentId =<< toObject jsNull
-          modifyComponent _componentId (isDirty .= False)
+-----------------------------------------------------------------------------
+-- | Perform a top-down rendering of the 'Component' tree.
+--
+-- We lookup the components each time to account for unmounting.
+-- Reset the dirty bit if a render occurs
+--
+renderComponents :: ComponentIds -> IO ()
+renderComponents dirtySet = do
+  forM_ (IS.toAscList dirtySet) $ \vcompId ->
+    IM.lookup vcompId <$> liftIO (readIORef components) >>= mapM \ComponentState {..} -> do
+      when _componentIsDirty $ do
+        _componentDraw _componentModel
+        FFI.modelHydration _componentId =<< toObject jsNull
+      modifyComponent _componentId (isDirty .= False)
 -----------------------------------------------------------------------------
 -- | Modify a single t'Component p m a' at a t'ComponentId'.
 --
@@ -450,7 +494,7 @@ visit vcompId = stack %= (vcompId:)
 -----------------------------------------------------------------------------
 pop :: Synch p m a (Maybe (ComponentState p m a))
 pop = use stack >>= \case
-  [] -> 
+  [] ->
     pure Nothing
   x : xs -> do
     stack .= xs
@@ -1527,7 +1571,7 @@ websocketClose :: WebSocket -> Effect parent model action
 websocketClose socketId = do
   ComponentInfo {..} <- ask
   io_ $ do
-    result <- 
+    result <-
       atomicModifyIORef' websocketConnections $ \imap ->
         dropWebSocket _componentInfoId socketId imap =:
           getWebSocket _componentInfoId socketId imap

--- a/src/Miso/Runtime.hs
+++ b/src/Miso/Runtime.hs
@@ -126,6 +126,7 @@ import           Text.Printf
 #endif
 import           Unsafe.Coerce (unsafeCoerce)
 -----------------------------------------------------------------------------
+import           Miso.Binding (Precedence(..))
 import           Miso.Concurrent (Waiter(..), waiter)
 import           Miso.CSS (renderStyleSheet)
 import           Miso.Delegate (delegator)
@@ -251,6 +252,9 @@ inheritParentBindings compParentId childModel bindings = do
             ParentToChild getParentField setChildField -> do
               ComponentState {..} <- (IM.! compParentId) <$> readIORef components
               pure (setChildField (getParentField _componentModel) m)
+            Bidirectional Parent getParentField _ _ setChildField -> do
+              ComponentState {..} <- (IM.! compParentId) <$> readIORef components
+              pure (setChildField (getParentField _componentModel) m)
             _ -> pure m
         ) childModel bindings
 -----------------------------------------------------------------------------
@@ -264,6 +268,10 @@ inheritChildBindings
 inheritChildBindings compParentId childState bindings = do
   forM_ bindings $ \case
      ChildToParent setParentField getChildField -> do
+       modifyComponent compParentId $ do
+         componentModel %= setParentField (getChildField childState)
+         isDirty .= True
+     Bidirectional Child _ setParentField getChildField _ -> do
        modifyComponent compParentId $ do
          componentModel %= setParentField (getChildField childState)
          isDirty .= True
@@ -442,7 +450,7 @@ propagateChildren currentState childComponents = do
               currentFieldValue = getCurrentField (currentState ^. componentModel)
               updatedChildModel = setChildField currentFieldValue currentChildModel
           pure (childState & componentModel .~ updatedChildModel)
-        Bidirectional getCurrentField _ _ setChildField -> do
+        Bidirectional _ getCurrentField _ _ setChildField -> do
           let currentChildModel = _componentModel childState
               currentFieldValue = getCurrentField (currentState ^. componentModel)
               updatedChildModel = setChildField currentFieldValue currentChildModel
@@ -478,7 +486,7 @@ propagateParent currentState parentId_ =
             currentFieldValue = getCurrentField (currentState ^. componentModel)
             updatedParentModel = setParentField currentFieldValue currentParentModel
         pure (parentState & componentModel .~ updatedParentModel)
-      Bidirectional _ setParentField getCurrentField _ -> do
+      Bidirectional _ _ setParentField getCurrentField _ -> do
         let currentParentModel = parentState ^. componentModel
             currentFieldValue = getCurrentField (currentState ^. componentModel)
             updatedParentModel = setParentField currentFieldValue currentParentModel


### PR DESCRIPTION
When a `Component` mounts, it should inherit its parent state (if `ParentToChild` binding is in use). Similarly, if `ChildToParent` is in use, the `parent` state should be overridden by the child state when mounting.

- [x] Adds `inheritParentBindings` and `inheritChildBindings` in `Runtime`