### PR TITLE
Add React-style "props", `VProp`.

### DIFF
--- a/sample-app/Main.hs
+++ b/sample-app/Main.hs
@@ -9,7 +9,7 @@ import           Miso
 import qualified Miso.Html as H
 import qualified Miso.Html.Property as P
 import           Miso.Lens
-import            Miso.Reload
+import           Miso.Reload
 ----------------------------------------------------------------------------
 -- | Component model state
 data Model
@@ -58,7 +58,7 @@ updateModel = \case
   SayHelloWorld -> io_ (consoleLog "Hello world")
 ----------------------------------------------------------------------------
 -- | Constructs a virtual DOM from a model
-viewModel :: Model -> View Model Action
+viewModel :: Model -> View parent Model Action
 viewModel x =
   H.div_
     [ P.className "counter"

--- a/src/Miso.hs
+++ b/src/Miso.hs
@@ -290,10 +290,11 @@
 -- 'Component' inside other 'Component'.
 --
 -- @
--- data 'View' model action
---   = 'VNode' 'Namespace' 'Tag' ['Attribute' action] ['View' model action]
+-- data 'View' parent model action
+--   = 'VNode' 'Namespace' 'Tag' ['Attribute' action] ['View' parent model action]
 --   | 'VText' (Maybe 'Key') 'MisoString'
 --   | 'VComp' (Maybe 'Key') ('SomeComponent' model)
+--   | 'VProp' (parent -> field)
 -- @
 --
 -- 'VNode' and 'VText' have a one-to-one mapping from the virtual DOM to the physical DOM. The 'VComp' constructor is abstract and does not contain a reference to the physical DOM. The existential type of 'SomeComponent' is defined recursively in terms of 'View' and is what allows us to embed other polymorphic 'Component'.

--- a/src/Miso/Canvas.hs
+++ b/src/Miso/Canvas.hs
@@ -109,14 +109,14 @@ import           Miso.CSS (Color, renderColor)
 -- useful when building applications with three.js, or other libraries where
 -- explicit context is not necessary.
 canvas_
-  :: forall model action canvasState
+  :: forall parent model action canvasState
    . (FromJSVal canvasState, ToJSVal canvasState)
   => [ Attribute action ]
   -> (DOMRef -> IO canvasState)
   -- ^ Init function, takes 'DOMRef' as arg, returns canvas init. state.
   -> (canvasState -> IO ())
   -- ^ Callback to render graphics using this canvas' context, takes init state as arg.
-  -> View model action
+  -> View parent model action
 canvas_ attributes initialize_ draw_ = node HTML "canvas" attrs []
   where
     attrs :: [ Attribute action ]
@@ -140,14 +140,14 @@ canvas_ attributes initialize_ draw_ = node HTML "canvas" attrs []
 -- This function abstracts over the context and interpret callback,
 -- including dimension ("2d" or "3d") canvas.
 canvas
-  :: forall model action canvasState
+  :: forall parent model action canvasState
    . (FromJSVal canvasState, ToJSVal canvasState)
   => [ Attribute action ]
   -> (DOMRef -> Canvas canvasState)
   -- ^ Init function, takes 'DOMRef' as arg, returns canvas init. state.
   -> (canvasState -> Canvas ())
   -- ^ Callback to render graphics using this canvas' context, takes init state as arg.
-  -> View model action
+  -> View parent model action
 canvas attributes initialize draw = node HTML "canvas" attrs []
   where
     attrs :: [ Attribute action ]

--- a/src/Miso/Html/Element.hs
+++ b/src/Miso/Html/Element.hs
@@ -157,347 +157,347 @@ import           Miso.Svg.Element (svg_)
 -----------------------------------------------------------------------------
 -- | Low-level helper used to construct 'HTML' 'node' in 'Miso.Types.View'.
 -- Almost all functions in this module, like 'div_', 'table_' etc. are defined in terms of it.
-nodeHtml :: MisoString -> [Attribute action] -> [View model action] -> View model action
+nodeHtml :: MisoString -> [Attribute action] -> [View parent model action] -> View parent model action
 nodeHtml nodeName = node HTML nodeName
 -----------------------------------------------------------------------------
 -- | [\<div\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/div)
-div_ :: [Attribute action] -> [View model action] -> View model action
+div_ :: [Attribute action] -> [View parent model action] -> View parent model action
 div_ = nodeHtml "div"
 -----------------------------------------------------------------------------
 -- | [\<table\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/table)
-table_ :: [Attribute action] -> [View model action] -> View model action
+table_ :: [Attribute action] -> [View parent model action] -> View parent model action
 table_ = nodeHtml "table"
 -----------------------------------------------------------------------------
 -- | [\<thead\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/thead)
-thead_ :: [Attribute action] -> [View model action] -> View model action
+thead_ :: [Attribute action] -> [View parent model action] -> View parent model action
 thead_ = nodeHtml "thead"
 -----------------------------------------------------------------------------
 -- | [\<tbody\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/tbody)
-tbody_ :: [Attribute action] -> [View model action] -> View model action
+tbody_ :: [Attribute action] -> [View parent model action] -> View parent model action
 tbody_ = nodeHtml "tbody"
 -----------------------------------------------------------------------------
 -- | [\<tr\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/tr)
-tr_ :: [Attribute action] -> [View model action] -> View model action
+tr_ :: [Attribute action] -> [View parent model action] -> View parent model action
 tr_ = nodeHtml "tr"
 -----------------------------------------------------------------------------
 -- | [\<th\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/th)
-th_ :: [Attribute action] -> [View model action] -> View model action
+th_ :: [Attribute action] -> [View parent model action] -> View parent model action
 th_ = nodeHtml "th"
 -----------------------------------------------------------------------------
 -- | [\<td\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/td)
-td_ :: [Attribute action] -> [View model action] -> View model action
+td_ :: [Attribute action] -> [View parent model action] -> View parent model action
 td_ = nodeHtml "td"
 -----------------------------------------------------------------------------
 -- | [\<tfoot\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/tfoot)
-tfoot_ :: [Attribute action] -> [View model action] -> View model action
+tfoot_ :: [Attribute action] -> [View parent model action] -> View parent model action
 tfoot_ = nodeHtml "tfoot"
 -----------------------------------------------------------------------------
 -- | [\<section\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/section)
-section_ :: [Attribute action] -> [View model action] -> View model action
+section_ :: [Attribute action] -> [View parent model action] -> View parent model action
 section_ = nodeHtml "section"
 -----------------------------------------------------------------------------
 -- | [\<header\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/header)
-header_ :: [Attribute action] -> [View model action] -> View model action
+header_ :: [Attribute action] -> [View parent model action] -> View parent model action
 header_ = nodeHtml "header"
 -----------------------------------------------------------------------------
 -- | [\<footer\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/footer)
-footer_ :: [Attribute action] -> [View model action] -> View model action
+footer_ :: [Attribute action] -> [View parent model action] -> View parent model action
 footer_ = nodeHtml "footer"
 -----------------------------------------------------------------------------
 -- | [\<button\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/button)
-button_ :: [Attribute action] -> [View model action] -> View model action
+button_ :: [Attribute action] -> [View parent model action] -> View parent model action
 button_ = nodeHtml "button"
 -----------------------------------------------------------------------------
 -- | [\<form\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/form)
 --
 -- For usage in a real-world application with the @onSubmit@ event.
 --
--- > view :: Model -> View model action
+-- > view :: Model -> View parent model action
 -- > view model = form_ [ onSubmit NoOp ] [ input [ type_ "submit" ] ]
 --
 -- Note: @onSubmit@ will use @preventDefault = True@. This will keep
 -- the form from submitting to the server.
 --
-form_ :: [Attribute action] -> [View model action] -> View model action
+form_ :: [Attribute action] -> [View parent model action] -> View parent model action
 form_ = nodeHtml "form"
 -----------------------------------------------------------------------------
 -- | [\<p\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/p)
-p_ :: [Attribute action] -> [View model action] -> View model action
+p_ :: [Attribute action] -> [View parent model action] -> View parent model action
 p_ = nodeHtml "p"
 -----------------------------------------------------------------------------
 -- | [\<s\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/s)
-s_ :: [Attribute action] -> [View model action] -> View model action
+s_ :: [Attribute action] -> [View parent model action] -> View parent model action
 s_ = nodeHtml "s"
 -----------------------------------------------------------------------------
 -- | [\<ul\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/ul)
-ul_ :: [Attribute action] -> [View model action] -> View model action
+ul_ :: [Attribute action] -> [View parent model action] -> View parent model action
 ul_ = nodeHtml "ul"
 -----------------------------------------------------------------------------
 -- | [\<span\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/span)
-span_ :: [Attribute action] -> [View model action] -> View model action
+span_ :: [Attribute action] -> [View parent model action] -> View parent model action
 span_ = nodeHtml "span"
 -----------------------------------------------------------------------------
 -- | [\<strong\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/strong)
-strong_ :: [Attribute action] -> [View model action] -> View model action
+strong_ :: [Attribute action] -> [View parent model action] -> View parent model action
 strong_ = nodeHtml "strong"
 -----------------------------------------------------------------------------
 -- | [\<li\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/li)
-li_ :: [Attribute action] -> [View model action] -> View model action
+li_ :: [Attribute action] -> [View parent model action] -> View parent model action
 li_ = nodeHtml "li"
 -----------------------------------------------------------------------------
 -- | [\<h1\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/Heading_Elements)
-h1_ :: [Attribute action] -> [View model action] -> View model action
+h1_ :: [Attribute action] -> [View parent model action] -> View parent model action
 h1_ = nodeHtml "h1"
 -----------------------------------------------------------------------------
 -- | [\<h2\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/Heading_Elements)
-h2_ :: [Attribute action] -> [View model action] -> View model action
+h2_ :: [Attribute action] -> [View parent model action] -> View parent model action
 h2_ = nodeHtml "h2"
 -----------------------------------------------------------------------------
 -- | [\<h3\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/Heading_Elements)
-h3_ :: [Attribute action] -> [View model action] -> View model action
+h3_ :: [Attribute action] -> [View parent model action] -> View parent model action
 h3_ = nodeHtml "h3"
 -----------------------------------------------------------------------------
 -- | [\<h4\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/Heading_Elements)
-h4_ :: [Attribute action] -> [View model action] -> View model action
+h4_ :: [Attribute action] -> [View parent model action] -> View parent model action
 h4_ = nodeHtml "h4"
 -----------------------------------------------------------------------------
 -- | [\<h5\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/Heading_Elements)
-h5_ :: [Attribute action] -> [View model action] -> View model action
+h5_ :: [Attribute action] -> [View parent model action] -> View parent model action
 h5_ = nodeHtml "h5"
 -----------------------------------------------------------------------------
 -- | [\<h6\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/Heading_Elements)
-h6_ :: [Attribute action] -> [View model action] -> View model action
+h6_ :: [Attribute action] -> [View parent model action] -> View parent model action
 h6_ = nodeHtml "h6"
 -----------------------------------------------------------------------------
 -- | [\<hr\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/hr)
-hr_ :: [Attribute action] -> View model action
+hr_ :: [Attribute action] -> View parent model action
 hr_ = flip (nodeHtml "hr") []
 -----------------------------------------------------------------------------
 -- | [\<pre\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/pre)
-pre_ :: [Attribute action] -> [View model action] -> View model action
+pre_ :: [Attribute action] -> [View parent model action] -> View parent model action
 pre_ = nodeHtml "pre"
 -----------------------------------------------------------------------------
 -- | [\<input\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/input)
-input_ :: [Attribute action] -> View model action
+input_ :: [Attribute action] -> View parent model action
 input_ = flip (nodeHtml "input") []
 -----------------------------------------------------------------------------
 -- | [\<label\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/label)
-label_ :: [Attribute action] -> [View model action] -> View model action
+label_ :: [Attribute action] -> [View parent model action] -> View parent model action
 label_ = nodeHtml "label"
 -----------------------------------------------------------------------------
 -- | [\<a\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/a)
-a_ :: [Attribute action] -> [View model action] -> View model action
+a_ :: [Attribute action] -> [View parent model action] -> View parent model action
 a_ = nodeHtml "a"
 -----------------------------------------------------------------------------
 -- | [\<mark\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/mark)
-mark_ :: [Attribute action] -> [View model action] -> View model action
+mark_ :: [Attribute action] -> [View parent model action] -> View parent model action
 mark_ = nodeHtml "mark"
 -----------------------------------------------------------------------------
 -- | [\<ruby\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/ruby)
-ruby_ :: [Attribute action] -> [View model action] -> View model action
+ruby_ :: [Attribute action] -> [View parent model action] -> View parent model action
 ruby_ = nodeHtml "ruby"
 -----------------------------------------------------------------------------
 -- | [\<rt\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/rt)
-rt_ :: [Attribute action] -> [View model action] -> View model action
+rt_ :: [Attribute action] -> [View parent model action] -> View parent model action
 rt_ = nodeHtml "rt"
 -----------------------------------------------------------------------------
 -- | [\<rp\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/rp)
-rp_ :: [Attribute action] -> [View model action] -> View model action
+rp_ :: [Attribute action] -> [View parent model action] -> View parent model action
 rp_ = nodeHtml "rp"
 -----------------------------------------------------------------------------
 -- | [\<bdi\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/bdi)
-bdi_ :: [Attribute action] -> [View model action] -> View model action
+bdi_ :: [Attribute action] -> [View parent model action] -> View parent model action
 bdi_ = nodeHtml "bdi"
 -----------------------------------------------------------------------------
 -- | [\<bdo\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/bdo)
-bdo_ :: [Attribute action] -> [View model action] -> View model action
+bdo_ :: [Attribute action] -> [View parent model action] -> View parent model action
 bdo_ = nodeHtml "bdo"
 -----------------------------------------------------------------------------
 -- | [\<wbr\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/wbr)
-wbr_ :: [Attribute action] -> View model action
+wbr_ :: [Attribute action] -> View parent model action
 wbr_ = flip (nodeHtml "wbr") []
 -----------------------------------------------------------------------------
 -- | [\<details\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/details)
-details_ :: [Attribute action] -> [View model action] -> View model action
+details_ :: [Attribute action] -> [View parent model action] -> View parent model action
 details_ = nodeHtml "details"
 -----------------------------------------------------------------------------
 -- | [\<summary\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/summary)
-summary_ :: [Attribute action] -> [View model action] -> View model action
+summary_ :: [Attribute action] -> [View parent model action] -> View parent model action
 summary_ = nodeHtml "summary"
 -----------------------------------------------------------------------------
 -- | [\<menu\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/menu)
-menu_ :: [Attribute action] -> [View model action] -> View model action
+menu_ :: [Attribute action] -> [View parent model action] -> View parent model action
 menu_ = nodeHtml "menu"
 -----------------------------------------------------------------------------
 -- | [\<fieldset\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/fieldset)
-fieldset_ :: [Attribute action] -> [View model action] -> View model action
+fieldset_ :: [Attribute action] -> [View parent model action] -> View parent model action
 fieldset_ = nodeHtml "fieldset"
 -----------------------------------------------------------------------------
 -- | [\<legend\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/legend)
-legend_ :: [Attribute action] -> [View model action] -> View model action
+legend_ :: [Attribute action] -> [View parent model action] -> View parent model action
 legend_ = nodeHtml "legend"
 -----------------------------------------------------------------------------
 -- | [\<datalist\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/datalist)
-datalist_ :: [Attribute action] -> [View model action] -> View model action
+datalist_ :: [Attribute action] -> [View parent model action] -> View parent model action
 datalist_ = nodeHtml "datalist"
 -----------------------------------------------------------------------------
 -- | [\<optgroup\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/optgroup)
-optgroup_ :: [Attribute action] -> [View model action] -> View model action
+optgroup_ :: [Attribute action] -> [View parent model action] -> View parent model action
 optgroup_ = nodeHtml "optgroup"
 -----------------------------------------------------------------------------
 -- | [\<output\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/output)
-output_ :: [Attribute action] -> [View model action] -> View model action
+output_ :: [Attribute action] -> [View parent model action] -> View parent model action
 output_ = nodeHtml "output"
 -----------------------------------------------------------------------------
 -- | [\<progress\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/progress)
-progress_ :: [Attribute action] -> [View model action] -> View model action
+progress_ :: [Attribute action] -> [View parent model action] -> View parent model action
 progress_ = nodeHtml "progress"
 -----------------------------------------------------------------------------
 -- | [\<meter\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/meter)
-meter_ :: [Attribute action] -> [View model action] -> View model action
+meter_ :: [Attribute action] -> [View parent model action] -> View parent model action
 meter_ = nodeHtml "meter"
 -----------------------------------------------------------------------------
 -- | [\<audio\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/audio)
-audio_ :: [Attribute action] -> [View model action] -> View model action
+audio_ :: [Attribute action] -> [View parent model action] -> View parent model action
 audio_ = nodeHtml "audio"
 -----------------------------------------------------------------------------
 -- | [\<video\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/video)
-video_ :: [Attribute action] -> [View model action] -> View model action
+video_ :: [Attribute action] -> [View parent model action] -> View parent model action
 video_ = nodeHtml "video"
 -----------------------------------------------------------------------------
 -- | [\<source\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/source)
-source_ :: [Attribute action] -> View model action
+source_ :: [Attribute action] -> View parent model action
 source_ = flip (nodeHtml "source") []
 -----------------------------------------------------------------------------
 -- | [\<track\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/track)
-track_ :: [Attribute action] -> View model action
+track_ :: [Attribute action] -> View parent model action
 track_ = flip (nodeHtml "track") []
 -----------------------------------------------------------------------------
 -- | [\<embed\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/embed)
-embed_ :: [Attribute action] -> View model action
+embed_ :: [Attribute action] -> View parent model action
 embed_ = flip (nodeHtml "embed") []
 -----------------------------------------------------------------------------
 -- | [\<object\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/object)
-object_ :: [Attribute action] -> [View model action] -> View model action
+object_ :: [Attribute action] -> [View parent model action] -> View parent model action
 object_ = nodeHtml "object"
 -----------------------------------------------------------------------------
 -- | [\<ins\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/ins)
-ins_ :: [Attribute action] -> [View model action] -> View model action
+ins_ :: [Attribute action] -> [View parent model action] -> View parent model action
 ins_ = nodeHtml "ins"
 -----------------------------------------------------------------------------
 -- | [\<del\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/del)
-del_ :: [Attribute action] -> [View model action] -> View model action
+del_ :: [Attribute action] -> [View parent model action] -> View parent model action
 del_ = nodeHtml "del"
 -----------------------------------------------------------------------------
 -- | [\<small\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/small)
-small_ :: [Attribute action] -> [View model action] -> View model action
+small_ :: [Attribute action] -> [View parent model action] -> View parent model action
 small_ = nodeHtml "small"
 -----------------------------------------------------------------------------
 -- | [\<cite\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/cite)
-cite_ :: [Attribute action] -> [View model action] -> View model action
+cite_ :: [Attribute action] -> [View parent model action] -> View parent model action
 cite_ = nodeHtml "cite"
 -----------------------------------------------------------------------------
 -- | [\<dfn\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/dfn)
-dfn_ :: [Attribute action] -> [View model action] -> View model action
+dfn_ :: [Attribute action] -> [View parent model action] -> View parent model action
 dfn_ = nodeHtml "dfn"
 -----------------------------------------------------------------------------
 -- | [\<abbr\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/abbr)
-abbr_ :: [Attribute action] -> [View model action] -> View model action
+abbr_ :: [Attribute action] -> [View parent model action] -> View parent model action
 abbr_ = nodeHtml "abbr"
 -----------------------------------------------------------------------------
 -- | [\<time\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/time)
-time_ :: [Attribute action] -> [View model action] -> View model action
+time_ :: [Attribute action] -> [View parent model action] -> View parent model action
 time_ = nodeHtml "time"
 -----------------------------------------------------------------------------
 -- | [\<var\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/var)
-var_ :: [Attribute action] -> [View model action] -> View model action
+var_ :: [Attribute action] -> [View parent model action] -> View parent model action
 var_ = nodeHtml "var"
 -----------------------------------------------------------------------------
 -- | [\<samp\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/samp)
-samp_ :: [Attribute action] -> [View model action] -> View model action
+samp_ :: [Attribute action] -> [View parent model action] -> View parent model action
 samp_ = nodeHtml "samp"
 -----------------------------------------------------------------------------
 -- | [\<kbd\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/kbd)
-kbd_ :: [Attribute action] -> [View model action] -> View model action
+kbd_ :: [Attribute action] -> [View parent model action] -> View parent model action
 kbd_ = nodeHtml "kbd"
 -----------------------------------------------------------------------------
 -- | [\<caption\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/caption)
-caption_ :: [Attribute action] -> [View model action] -> View model action
+caption_ :: [Attribute action] -> [View parent model action] -> View parent model action
 caption_ = nodeHtml "caption"
 -----------------------------------------------------------------------------
 -- | [\<colgroup\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/colgroup)
-colgroup_ :: [Attribute action] -> [View model action] -> View model action
+colgroup_ :: [Attribute action] -> [View parent model action] -> View parent model action
 colgroup_ = nodeHtml "colgroup"
 -----------------------------------------------------------------------------
 -- | [\<col\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/col)
-col_ :: [Attribute action] -> View model action
+col_ :: [Attribute action] -> View parent model action
 col_ = flip (nodeHtml "col") []
 -----------------------------------------------------------------------------
 -- | [\<nav\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/nav)
-nav_ :: [Attribute action] -> [View model action] -> View model action
+nav_ :: [Attribute action] -> [View parent model action] -> View parent model action
 nav_ = nodeHtml "nav"
 -----------------------------------------------------------------------------
 -- | [\<article\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/article)
-article_ :: [Attribute action] -> [View model action] -> View model action
+article_ :: [Attribute action] -> [View parent model action] -> View parent model action
 article_ = nodeHtml "article"
 -----------------------------------------------------------------------------
 -- | [\<aside\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/aside)
-aside_ :: [Attribute action] -> [View model action] -> View model action
+aside_ :: [Attribute action] -> [View parent model action] -> View parent model action
 aside_ = nodeHtml "aside"
 -----------------------------------------------------------------------------
 -- | [\<address\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/address)
-address_ :: [Attribute action] -> [View model action] -> View model action
+address_ :: [Attribute action] -> [View parent model action] -> View parent model action
 address_ = nodeHtml "address"
 -----------------------------------------------------------------------------
 -- | [\<main\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/main)
-main_ :: [Attribute action] -> [View model action] -> View model action
+main_ :: [Attribute action] -> [View parent model action] -> View parent model action
 main_ = nodeHtml "main"
 -----------------------------------------------------------------------------
 -- | [\<body\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/body)
-body_ :: [Attribute action] -> [View model action] -> View model action
+body_ :: [Attribute action] -> [View parent model action] -> View parent model action
 body_ = nodeHtml "body"
 -----------------------------------------------------------------------------
 -- | [\<figure\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/figure)
-figure_ :: [Attribute action] -> [View model action] -> View model action
+figure_ :: [Attribute action] -> [View parent model action] -> View parent model action
 figure_ = nodeHtml "figure"
 -----------------------------------------------------------------------------
 -- | [\<figcaption\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/figcaption)
-figcaption_ :: [Attribute action] -> [View model action] -> View model action
+figcaption_ :: [Attribute action] -> [View parent model action] -> View parent model action
 figcaption_ = nodeHtml "figcaption"
 -----------------------------------------------------------------------------
 -- | [\<dl\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/dl)
-dl_ :: [Attribute action] -> [View model action] -> View model action
+dl_ :: [Attribute action] -> [View parent model action] -> View parent model action
 dl_ = nodeHtml "dl"
 -----------------------------------------------------------------------------
 -- | [\<dt\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/dt)
-dt_ :: [Attribute action] -> [View model action] -> View model action
+dt_ :: [Attribute action] -> [View parent model action] -> View parent model action
 dt_ = nodeHtml "dt"
 -----------------------------------------------------------------------------
 -- | [\<dd\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/dd)
-dd_ :: [Attribute action] -> [View model action] -> View model action
+dd_ :: [Attribute action] -> [View parent model action] -> View parent model action
 dd_ = nodeHtml "dd"
 -----------------------------------------------------------------------------
 -- | [\<img\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/img)
-img_ :: [Attribute action] -> View model action
+img_ :: [Attribute action] -> View parent model action
 img_ = flip (nodeHtml "img") []
 -----------------------------------------------------------------------------
 -- | [\<iframe\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/iframe)
-iframe_ :: [Attribute action] -> [View model action] -> View model action
+iframe_ :: [Attribute action] -> [View parent model action] -> View parent model action
 iframe_ = nodeHtml "iframe"
 -----------------------------------------------------------------------------
 -- | [\<canvas\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/canvas)
 --
 -- Note this just renders a canvas element.
 -- See also 'Miso.Canvas.canvas_' which supports canvas drawing DSL.
-canvas_ :: [Attribute action] -> [View model action] -> View model action
+canvas_ :: [Attribute action] -> [View parent model action] -> View parent model action
 canvas_ = nodeHtml "canvas"
 -----------------------------------------------------------------------------
 -- | [\<select\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/select)
-select_ :: [Attribute action] -> [View model action] -> View model action
+select_ :: [Attribute action] -> [View parent model action] -> View parent model action
 select_ = nodeHtml "select"
 -----------------------------------------------------------------------------
 -- | [\<option\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/option)
-option_ :: [Attribute action] -> [View model action] -> View model action
+option_ :: [Attribute action] -> [View parent model action] -> View parent model action
 option_ = nodeHtml "option"
 -----------------------------------------------------------------------------
 -- | [\<textarea\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/textarea)
@@ -509,7 +509,7 @@ option_ = nodeHtml "option"
 -- When compiling on the server, this combinator will render HTML as \<textarea\>text\<\/textarea\>.
 --
 -- @since 1.9.0.0
-textarea_ :: [Attribute action] -> View model action
+textarea_ :: [Attribute action] -> View parent model action
 #ifdef VANILLA
 textarea_ attrs = nodeHtml "textarea" newAttrs
   [ text x
@@ -523,51 +523,51 @@ textarea_ = flip (nodeHtml "textarea") []
 #endif
 -----------------------------------------------------------------------------
 -- | [\<sub\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/sub)
-sub_ :: [Attribute action] -> [View model action] -> View model action
+sub_ :: [Attribute action] -> [View parent model action] -> View parent model action
 sub_ = nodeHtml "sub"
 -----------------------------------------------------------------------------
 -- | [\<sup\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/sup)
-sup_ :: [Attribute action] -> [View model action] -> View model action
+sup_ :: [Attribute action] -> [View parent model action] -> View parent model action
 sup_ = nodeHtml "sup"
 -----------------------------------------------------------------------------
 -- | [\<br\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/br)
-br_ :: [Attribute action] -> View model action
+br_ :: [Attribute action] -> View parent model action
 br_ = flip (nodeHtml "br") []
 -----------------------------------------------------------------------------
 -- | [\<ol\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/ol)
-ol_ :: [Attribute action] -> [View model action] -> View model action
+ol_ :: [Attribute action] -> [View parent model action] -> View parent model action
 ol_ = nodeHtml "ol"
 -----------------------------------------------------------------------------
 -- | [\<blockquote\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/blockquote)
-blockquote_ :: [Attribute action] -> [View model action] -> View model action
+blockquote_ :: [Attribute action] -> [View parent model action] -> View parent model action
 blockquote_ = nodeHtml "blockquote"
 -----------------------------------------------------------------------------
 -- | [\<code\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/code)
-code_ :: [Attribute action] -> [View model action] -> View model action
+code_ :: [Attribute action] -> [View parent model action] -> View parent model action
 code_ = nodeHtml "code"
 -----------------------------------------------------------------------------
 -- | [\<em\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/em)
-em_ :: [Attribute action] -> [View model action] -> View model action
+em_ :: [Attribute action] -> [View parent model action] -> View parent model action
 em_ = nodeHtml "em"
 -----------------------------------------------------------------------------
 -- | [\<i\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/i)
-i_ :: [Attribute action] -> [View model action] -> View model action
+i_ :: [Attribute action] -> [View parent model action] -> View parent model action
 i_ = nodeHtml "i"
 -----------------------------------------------------------------------------
 -- | [\<b\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/b)
-b_ :: [Attribute action] -> [View model action] -> View model action
+b_ :: [Attribute action] -> [View parent model action] -> View parent model action
 b_ = nodeHtml "b"
 -----------------------------------------------------------------------------
 -- | [\<u\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/u)
-u_ :: [Attribute action] -> [View model action] -> View model action
+u_ :: [Attribute action] -> [View parent model action] -> View parent model action
 u_ = nodeHtml "u"
 -----------------------------------------------------------------------------
 -- | [\<q\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/q)
-q_ :: [Attribute action] -> [View model action] -> View model action
+q_ :: [Attribute action] -> [View parent model action] -> View parent model action
 q_ = nodeHtml "q"
 -----------------------------------------------------------------------------
 -- | [\<link\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/link)
-link_ :: [Attribute action] -> View model action
+link_ :: [Attribute action] -> View parent model action
 link_ = flip (nodeHtml "link") []
 -----------------------------------------------------------------------------
 -- | [\<style\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/style)
@@ -584,7 +584,7 @@ link_ = flip (nodeHtml "link") []
 -- @
 --
 -- You can use 'Miso.CSS.style_' as a safer anternative.
-style_ :: [Attribute action] -> MisoString -> View model action
+style_ :: [Attribute action] -> MisoString -> View parent model action
 style_ attrs rawText = node HTML "style" attrs [text rawText]
 -----------------------------------------------------------------------------
 -- | [\<script\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/script)
@@ -598,100 +598,100 @@ style_ attrs rawText = node HTML "style" attrs [text rawText]
 -- You can also easily shoot yourself in the foot with something like:
 --
 -- @'script_' [] "\</script\>"@
-script_ :: [Attribute action] -> MisoString -> View model action
+script_ :: [Attribute action] -> MisoString -> View parent model action
 script_ attrs rawText = node HTML "script" attrs [textRaw rawText]
 -----------------------------------------------------------------------------
 -- | [\<doctype\>](https://developer.mozilla.org/en-US/docs/Glossary/Doctype)
-doctype_ :: View model action
+doctype_ :: View parent model action
 doctype_ = nodeHtml "doctype" [] []
 -----------------------------------------------------------------------------
 -- | [\<html\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/html)
-html_ :: [Attribute action] -> [View model action] -> View model action
+html_ :: [Attribute action] -> [View parent model action] -> View parent model action
 html_ = nodeHtml "html"
 -----------------------------------------------------------------------------
 -- | [\<head\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/head)
-head_ :: [Attribute action] -> [View model action] -> View model action
+head_ :: [Attribute action] -> [View parent model action] -> View parent model action
 head_ = nodeHtml "head"
 -----------------------------------------------------------------------------
 -- | [\<meta\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/meta)
-meta_ :: [Attribute action] -> View model action
+meta_ :: [Attribute action] -> View parent model action
 meta_ = flip (nodeHtml "meta") []
 -----------------------------------------------------------------------------
 -- | [\<area\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/area)
 --
 -- @since 1.9.0.0
-area_ :: [Attribute action] -> View model action
+area_ :: [Attribute action] -> View parent model action
 area_ = flip (nodeHtml "area") []
 -----------------------------------------------------------------------------
 -- | [\<base\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/base)
 --
 -- @since 1.9.0.0
-base_ :: [Attribute action] -> View model action
+base_ :: [Attribute action] -> View parent model action
 base_ = flip (nodeHtml "base") []
 -----------------------------------------------------------------------------
 -- | [\<data\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/data)
 --
 -- @since 1.9.0.0
-data_ :: [Attribute action] -> [View model action] -> View model action
+data_ :: [Attribute action] -> [View parent model action] -> View parent model action
 data_ = nodeHtml "data"
 -----------------------------------------------------------------------------
 -- | [\<dialog\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/dialog)
 --
 -- @since 1.9.0.0
-dialog_ :: [Attribute action] -> [View model action] -> View model action
+dialog_ :: [Attribute action] -> [View parent model action] -> View parent model action
 dialog_ = nodeHtml "dialog"
 -----------------------------------------------------------------------------
 -- | [\<fencedframe\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/fencedframe)
 --
 -- @since 1.9.0.0
-fencedframe_ :: [Attribute action] -> [View model action] -> View model action
+fencedframe_ :: [Attribute action] -> [View parent model action] -> View parent model action
 fencedframe_ = nodeHtml "fencedframe"
 -----------------------------------------------------------------------------
 -- | [\<hgroup\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/hgroup)
 --
 -- @since 1.9.0.0
-hgroup_ :: [Attribute action] -> [View model action] -> View model action
+hgroup_ :: [Attribute action] -> [View parent model action] -> View parent model action
 hgroup_ = nodeHtml "hgroup"
 -----------------------------------------------------------------------------
 -- | [\<map\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/map)
 --
 -- @since 1.9.0.0
-map_ :: [Attribute action] -> [View model action] -> View model action
+map_ :: [Attribute action] -> [View parent model action] -> View parent model action
 map_ = nodeHtml "map"
 -----------------------------------------------------------------------------
 -- | [\<noscript\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/noscript)
 --
 -- @since 1.9.0.0
-noscript_ :: [Attribute action] -> [View model action] -> View model action
+noscript_ :: [Attribute action] -> [View parent model action] -> View parent model action
 noscript_ = nodeHtml "noscript"
 -----------------------------------------------------------------------------
 -- | [\<picture\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/picture)
 --
 -- @since 1.9.0.0
-picture_ :: [Attribute action] -> [View model action] -> View model action
+picture_ :: [Attribute action] -> [View parent model action] -> View parent model action
 picture_ = nodeHtml "picture"
 -----------------------------------------------------------------------------
 -- | [\<search\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/search)
 --
 -- @since 1.9.0.0
-search_ :: [Attribute action] -> [View model action] -> View model action
+search_ :: [Attribute action] -> [View parent model action] -> View parent model action
 search_ = nodeHtml "search"
 -----------------------------------------------------------------------------
 -- | [\<slot\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/slot)
 --
 -- @since 1.9.0.0
-slot_ :: [Attribute action] -> [View model action] -> View model action
+slot_ :: [Attribute action] -> [View parent model action] -> View parent model action
 slot_ = nodeHtml "slot"
 -----------------------------------------------------------------------------
 -- | [\<template\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/template)
 --
 -- @since 1.9.0.0
-template_ :: [Attribute action] -> [View model action] -> View model action
+template_ :: [Attribute action] -> [View parent model action] -> View parent model action
 template_ = nodeHtml "template"
 -----------------------------------------------------------------------------
 -- | [\<title\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/title)
 --
 -- @since 1.9.0.0
-title_ :: [Attribute action] -> [View model action] -> View model action
+title_ :: [Attribute action] -> [View parent model action] -> View parent model action
 title_ = nodeHtml "title"
 -----------------------------------------------------------------------------

--- a/src/Miso/Html/Render.hs
+++ b/src/Miso/Html/Render.hs
@@ -44,14 +44,14 @@ class ToHtml a where
   toHtml :: a -> L.ByteString
 ----------------------------------------------------------------------------
 -- | Render a @Miso.Types.View@ to a @L.ByteString@
-instance ToHtml (Miso.Types.View m a) where
+instance ToHtml (View p m a) where
   toHtml = renderView
 ----------------------------------------------------------------------------
 -- | Render a @[Miso.Types.View]@ to a @L.ByteString@
-instance ToHtml [Miso.Types.View m a] where
+instance ToHtml [View p m a] where
   toHtml = foldMap renderView
 ----------------------------------------------------------------------------
-renderView :: View m a -> L.ByteString
+renderView :: View p m a -> L.ByteString
 renderView = toLazyByteString . renderBuilder
 ----------------------------------------------------------------------------
 intercalate :: Builder -> [Builder] -> Builder
@@ -97,7 +97,9 @@ booleanProperties = S.fromList
   , "truespeed"
   ]
 ----------------------------------------------------------------------------
-renderBuilder :: Miso.Types.View m a -> Builder
+renderBuilder :: View p m a -> Builder
+renderBuilder (VProp _ _) =
+  error "todo implement"
 renderBuilder (VText _ "")    = fromMisoString " "
 renderBuilder (VText _ s)     = fromMisoString s
 renderBuilder (VNode _ "doctype" [] []) = "<!doctype html>"
@@ -185,7 +187,7 @@ renderAttrs (Styles styles) =
 -- | The browser can't distinguish between multiple text nodes
 -- and a single text node. So it will always parse a single text node
 -- this means we must collapse adjacent text nodes during hydration.
-collapseSiblingTextNodes :: [View m a] -> [View m a]
+collapseSiblingTextNodes :: [View p m a] -> [View p m a]
 collapseSiblingTextNodes [] = []
 collapseSiblingTextNodes (VText _ x : VText k y : xs) =
   collapseSiblingTextNodes (VText k (x <> y) : xs)

--- a/src/Miso/Mathml/Element.hs
+++ b/src/Miso/Mathml/Element.hs
@@ -49,186 +49,186 @@ import           Miso.Types
 -----------------------------------------------------------------------------
 -- | Low-level helper used to construct 'MATHML' 'node' in 'Miso.Types.View'.
 -- Most View helpers in this module are defined in terms of it.
-nodeMathml :: MisoString -> [Attribute action] -> [View model action] -> View model action
+nodeMathml :: MisoString -> [Attribute action] -> [View parent model action] -> View parent model action
 nodeMathml nodeName = node MATHML nodeName
 -----------------------------------------------------------------------------
 -- | [\<annotation-xml\>](https://developer.mozilla.org/en-US/docs/Web/MathML/Reference/Element/annotation-xml)
 --
 -- @since 1.9.0.0
-annotationXml_ :: [Attribute action] -> [View model action] -> View model action
+annotationXml_ :: [Attribute action] -> [View parent model action] -> View parent model action
 annotationXml_ = nodeMathml "annotation-xml"
 -----------------------------------------------------------------------------
 -- | [\<annotation\>](https://developer.mozilla.org/en-US/docs/Web/MathML/Reference/Element/annotation)
 --
 -- @since 1.9.0.0
-annotation_ :: [Attribute action] -> [View model action] -> View model action
+annotation_ :: [Attribute action] -> [View parent model action] -> View parent model action
 annotation_ = nodeMathml "annotation"
 -----------------------------------------------------------------------------
 -- | [\<math\>](https://developer.mozilla.org/en-US/docs/Web/MathML/Reference/Element/math)
 --
 -- @since 1.9.0.0
-math_ :: [Attribute action] -> [View model action] -> View model action
+math_ :: [Attribute action] -> [View parent model action] -> View parent model action
 math_ = nodeMathml "math"
 -----------------------------------------------------------------------------
 -- | [\<merror\>](https://developer.mozilla.org/en-US/docs/Web/MathML/Reference/Element/merror)
 --
 -- @since 1.9.0.0
-merror_ :: [Attribute action] -> [View model action] -> View model action
+merror_ :: [Attribute action] -> [View parent model action] -> View parent model action
 merror_ = nodeMathml "merror"
 -----------------------------------------------------------------------------
 -- | [\<mfrac\>](https://developer.mozilla.org/en-US/docs/Web/MathML/Reference/Element/mfrac)
 --
 -- @since 1.9.0.0
-mfrac_ :: [Attribute action] -> [View model action] -> View model action
+mfrac_ :: [Attribute action] -> [View parent model action] -> View parent model action
 mfrac_ = nodeMathml "mfrac"
 -----------------------------------------------------------------------------
 -- | [\<mi\>](https://developer.mozilla.org/en-US/docs/Web/MathML/Reference/Element/mi)
 --
 -- @since 1.9.0.0
-mi_ :: [Attribute action] -> [View model action] -> View model action
+mi_ :: [Attribute action] -> [View parent model action] -> View parent model action
 mi_ = nodeMathml "mi"
 -----------------------------------------------------------------------------
 -- | [\<mmultiscripts\>](https://developer.mozilla.org/en-US/docs/Web/MathML/Reference/Element/mmultiscripts)
 --
 -- @since 1.9.0.0
-mmultiscripts_ :: [Attribute action] -> [View model action] -> View model action
+mmultiscripts_ :: [Attribute action] -> [View parent model action] -> View parent model action
 mmultiscripts_ = nodeMathml "mmultiscripts"
 -----------------------------------------------------------------------------
 -- | [\<mn\>](https://developer.mozilla.org/en-US/docs/Web/MathML/Reference/Element/mn)
 --
 -- @since 1.9.0.0
-mn_ :: [Attribute action] -> [View model action] -> View model action
+mn_ :: [Attribute action] -> [View parent model action] -> View parent model action
 mn_ = nodeMathml "mn"
 -----------------------------------------------------------------------------
 -- | [\<mo\>](https://developer.mozilla.org/en-US/docs/Web/MathML/Reference/Element/mo)
 --
 -- @since 1.9.0.0
-mo_ :: [Attribute action] -> [View model action] -> View model action
+mo_ :: [Attribute action] -> [View parent model action] -> View parent model action
 mo_ = nodeMathml "mo"
 -----------------------------------------------------------------------------
 -- | [\<mover\>](https://developer.mozilla.org/en-US/docs/Web/MathML/Reference/Element/mover)
 --
 -- @since 1.9.0.0
-mover_ :: [Attribute action] -> [View model action] -> View model action
+mover_ :: [Attribute action] -> [View parent model action] -> View parent model action
 mover_ = nodeMathml "mover"
 -----------------------------------------------------------------------------
 -- | [\<mpadded\>](https://developer.mozilla.org/en-US/docs/Web/MathML/Reference/Element/mpadded)
 --
 -- @since 1.9.0.0
-mpadded_ :: [Attribute action] -> [View model action] -> View model action
+mpadded_ :: [Attribute action] -> [View parent model action] -> View parent model action
 mpadded_ = nodeMathml "mpadded"
 -----------------------------------------------------------------------------
 -- | [\<mphantom\>](https://developer.mozilla.org/en-US/docs/Web/MathML/Reference/Element/mphantom)
 --
 -- @since 1.9.0.0
-mphantom_ :: [Attribute action] -> [View model action] -> View model action
+mphantom_ :: [Attribute action] -> [View parent model action] -> View parent model action
 mphantom_ = nodeMathml "mphantom"
 -----------------------------------------------------------------------------
 -- | [\<mprescripts\>](https://developer.mozilla.org/en-US/docs/Web/MathML/Reference/Element/mprescripts)
 --
 -- @since 1.9.0.0
-mprescripts_ :: [Attribute action] -> [View model action] -> View model action
+mprescripts_ :: [Attribute action] -> [View parent model action] -> View parent model action
 mprescripts_ = nodeMathml "mprescripts"
 -----------------------------------------------------------------------------
 -- | [\<mroot\>](https://developer.mozilla.org/en-US/docs/Web/MathML/Reference/Element/mroot)
 --
 -- @since 1.9.0.0
-mroot_ :: [Attribute action] -> [View model action] -> View model action
+mroot_ :: [Attribute action] -> [View parent model action] -> View parent model action
 mroot_ = nodeMathml "mroot"
 -----------------------------------------------------------------------------
 -- | [\<mrow\>](https://developer.mozilla.org/en-US/docs/Web/MathML/Reference/Element/mrow)
 --
 -- @since 1.9.0.0
-mrow_ :: [Attribute action] -> [View model action] -> View model action
+mrow_ :: [Attribute action] -> [View parent model action] -> View parent model action
 mrow_ = nodeMathml "mrow"
 -----------------------------------------------------------------------------
 -- | [\<ms\>](https://developer.mozilla.org/en-US/docs/Web/MathML/Reference/Element/ms)
 --
 -- @since 1.9.0.0
-ms_ :: [Attribute action] -> [View model action] -> View model action
+ms_ :: [Attribute action] -> [View parent model action] -> View parent model action
 ms_ = nodeMathml "ms"
 -----------------------------------------------------------------------------
 -- | [\<mspace\>](https://developer.mozilla.org/en-US/docs/Web/MathML/Reference/Element/mspace)
 --
 -- @since 1.9.0.0
-mspace_ :: [Attribute action] -> [View model action] -> View model action
+mspace_ :: [Attribute action] -> [View parent model action] -> View parent model action
 mspace_ = nodeMathml "mspace"
 -----------------------------------------------------------------------------
 -- | [\<msqrt\>](https://developer.mozilla.org/en-US/docs/Web/MathML/Reference/Element/msqrt)
 --
 -- @since 1.9.0.0
-msqrt_ :: [Attribute action] -> [View model action] -> View model action
+msqrt_ :: [Attribute action] -> [View parent model action] -> View parent model action
 msqrt_ = nodeMathml "msqrt"
 -----------------------------------------------------------------------------
 -- | [\<mstyle\>](https://developer.mozilla.org/en-US/docs/Web/MathML/Reference/Element/mstyle)
 --
 -- @since 1.9.0.0
-mstyle_ :: [Attribute action] -> [View model action] -> View model action
+mstyle_ :: [Attribute action] -> [View parent model action] -> View parent model action
 mstyle_ = nodeMathml "mstyle"
 -----------------------------------------------------------------------------
 -- | [\<msub\>](https://developer.mozilla.org/en-US/docs/Web/MathML/Reference/Element/msub)
 --
 -- @since 1.9.0.0
-msub_ :: [Attribute action] -> [View model action] -> View model action
+msub_ :: [Attribute action] -> [View parent model action] -> View parent model action
 msub_ = nodeMathml "msub"
 -----------------------------------------------------------------------------
 -- | [\<msubsup\>](https://developer.mozilla.org/en-US/docs/Web/MathML/Reference/Element/msubsup)
 --
 -- @since 1.9.0.0
-msubsup_ :: [Attribute action] -> [View model action] -> View model action
+msubsup_ :: [Attribute action] -> [View parent model action] -> View parent model action
 msubsup_ = nodeMathml "msubsup"
 -----------------------------------------------------------------------------
 -- | [\<msup\>](https://developer.mozilla.org/en-US/docs/Web/MathML/Reference/Element/msup)
 --
 -- @since 1.9.0.0
-msup_ :: [Attribute action] -> [View model action] -> View model action
+msup_ :: [Attribute action] -> [View parent model action] -> View parent model action
 msup_ = nodeMathml "msup"
 -----------------------------------------------------------------------------
 -- | [\<mtable\>](https://developer.mozilla.org/en-US/docs/Web/MathML/Reference/Element/mtable)
 --
 -- @since 1.9.0.0
-mtable_ :: [Attribute action] -> [View model action] -> View model action
+mtable_ :: [Attribute action] -> [View parent model action] -> View parent model action
 mtable_ = nodeMathml "mtable"
 -----------------------------------------------------------------------------
 -- | [\<mtd\>](https://developer.mozilla.org/en-US/docs/Web/MathML/Reference/Element/mtd)
 --
 -- @since 1.9.0.0
-mtd_ :: [Attribute action] -> [View model action] -> View model action
+mtd_ :: [Attribute action] -> [View parent model action] -> View parent model action
 mtd_ = nodeMathml "mtd"
 -----------------------------------------------------------------------------
 -- | [\<mtext\>](https://developer.mozilla.org/en-US/docs/Web/MathML/Reference/Element/mtext)
 --
 -- @since 1.9.0.0
-mtext_ :: [Attribute action] -> [View model action] -> View model action
+mtext_ :: [Attribute action] -> [View parent model action] -> View parent model action
 mtext_ = nodeMathml "mtext"
 -----------------------------------------------------------------------------
 -- | [\<mtr\>](https://developer.mozilla.org/en-US/docs/Web/MathML/Reference/Element/mtr)
 --
 -- @since 1.9.0.0
-mtr_ :: [Attribute action] -> [View model action] -> View model action
+mtr_ :: [Attribute action] -> [View parent model action] -> View parent model action
 mtr_ = nodeMathml "mtr"
 -----------------------------------------------------------------------------
 -- | [\<munder\>](https://developer.mozilla.org/en-US/docs/Web/MathML/Reference/Element/munder)
 --
 -- @since 1.9.0.0
-munder_ :: [Attribute action] -> [View model action] -> View model action
+munder_ :: [Attribute action] -> [View parent model action] -> View parent model action
 munder_ = nodeMathml "munder"
 -----------------------------------------------------------------------------
 -- | [\<munderover\>](https://developer.mozilla.org/en-US/docs/Web/MathML/Reference/Element/munderover)
 --
 -- @since 1.9.0.0
-munderover_ :: [Attribute action] -> [View model action] -> View model action
+munderover_ :: [Attribute action] -> [View parent model action] -> View parent model action
 munderover_ = nodeMathml "munderover"
 -----------------------------------------------------------------------------
 -- | [\<semantics\>](https://developer.mozilla.org/en-US/docs/Web/MathML/Reference/Element/semantics)
 --
 -- @since 1.9.0.0
-semantics_ :: [Attribute action] -> [View model action] -> View model action
+semantics_ :: [Attribute action] -> [View parent model action] -> View parent model action
 semantics_ = nodeMathml "semantics"
 -----------------------------------------------------------------------------
 -- | [\<semantics\>](https://developer.mozilla.org/en-US/docs/Web/MathML/Reference/Element/mfenced)
 --
 -- @since 1.9.0.0
-mfenced_ :: [Attribute action] -> [View model action] -> View model action
+mfenced_ :: [Attribute action] -> [View parent model action] -> View parent model action
 mfenced_ = nodeMathml "mfenced"
 -----------------------------------------------------------------------------

--- a/src/Miso/Runtime.hs
+++ b/src/Miso/Runtime.hs
@@ -286,14 +286,23 @@ scheduler =
           evalScheduled Async (action _componentSink)
         Schedule Sync action ->
           evalScheduled Sync (action _componentSink)
-      if _componentModelDirty _componentModel updatedModel || _componentUseProps
+
+      childrenToRender <- IS.unions <$> do
+        forM (IS.toList _componentChildren) $ \childId -> do
+          IM.lookup childId <$> readIORef components >>= \case
+            Just child | Miso.Runtime._componentUseProps child -> do
+                           modifyComponent childId (isDirty .= True)
+                           pure (IS.singleton childId)
+            _ -> pure mempty
+
+      if _componentModelDirty _componentModel updatedModel
         then do
           modifyComponent _componentId $ do
             isDirty .= True
             componentModel .= updatedModel
-          pure dirtySet
+          pure (dirtySet <> childrenToRender)
         else
-          pure mempty
+          pure childrenToRender
     -----------------------------------------------------------------------------
     -- | Perform a top-down rendering of the 'Component' tree.
     --

--- a/src/Miso/Runtime.hs
+++ b/src/Miso/Runtime.hs
@@ -222,6 +222,7 @@ initialize events _componentParentId hydrate isRoot comp@Component {..} getCompo
         , _componentTopics = mempty
         , _componentModelDirty = modelCheck
         , _componentChildren = mempty
+        , _componentUseProps = useProps
         , ..
         }
 
@@ -285,7 +286,7 @@ scheduler =
           evalScheduled Async (action _componentSink)
         Schedule Sync action ->
           evalScheduled Sync (action _componentSink)
-      if _componentModelDirty _componentModel updatedModel
+      if _componentModelDirty _componentModel updatedModel || _componentUseProps
         then do
           modifyComponent _componentId $ do
             isDirty .= True
@@ -655,6 +656,7 @@ data ComponentState parent model action
   , _componentTopics :: Map MisoString (Value -> IO ())
   -- ^ t'Miso.Types.Component' topics using for Pub Sub async communication.
   , _componentChildren :: ComponentIds
+  , _componentUseProps :: Bool
   }
 -----------------------------------------------------------------------------
 -- | A @Topic@ represents a place to send and receive messages. @Topic@ is used to facilitate
@@ -985,7 +987,7 @@ buildVTree
   -> Hydrate
   -> Sink action
   -> LogLevel
-  -> View model action
+  -> View parent model action
   -> IO VTree
 buildVTree events_ parentId_ vcompId hydrate snk logLevel_ = \case
   VComp maybeKey (SomeComponent app) -> do
@@ -1044,6 +1046,10 @@ buildVTree events_ parentId_ vcompId hydrate snk logLevel_ = \case
     FFI.set "ns" ("text" :: MisoString) vtree
     FFI.set "text" t vtree
     pure (VTree vtree)
+  VProp getParentField display -> do
+    ComponentState {..} <- (IM.! parentId_) <$> readIORef components
+    buildVTree events_ parentId_ vcompId hydrate snk logLevel_ $
+      display (getParentField _componentModel)
 -----------------------------------------------------------------------------
 -- | @createNode@
 -- A helper function for constructing a vtree (used for @vcomp@ and @vnode@)

--- a/src/Miso/Svg/Element.hs
+++ b/src/Miso/Svg/Element.hs
@@ -90,258 +90,258 @@ import           Miso.Types  hiding (text_)
 --
 -- > document.createElementNS('http://www.w3.org/2000/svg', 'circle');
 --
-nodeSvg :: MisoString -> [Attribute action] -> [View model action] -> View model action
+nodeSvg :: MisoString -> [Attribute action] -> [View parent model action] -> View parent model action
 nodeSvg nodeName = node SVG nodeName
 -----------------------------------------------------------------------------
 -- | [\<svg\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/svg)
-svg_ :: [Attribute action] -> [View model action] -> View model action
+svg_ :: [Attribute action] -> [View parent model action] -> View parent model action
 svg_ = nodeSvg "svg"
 -----------------------------------------------------------------------------
 -- | [\<foreignObject\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/foreignObject)
-foreignObject_ :: [Attribute action] -> [View model action] -> View model action
+foreignObject_ :: [Attribute action] -> [View parent model action] -> View parent model action
 foreignObject_ = nodeSvg "foreignObject"
 -----------------------------------------------------------------------------
 -- | [\<circle\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/circle)
-circle_ :: [Attribute action] -> View model action
+circle_ :: [Attribute action] -> View parent model action
 circle_ = flip (nodeSvg "circle") []
 -----------------------------------------------------------------------------
 -- | [\<ellipse\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/ellipse)
-ellipse_ :: [Attribute action] -> View model action
+ellipse_ :: [Attribute action] -> View parent model action
 ellipse_ = flip (nodeSvg "ellipse") []
 -----------------------------------------------------------------------------
 -- | [\<image\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/image)
-image_ :: [Attribute action] -> View model action
+image_ :: [Attribute action] -> View parent model action
 image_ = flip (nodeSvg "image") []
 -----------------------------------------------------------------------------
 -- | [\<line\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/line)
-line_ :: [Attribute action] -> View model action
+line_ :: [Attribute action] -> View parent model action
 line_ = flip (nodeSvg "line") []
 -----------------------------------------------------------------------------
 -- | [\<path\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/path)
-path_ :: [Attribute action] -> View model action
+path_ :: [Attribute action] -> View parent model action
 path_ = flip (nodeSvg "path") []
 -----------------------------------------------------------------------------
 -- | [\<polygon\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/polygon)
-polygon_ :: [Attribute action] -> View model action
+polygon_ :: [Attribute action] -> View parent model action
 polygon_ = flip (nodeSvg "polygon") []
 -----------------------------------------------------------------------------
 -- | [\<polyline\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/polyline)
-polyline_ :: [Attribute action] -> View model action
+polyline_ :: [Attribute action] -> View parent model action
 polyline_ = flip (nodeSvg "polyline") []
 -----------------------------------------------------------------------------
 -- | [\<rect\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/rect)
-rect_ :: [Attribute action] -> View model action
+rect_ :: [Attribute action] -> View parent model action
 rect_ = flip (nodeSvg "rect") []
 -----------------------------------------------------------------------------
 -- | [\<use\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/use)
-use_ :: [Attribute action] -> View model action
+use_ :: [Attribute action] -> View parent model action
 use_ = flip (nodeSvg "use") []
 -----------------------------------------------------------------------------
 -- | [\<animate\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/animate)
-animate_ :: [Attribute action] -> View model action
+animate_ :: [Attribute action] -> View parent model action
 animate_ = flip (nodeSvg "animate") []
 -----------------------------------------------------------------------------
 -- | [\<animateMotion\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/animateMotion)
-animateMotion_ :: [Attribute action] -> View model action
+animateMotion_ :: [Attribute action] -> View parent model action
 animateMotion_ = flip (nodeSvg "animateMotion") []
 -----------------------------------------------------------------------------
 -- | [\<animateTransform\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/animateTransform)
-animateTransform_ :: [Attribute action] -> View model action
+animateTransform_ :: [Attribute action] -> View parent model action
 animateTransform_ = flip (nodeSvg "animateTransform") []
 -----------------------------------------------------------------------------
 -- | [\<mpath\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/mpath)
-mpath_ :: [Attribute action] -> View model action
+mpath_ :: [Attribute action] -> View parent model action
 mpath_ = flip (nodeSvg "mpath") []
 -----------------------------------------------------------------------------
 -- | [\<set\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/set)
-set_ :: [Attribute action] -> View model action
+set_ :: [Attribute action] -> View parent model action
 set_ = flip (nodeSvg "set") []
 -----------------------------------------------------------------------------
 -- | [\<desc\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/desc)
-desc_ :: [Attribute action] -> [View model action] -> View model action
+desc_ :: [Attribute action] -> [View parent model action] -> View parent model action
 desc_ = nodeSvg "desc"
 -----------------------------------------------------------------------------
 -- | [\<metadata\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/metadata)
-metadata_ :: [Attribute action] -> [View model action] -> View model action
+metadata_ :: [Attribute action] -> [View parent model action] -> View parent model action
 metadata_ = nodeSvg "metadata"
 -----------------------------------------------------------------------------
 -- | [\<title\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/title)
-title_ :: [Attribute action] -> [View model action] -> View model action
+title_ :: [Attribute action] -> [View parent model action] -> View parent model action
 title_ = nodeSvg "title"
 -----------------------------------------------------------------------------
 -- | [\<defs\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/defs)
-defs_ :: [Attribute action] -> [View model action] -> View model action
+defs_ :: [Attribute action] -> [View parent model action] -> View parent model action
 defs_ = nodeSvg "defs"
 -----------------------------------------------------------------------------
 -- | [\<g\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/g)
-g_ :: [Attribute action] -> [View model action] -> View model action
+g_ :: [Attribute action] -> [View parent model action] -> View parent model action
 g_ = nodeSvg "g"
 -----------------------------------------------------------------------------
 -- | [\<marker\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/marker)
-marker_ :: [Attribute action] -> [View model action] -> View model action
+marker_ :: [Attribute action] -> [View parent model action] -> View parent model action
 marker_ = nodeSvg "marker"
 -----------------------------------------------------------------------------
 -- | [\<mask\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/mask)
-mask_ :: [Attribute action] -> [View model action] -> View model action
+mask_ :: [Attribute action] -> [View parent model action] -> View parent model action
 mask_ = nodeSvg "mask"
 -----------------------------------------------------------------------------
 -- | [\<pattern\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/pattern)
-pattern_ :: [Attribute action] -> [View model action] -> View model action
+pattern_ :: [Attribute action] -> [View parent model action] -> View parent model action
 pattern_ = nodeSvg "pattern"
 -----------------------------------------------------------------------------
 -- | [\<switch\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/switch)
-switch_ :: [Attribute action] -> [View model action] -> View model action
+switch_ :: [Attribute action] -> [View parent model action] -> View parent model action
 switch_ = nodeSvg "switch"
 -----------------------------------------------------------------------------
 -- | [\<symbol\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/symbol)
-symbol_ :: [Attribute action] -> [View model action] -> View model action
+symbol_ :: [Attribute action] -> [View parent model action] -> View parent model action
 symbol_ = nodeSvg "symbol"
 -----------------------------------------------------------------------------
 -- | [\<textPath\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/textPath)
-textPath_ :: [Attribute action] -> [View model action] -> View model action
+textPath_ :: [Attribute action] -> [View parent model action] -> View parent model action
 textPath_ = nodeSvg "textPath"
 -----------------------------------------------------------------------------
 -- | [\<text\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/text)
-text_ :: [Attribute action] -> [View model action] -> View model action
+text_ :: [Attribute action] -> [View parent model action] -> View parent model action
 text_ = nodeSvg "text"
 -----------------------------------------------------------------------------
 -- | [\<tspan\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/tspan)
-tspan_ :: [Attribute action] -> [View model action] -> View model action
+tspan_ :: [Attribute action] -> [View parent model action] -> View parent model action
 tspan_ = nodeSvg "tspan"
 -----------------------------------------------------------------------------
 -- | [\<linearGradient\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/linearGradient)
-linearGradient_ :: [Attribute action] -> [View model action] -> View model action
+linearGradient_ :: [Attribute action] -> [View parent model action] -> View parent model action
 linearGradient_ = nodeSvg "linearGradient"
 -----------------------------------------------------------------------------
 -- | [\<radialGradient\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/radialGradient)
-radialGradient_ :: [Attribute action] -> [View model action] -> View model action
+radialGradient_ :: [Attribute action] -> [View parent model action] -> View parent model action
 radialGradient_ = nodeSvg "radialGradient"
 -----------------------------------------------------------------------------
 -- | [\<stop\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/stop)
-stop_ :: [Attribute action] -> View model action
+stop_ :: [Attribute action] -> View parent model action
 stop_ = flip (nodeSvg "stop") []
 -----------------------------------------------------------------------------
 -- | [\<feBlend\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/feBlend)
-feBlend_ :: [Attribute action] -> View model action
+feBlend_ :: [Attribute action] -> View parent model action
 feBlend_ = flip (nodeSvg "feBlend") []
 -----------------------------------------------------------------------------
 -- | [\<feColorMatrix\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/feColorMatrix)
-feColorMatrix_ :: [Attribute action] -> View model action
+feColorMatrix_ :: [Attribute action] -> View parent model action
 feColorMatrix_ = flip (nodeSvg "feColorMatrix") []
 -----------------------------------------------------------------------------
 -- | [\<feComponentTransfer\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/feComponentTransfer)
-feComponentTransfer_ :: [Attribute action] -> [View model action] -> View model action
+feComponentTransfer_ :: [Attribute action] -> [View parent model action] -> View parent model action
 feComponentTransfer_ = nodeSvg "feComponentTransfer"
 -----------------------------------------------------------------------------
 -- | [\<feComposite\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/feComposite)
-feComposite_ :: [Attribute action] -> View model action
+feComposite_ :: [Attribute action] -> View parent model action
 feComposite_ = flip (nodeSvg "feComposite") []
 -----------------------------------------------------------------------------
 -- | [\<feConvolveMatrix\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/feConvolveMatrix)
-feConvolveMatrix_ :: [Attribute action] -> View model action
+feConvolveMatrix_ :: [Attribute action] -> View parent model action
 feConvolveMatrix_ = flip (nodeSvg "feConvolveMatrix") []
 -----------------------------------------------------------------------------
 -- | [\<feDiffuseLighting\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/feDiffuseLighting)
-feDiffuseLighting_ :: [Attribute action] -> [View model action] -> View model action
+feDiffuseLighting_ :: [Attribute action] -> [View parent model action] -> View parent model action
 feDiffuseLighting_ = nodeSvg "feDiffuseLighting"
 -----------------------------------------------------------------------------
 -- | [\<feDisplacementMap\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/feDisplacementMap)
-feDisplacementMap_ :: [Attribute action] -> View model action
+feDisplacementMap_ :: [Attribute action] -> View parent model action
 feDisplacementMap_ = flip (nodeSvg "feDisplacementMap") []
 -----------------------------------------------------------------------------
 -- | [\<feDropShadow\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/feDropShadow)
 --
 -- @since 1.9.0.0
-feDropShadow_ :: [Attribute action] -> View model action
+feDropShadow_ :: [Attribute action] -> View parent model action
 feDropShadow_ = flip (nodeSvg "feDropShadow") []
 -----------------------------------------------------------------------------
 -- | [\<feFlood\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/feFlood)
-feFlood_ :: [Attribute action] -> View model action
+feFlood_ :: [Attribute action] -> View parent model action
 feFlood_ = flip (nodeSvg "feFlood") []
 -----------------------------------------------------------------------------
 -- | [\<feFuncA\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/feFuncA)
-feFuncA_ :: [Attribute action] -> [View model action] -> View model action
+feFuncA_ :: [Attribute action] -> [View parent model action] -> View parent model action
 feFuncA_ = nodeSvg "feFuncA"
 -----------------------------------------------------------------------------
 -- | [\<feFuncB\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/feFuncB)
-feFuncB_ :: [Attribute action] -> [View model action] -> View model action
+feFuncB_ :: [Attribute action] -> [View parent model action] -> View parent model action
 feFuncB_ = nodeSvg "feFuncB"
 -----------------------------------------------------------------------------
 -- | [\<feFuncG\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/feFuncG)
-feFuncG_ :: [Attribute action] -> [View model action] -> View model action
+feFuncG_ :: [Attribute action] -> [View parent model action] -> View parent model action
 feFuncG_ = nodeSvg "feFuncG"
 -----------------------------------------------------------------------------
 -- | [\<feFuncR\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/feFuncR)
-feFuncR_ :: [Attribute action] -> [View model action] -> View model action
+feFuncR_ :: [Attribute action] -> [View parent model action] -> View parent model action
 feFuncR_ = nodeSvg "feFuncR"
 -----------------------------------------------------------------------------
 -- | [\<feGaussianBlur\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/feGaussianBlur)
-feGaussianBlur_ :: [Attribute action] -> View model action
+feGaussianBlur_ :: [Attribute action] -> View parent model action
 feGaussianBlur_ = flip (nodeSvg "feGaussianBlur") []
 -----------------------------------------------------------------------------
 -- | [\<feImage\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/feImage)
-feImage_ :: [Attribute action] -> View model action
+feImage_ :: [Attribute action] -> View parent model action
 feImage_ = flip (nodeSvg "feImage") []
 -----------------------------------------------------------------------------
 -- | [\<feMerge\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/feMerge)
-feMerge_ :: [Attribute action] -> [View model action] -> View model action
+feMerge_ :: [Attribute action] -> [View parent model action] -> View parent model action
 feMerge_ = nodeSvg "feMerge"
 -----------------------------------------------------------------------------
 -- | [\<feMergeNode\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/feMergeNode)
-feMergeNode_ :: [Attribute action] -> View model action
+feMergeNode_ :: [Attribute action] -> View parent model action
 feMergeNode_ = flip (nodeSvg "feMergeNode") []
 -----------------------------------------------------------------------------
 -- | [\<feMorphology\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/feMorphology)
 --
 -- @since 1.9.0.0
-feMorphology_ :: [Attribute action] -> View model action
+feMorphology_ :: [Attribute action] -> View parent model action
 feMorphology_ = flip (nodeSvg "feMorphology") []
 -----------------------------------------------------------------------------
 -- | [\<feOffset\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/feOffset)
-feOffset_ :: [Attribute action] -> View model action
+feOffset_ :: [Attribute action] -> View parent model action
 feOffset_ = flip (nodeSvg "feOffset") []
 -----------------------------------------------------------------------------
 -- | [\<feSpecularLighting\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/feSpecularLighting)
-feSpecularLighting_ :: [Attribute action] -> [View model action] -> View model action
+feSpecularLighting_ :: [Attribute action] -> [View parent model action] -> View parent model action
 feSpecularLighting_ = nodeSvg "feSpecularLighting"
 -----------------------------------------------------------------------------
 -- | [\<feTile\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/feTile)
-feTile_ :: [Attribute action] -> View model action
+feTile_ :: [Attribute action] -> View parent model action
 feTile_ = flip (nodeSvg "feTile") []
 -----------------------------------------------------------------------------
 -- | [\<feTurbulence\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/feTurbulence)
-feTurbulence_ :: [Attribute action] -> View model action
+feTurbulence_ :: [Attribute action] -> View parent model action
 feTurbulence_ = flip (nodeSvg "feTurbulence") []
 -----------------------------------------------------------------------------
 -- | [\<feDistantLight\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/feDistantLight)
-feDistantLight_ :: [Attribute action] -> [View model action] -> View model action
+feDistantLight_ :: [Attribute action] -> [View parent model action] -> View parent model action
 feDistantLight_ = nodeSvg "feDistantLight"
 -----------------------------------------------------------------------------
 -- | [\<fePointLight\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/fePointLight)
-fePointLight_ :: [Attribute action] -> View model action
+fePointLight_ :: [Attribute action] -> View parent model action
 fePointLight_ = flip (nodeSvg "fePointLight") []
 -----------------------------------------------------------------------------
 -- | [\<feSpotLight\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/feSpotLight)
-feSpotLight_ :: [Attribute action] -> View model action
+feSpotLight_ :: [Attribute action] -> View parent model action
 feSpotLight_ = flip (nodeSvg "feSpotLight") []
 -----------------------------------------------------------------------------
 -- | [\<clipPath\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/clipPath)
-clipPath_ :: [Attribute action] -> [View model action] -> View model action
+clipPath_ :: [Attribute action] -> [View parent model action] -> View parent model action
 clipPath_ = nodeSvg "clipPath"
 -----------------------------------------------------------------------------
 -- | [\<filter\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/filter)
-filter_ :: [Attribute action] -> [View model action] -> View model action
+filter_ :: [Attribute action] -> [View parent model action] -> View parent model action
 filter_ = nodeSvg "filter"
 -----------------------------------------------------------------------------
 -- | [\<script\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/script)
-script_ :: [Attribute action] -> [View model action] -> View model action
+script_ :: [Attribute action] -> [View parent model action] -> View parent model action
 script_ = nodeSvg "script"
 -----------------------------------------------------------------------------
 -- | [\<style\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/style)
-style_ :: [Attribute action] -> [View model action] -> View model action
+style_ :: [Attribute action] -> [View parent model action] -> View parent model action
 style_ = nodeSvg "style"
 -----------------------------------------------------------------------------
 -- | [\<view\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/view)
-view_ :: [Attribute action] -> View model action
+view_ :: [Attribute action] -> View parent model action
 view_ = flip (nodeSvg "view") []
 -----------------------------------------------------------------------------

--- a/src/Miso/Types.hs
+++ b/src/Miso/Types.hs
@@ -93,13 +93,13 @@ module Miso.Types
   , ms
   ) where
 -----------------------------------------------------------------------------
-import           Data.Proxy (Proxy(..))
 import qualified Data.Map.Strict as M
 import           Data.Maybe (fromMaybe, isJust)
 import           Data.String (IsString, fromString)
 import qualified Data.Text as T
 import           GHC.Generics
 import           GHC.Records
+import           GHC.TypeLits (Symbol)
 import           Prelude
 -----------------------------------------------------------------------------
 import           Miso.Binding ((<--), (-->), (<-->), (<---), (--->), (<--->), Binding(..))
@@ -311,7 +311,7 @@ data View parent model action
 -----------------------------------------------------------------------------
 -- |
 props
-  :: forall field parent a model action . HasField field parent a
+  :: forall (field :: Symbol) parent a model action . HasField field parent a
   => (a -> View parent model action)
   -> View parent model action
 props = VProp (getField @field @parent @a)

--- a/src/Miso/Types.hs
+++ b/src/Miso/Types.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE ExistentialQuantification  #-}
 {-# LANGUAGE MultiParamTypeClasses      #-}
 {-# LANGUAGE ScopedTypeVariables        #-}
+{-# LANGUAGE AllowAmbiguousTypes        #-}
 {-# LANGUAGE DerivingStrategies         #-}
 {-# LANGUAGE OverloadedStrings          #-}
 {-# LANGUAGE FlexibleInstances          #-}
@@ -311,10 +312,9 @@ data View parent model action
 -- |
 props
   :: forall field parent a model action . HasField field parent a
-  => Proxy field
-  -> (a -> View parent model action)
+  => (a -> View parent model action)
   -> View parent model action
-props Proxy = VProp (getField @field @parent @a)
+props = VProp (getField @field @parent @a)
 -----------------------------------------------------------------------------
 -- | Existential wrapper allowing nesting of t'Miso.Types.Component' in t'Miso.Types.Component'
 data SomeComponent parent

--- a/src/Miso/Types.hs
+++ b/src/Miso/Types.hs
@@ -6,6 +6,7 @@
 {-# LANGUAGE DerivingStrategies         #-}
 {-# LANGUAGE OverloadedStrings          #-}
 {-# LANGUAGE FlexibleInstances          #-}
+{-# LANGUAGE TypeApplications           #-}
 {-# LANGUAGE RecordWildCards            #-}
 {-# LANGUAGE DeriveAnyClass             #-}
 {-# LANGUAGE DeriveGeneric              #-}
@@ -82,6 +83,7 @@ module Miso.Types
   , textRaw
   , textKey
   , textKey_
+  , props
   , htmlEncode
   -- *** MisoString
   , MisoString
@@ -90,11 +92,13 @@ module Miso.Types
   , ms
   ) where
 -----------------------------------------------------------------------------
+import           Data.Proxy (Proxy(..))
 import qualified Data.Map.Strict as M
 import           Data.Maybe (fromMaybe, isJust)
 import           Data.String (IsString, fromString)
 import qualified Data.Text as T
 import           GHC.Generics
+import           GHC.Records
 import           Prelude
 -----------------------------------------------------------------------------
 import           Miso.Binding ((<--), (-->), (<-->), (<---), (--->), (<--->), Binding(..))
@@ -120,7 +124,7 @@ data Component parent model action
   --   The resulting 'model' is only used during initial hydration, not on remounts.
   , update :: action -> Effect parent model action
   -- ^ Updates model, optionally providing effects.
-  , view :: model -> View model action
+  , view :: model -> View parent model action
   -- ^ Draws 'View'
   , subs :: [ Sub action ]
   -- ^ Subscriptions to run during application lifetime
@@ -163,6 +167,10 @@ data Component parent model action
   -- ^ action to execute during t'Miso.Types.Component' unmount phase.
   --
   -- @since 1.9.0.0
+  , useProps :: Bool
+  -- ^ boolean to determine if React-style "props" should be used
+  --
+  -- @since 1.10.0.0
   }
 -----------------------------------------------------------------------------
 -- | @mountPoint@ for t'Miso.Types.Component', e.g "body"
@@ -223,7 +231,7 @@ component
   -- ^ model
   -> (action -> Effect parent model action)
   -- ^ update
-  -> (model -> View model action)
+  -> (model -> View parent model action)
   -- ^ view
   -> Component parent model action
 component m u v = Component
@@ -241,6 +249,7 @@ component m u v = Component
   , eventPropagation = False
   , mount = Nothing
   , unmount = Nothing
+  , useProps = False
   }
 -----------------------------------------------------------------------------
 -- | Synonym for 'component'
@@ -249,10 +258,10 @@ vcomp
   -- ^ model
   -> (action -> Effect parent model action)
   -- ^ update
-  -> (model -> View model action)
+  -> (model -> View parent model action)
   -- ^ view
   -> Component parent model action
-vcomp = component  
+vcomp = component
 -----------------------------------------------------------------------------
 -- | A top-level t'Miso.Types.Component' can have no @parent@.
 --
@@ -293,11 +302,19 @@ data LogLevel
 type Tag = MisoString
 -----------------------------------------------------------------------------
 -- | Core type for constructing a virtual DOM in Haskell
-data View model action
-  = VNode Namespace Tag [Attribute action] [View model action]
+data View parent model action
+  = VNode Namespace Tag [Attribute action] [View parent model action]
   | VText (Maybe Key) MisoString
   | VComp (Maybe Key) (SomeComponent model)
-  deriving Functor
+  | forall field . VProp (parent -> field) (field -> View parent model action)
+-----------------------------------------------------------------------------
+-- |
+props
+  :: forall field parent a model action . HasField field parent a
+  => Proxy field
+  -> (a -> View parent model action)
+  -> View parent model action
+props Proxy = VProp (getField @field @parent @a)
 -----------------------------------------------------------------------------
 -- | Existential wrapper allowing nesting of t'Miso.Types.Component' in t'Miso.Types.Component'
 data SomeComponent parent
@@ -315,12 +332,12 @@ data SomeComponent parent
 --
 -- @since 1.9.0.0
 (+>)
-  :: forall child model action a . Eq child
+  :: forall parent child model action a . Eq child
   => MisoString
   -- ^ 'VComp' 'key_'
   -> Component model child action
   -- ^ 'Component'
-  -> View model a
+  -> View parent model a
 infixr 0 +>
 key +> comp = VComp (Just (toKey key)) (SomeComponent comp)
 -----------------------------------------------------------------------------
@@ -340,7 +357,7 @@ mount_
   :: Eq child
   => Component model child a
   -- ^ 'Component' to mount
-  -> View model action
+  -> View parent model action
 mount_ comp = VComp Nothing (SomeComponent comp)
 -----------------------------------------------------------------------------
 -- | DOM element namespace.
@@ -441,7 +458,7 @@ instance Show (Attribute action) where
         ]
 -----------------------------------------------------------------------------
 -- | 'IsString' instance
-instance IsString (View model action) where
+instance IsString (View parent model action) where
   fromString = VText Nothing . fromString
 -----------------------------------------------------------------------------
 -- | Virtual DOM implemented as a JavaScript t'Object'.
@@ -459,8 +476,8 @@ node
   :: Namespace
   -> MisoString
   -> [Attribute action]
-  -> [View model action]
-  -> View model action
+  -> [View parent model action]
+  -> View parent model action
 node = VNode
 -----------------------------------------------------------------------------
 -- | Create a new 'Miso.Types.VNode'.
@@ -471,12 +488,12 @@ vnode
   :: Namespace
   -> MisoString
   -> [Attribute action]
-  -> [View model action]
-  -> View model action
+  -> [View parent model action]
+  -> View parent model action
 vnode = node
 -----------------------------------------------------------------------------
 -- | Create a new v'VText' with the given content.
-text :: MisoString -> View model action
+text :: MisoString -> View parent model action
 #ifdef SSR
 text = VText Nothing . htmlEncode
 #else
@@ -484,14 +501,14 @@ text = VText Nothing
 #endif
 -----------------------------------------------------------------------------
 -- | Synonym for 'text'
-vtext :: MisoString -> View model action
+vtext :: MisoString -> View parent model action
 vtext = text
 ----------------------------------------------------------------------------
 -- | Create a new v'VText', not subject to HTML escaping.
 --
 -- Like 'text', except will not escape HTML when used on the server.
 --
-textRaw :: MisoString -> View model action
+textRaw :: MisoString -> View parent model action
 textRaw = VText Nothing
 ----------------------------------------------------------------------------
 -- |
@@ -514,7 +531,7 @@ htmlEncode = MS.concatMap $ \case
 -- | Create a new v'VText' containing concatenation of the given strings.
 --
 -- @
---   view :: View model action
+--   view :: View parent model action
 --   view = div_
 --     [ className "container" ]
 --     [ text_
@@ -528,46 +545,46 @@ htmlEncode = MS.concatMap $ \case
 --
 -- A single additional space is added between elements.
 --
-text_ :: [MisoString] -> View model action
+text_ :: [MisoString] -> View parent model action
 text_ = VText Nothing . MS.intercalate " "
 -----------------------------------------------------------------------------
 -- | Like 'text', but allow the node to be keyed for efficient diffing.
 --
 -- @
--- view :: model -> View model action
+-- view :: model -> View parent model action
 -- view = \x -> div_ [] [ textKey (1 :: Int) "text here" ]
 -- @
 --
 -- @since 1.9.0.0
-textKey :: ToKey key => key -> MisoString -> View model action
+textKey :: ToKey key => key -> MisoString -> View parent model action
 textKey k = VText (Just (toKey k))
 -----------------------------------------------------------------------------
 -- | Like 'text_', but allow the node to be keyed for efficient diffing.
 --
 -- @
--- view :: model -> View model action
+-- view :: model -> View parent model action
 -- view = \x -> div_ [] [ textKey_ (1 :: Int) [ "text", "goes", "here" ] ]
 -- @
 --
 -- @since 1.9.0.0
-textKey_ :: ToKey key => key -> [MisoString] -> View model action
+textKey_ :: ToKey key => key -> [MisoString] -> View parent model action
 textKey_ k xs = VText (Just (toKey k)) (MS.intercalate " " xs)
 -----------------------------------------------------------------------------
 -- | Utility function to make it easy to specify conditional attributes
 --
 -- @
--- view :: Bool -> View model action
+-- view :: Bool -> View parent model action
 -- view danger = optionalAttrs div_ [ id_ "some-div" ] danger [ class_ "danger" ] ["child"]
 -- @
 --
 -- @since 1.9.0.0
 optionalAttrs
-  :: ([Attribute action] -> [View model action] -> View model action)
+  :: ([Attribute action] -> [View parent model action] -> View parent model action)
   -> [Attribute action] -- ^ Attributes to be added unconditionally
   -> Bool -- ^ A condition
   -> [Attribute action] -- ^ Additional attributes to add if the condition is True
-  -> [View model action] -- ^ Children
-  -> View model action
+  -> [View parent model action] -- ^ Children
+  -> View parent model action
 optionalAttrs element attrs condition opts kids =
   case element attrs kids of
     VNode ns name _ _ -> do
@@ -578,17 +595,17 @@ optionalAttrs element attrs condition opts kids =
 -- | Utility function to make it easy to specify conditional attributes for void elements.
 --
 -- @
--- view :: Bool -> View model action
+-- view :: Bool -> View parent model action
 -- view shouldClear = optionalVoidAttrs textarea_ [ value_ "" ] shouldClear [ id_ "text-area-id" ]
 -- @
 --
 -- @since 1.9.0.0
 optionalVoidAttrs
-  :: ([Attribute action] -> View model action)
+  :: ([Attribute action] -> View parent model action)
   -> [Attribute action] -- ^ Attributes to be added unconditionally
   -> Bool -- ^ A condition
   -> [Attribute action] -- ^ Additional attributes to add if the condition is True
-  -> View model action
+  -> View parent model action
 optionalVoidAttrs element attrs condition opts =
   case element attrs of
     VNode ns name _ kids -> do
@@ -599,18 +616,18 @@ optionalVoidAttrs element attrs condition opts =
 -- | Conditionally adds children.
 --
 -- @
--- view :: Bool -> View model action
+-- view :: Bool -> View parent model action
 -- view withChild = optionalChildren div_ [ id_ "txt" ] [] withChild [ "foo" ]
 -- @
 --
 -- @since 1.9.0.0
 optionalChildren
-  :: ([Attribute action] -> [View model action] -> View model action)
+  :: ([Attribute action] -> [View parent model action] -> View parent model action)
   -> [Attribute action] -- ^ Attributes to be added unconditionally
-  -> [View model action] -- ^ Children to be added unconditionally
+  -> [View parent model action] -- ^ Children to be added unconditionally
   -> Bool -- ^ A condition
-  -> [View model action] -- ^ Additional children to add if the condition is True
-  -> View model action
+  -> [View parent model action] -- ^ Additional children to add if the condition is True
+  -> View parent model action
 optionalChildren element attrs kids condition opts =
   case element attrs kids of
     VNode ns name _ _ -> do


### PR DESCRIPTION
This adds the `VProp` constructor to the miso `View` DSL. The goal of this PR is to emulate the React "props" feature.

- https://react.dev/learn/passing-props-to-a-component

Always redraw if `useProps` is `True`. This must be opted into currently.

- [x] Parameterize `View` by `parent`
- [x] Add `VProp` constructor case
- [x] Add `useProps`, `_componentUseProps`
- [ ] Implement `VProps` case for rendering `HTML`