### PR TITLE
feat: Component `reactiveRendering` prop preventing view and update from getting stale

### DIFF
--- a/src/Miso/Runtime.hs
+++ b/src/Miso/Runtime.hs
@@ -156,11 +156,12 @@ initialize
   -> Hydrate
   -> Bool
   -- ^ Is the root node being rendered?
+  -> Maybe Key
   -> Component parent model action
   -> IO DOMRef
   -- ^ Callback function is used for obtaining the t'Miso.Types.Component' 'DOMRef'.
   -> IO (ComponentState parent model action)
-initialize events _componentParentId hydrate isRoot comp@Component {..} getComponentMountPoint = do
+initialize events _componentParentId hydrate isRoot maybeKey comp@Component {..} getComponentMountPoint = do
   _componentId <- freshComponentId
   let
     _componentSink = \action -> liftIO $ do
@@ -191,8 +192,8 @@ initialize events _componentParentId hydrate isRoot comp@Component {..} getCompo
     asyncCallback1 $ \jsval -> do
       putMVar frame =<< fromJSValUnchecked jsval
 
-  let _componentDraw = \newModel -> do
-        newVTree <- buildVTree events _componentParentId _componentId Draw _componentSink logLevel (view newModel)
+  let _componentDraw = \latestViewFn newModel -> do
+        newVTree <- buildVTree events _componentParentId _componentId Draw _componentSink logLevel (latestViewFn newModel)
         oldVTree <- liftIO (readIORef _componentVTree)
         _frame <- requestAnimationFrame rAFCallback
         _timestamp :: Double <- takeMVar frame
@@ -201,10 +202,10 @@ initialize events _componentParentId hydrate isRoot comp@Component {..} getCompo
         liftIO (atomicWriteIORef _componentVTree newVTree)
         FFI.flush
 
-  let _componentApplyActions = \(actions :: [action]) model_ comps -> do
+  let _componentApplyActions = \latestUpdateFn (actions :: [action]) model_ comps -> do
         let info = ComponentInfo _componentId _componentParentId _componentDOMRef
         List.foldl' (\(vcomps, m, ss, dirtySet) a ->
-          case runEffect (update a) info m of
+          case runEffect (latestUpdateFn a) info m of
             (n, sss) ->
               let (newComps, newDirty)
                     | modelCheck m n =
@@ -223,6 +224,10 @@ initialize events _componentParentId hydrate isRoot comp@Component {..} getCompo
         , _componentModelDirty = modelCheck
         , _componentChildren = mempty
         , _componentModel = initializedModel
+        , _componentKey = maybeKey
+        , _componentView = view
+        , _componentUpdate = update
+        , _componentReactiveRendering = reactiveRendering
         , ..
         }
 
@@ -329,7 +334,7 @@ scheduler =
       (updatedModel, schedules, dirtySet, ComponentState{..}) <- do
         atomicModifyIORef' components $ \vcomps -> do
           let cs@ComponentState {..} = vcomps IM.! vcompId
-          case _componentApplyActions events _componentModel vcomps of
+          case _componentApplyActions _componentUpdate events _componentModel vcomps of
             (x, updatedModel, schedules, dirtySet) ->
               (x, (updatedModel, schedules, dirtySet, cs))
       forM_ schedules $ \case
@@ -337,12 +342,24 @@ scheduler =
           evalScheduled Async (action _componentSink)
         Schedule Sync action ->
           evalScheduled Sync (action _componentSink)
+      let findDescendantsToRender ids =
+            fmap IS.unions . forM (IS.toList ids) $ \childId -> do
+              allComponents <- readIORef components
+              case IM.lookup childId allComponents of
+                Just (ComponentState{_componentChildren, _componentReactiveRendering})
+                  | _componentReactiveRendering -> do
+                    modifyComponent childId (isDirty .= True)
+                    let grandchildren = _componentChildren
+                    furtherDescendants <- findDescendantsToRender grandchildren
+                    pure (IS.insert childId furtherDescendants)
+                _ -> pure mempty
+      descendantsToRender <- findDescendantsToRender _componentChildren
       if _componentModelDirty _componentModel updatedModel
         then do
           modifyComponent _componentId $ do
             isDirty .= True
             componentModel .= updatedModel
-          pure dirtySet
+          pure (dirtySet <> descendantsToRender)
         else
           pure mempty
 -----------------------------------------------------------------------------
@@ -356,7 +373,7 @@ renderComponents dirtySet = do
   forM_ (IS.toAscList dirtySet) $ \vcompId ->
     IM.lookup vcompId <$> liftIO (readIORef components) >>= mapM \ComponentState {..} -> do
       when _componentIsDirty $ do
-        _componentDraw _componentModel
+        _componentDraw _componentView _componentModel
         FFI.modelHydration _componentId =<< toObject jsNull
       modifyComponent _componentId (isDirty .= False)
 -----------------------------------------------------------------------------
@@ -654,6 +671,12 @@ componentTopics = lens _componentTopics $ \record field -> record { _componentTo
 isDirty :: Lens (ComponentState parent model action) Bool
 isDirty = lens _componentIsDirty $ \record field -> record { _componentIsDirty = field }
 -----------------------------------------------------------------------------
+componentView :: Lens (ComponentState parent model action) (model -> View model action)
+componentView = lens _componentView $ \record field -> record { _componentView = field }
+-----------------------------------------------------------------------------
+componentUpdate :: Lens (ComponentState parent model action) (action -> Effect parent model action)
+componentUpdate = lens _componentUpdate $ \record field -> record { _componentUpdate = field }
+-----------------------------------------------------------------------------
 componentModel :: Lens (ComponentState parent model action) model
 componentModel = lens _componentModel $ \record field -> record { _componentModel = field }
 -----------------------------------------------------------------------------
@@ -672,6 +695,7 @@ data ComponentState parent model action
   = ComponentState
   { _componentId :: ComponentId
   -- ^ The ID of the current t'Miso.Types.Component'
+  , _componentKey :: Maybe Key
   , _componentParentId :: ComponentId
   -- ^ The ID of the t'Miso.Types.Component''s parent
   , _componentSubThreads :: IORef (Map MisoString ThreadId)
@@ -684,6 +708,10 @@ data ComponentState parent model action
   -- ^ t'Miso.Types.Component' t'Sink' used to enter events into the system
   , _componentModel :: model
   -- ^ t'Miso.Types.Component' state
+  , _componentView :: model -> View model action
+  -- ^ component view function, updated on re-renders in case dependencies change
+  , _componentUpdate :: action -> Effect parent model action
+  -- ^ component update function, updated on re-renders in case dependencies change
   , _componentIsDirty :: Bool
   -- ^ Indicator if t'Miso.Types.Component' needs to be drawn
   , _componentScripts :: [DOMRef]
@@ -694,12 +722,13 @@ data ComponentState parent model action
   -- ^ Declarative bindings between t'Miso.Types.Component' 'model'.
   , _componentMailbox :: Value -> Maybe action
   -- ^ Mailbox for asynchronous t'Miso.Types.Component' communication
-  , _componentDraw :: model -> IO ()
+  , _componentDraw :: (model -> View model action) -> model -> IO ()
   -- ^ Helper function for t'Miso.Types.Component' rendering
   , _componentModelDirty :: model -> model -> Bool
   -- ^ Model diffing
   , _componentApplyActions
-      :: [action]
+    :: (action -> Effect parent model action)
+      -> [action]
       -> model
       -> IntMap (ComponentState parent model action)
       -> (IntMap (ComponentState parent model action), model, [Schedule action], ComponentIds)
@@ -707,6 +736,7 @@ data ComponentState parent model action
   , _componentTopics :: Map MisoString (Value -> IO ())
   -- ^ t'Miso.Types.Component' topics using for Pub Sub async communication.
   , _componentChildren :: ComponentIds
+  , _componentReactiveRendering :: Bool
   }
 -----------------------------------------------------------------------------
 -- | A @Topic@ represents a place to send and receive messages. @Topic@ is used to facilitate
@@ -972,7 +1002,7 @@ drain ComponentState {..} = do
     [] -> pure ()
     actions -> do
        vcomps <- readIORef components
-       case _componentApplyActions actions _componentModel vcomps of
+       case _componentApplyActions _componentUpdate actions _componentModel vcomps of
          (newVComps, _, schedules, _) -> do
            forM_ schedules $ \case
              -- dmj: process all actions synchronously during unmount
@@ -1042,10 +1072,23 @@ buildVTree
 buildVTree events_ parentId_ vcompId hydrate snk logLevel_ = \case
   VComp maybeKey (SomeComponent app) -> do
     vcomp_ <- create
+    case maybeKey of
+      Just key -> do
+        maybeMountedChildId <- findChildByKey vcompId key
+        case maybeMountedChildId of
+          Just mountedChildId -> do
+            childCompState <- (IM.! mountedChildId) <$> readIORef components
+            when (_componentReactiveRendering childCompState) $
+              modifyComponent mountedChildId $ do
+                componentView .= view app
+                componentUpdate .= update app
+                isDirty .= True
+          Nothing -> pure ()
+      Nothing -> pure ()
 
     mountCallback <- do
       syncCallback1' $ \parent_ -> do
-        ComponentState {..} <- initialize events_ vcompId hydrate False app (pure parent_)
+        ComponentState {..} <- initialize events_ vcompId hydrate False maybeKey app (pure parent_)
         modifyComponent vcompId (children %= IS.insert _componentId)
         vtree <- toJSVal =<< readIORef _componentVTree
         FFI.set "parent" vcomp_ (Object vtree)
@@ -1096,6 +1139,19 @@ buildVTree events_ parentId_ vcompId hydrate snk logLevel_ = \case
     FFI.set "ns" ("text" :: MisoString) vtree
     FFI.set "text" t vtree
     pure (VTree vtree)
+-----------------------------------------------------------------------------
+findChildByKey :: ComponentId -> Key -> IO (Maybe ComponentId)
+findChildByKey parentComponentId key = do
+  comps <- readIORef components
+  case IM.lookup parentComponentId comps of
+    Nothing -> pure Nothing
+    Just ComponentState {_componentChildren} ->
+      pure $ listToMaybe
+        [ childId
+        | childId <- IS.toList _componentChildren
+        , Just cs <- [IM.lookup childId comps]
+        , _componentKey cs == Just key
+        ]
 -----------------------------------------------------------------------------
 -- | @createNode@
 -- A helper function for constructing a vtree (used for @vcomp@ and @vnode@)
@@ -1873,6 +1929,7 @@ blob = BLOB
 arrayBuffer :: ArrayBuffer -> Payload value
 arrayBuffer = BUFFER
 -----------------------------------------------------------------------------
+-- | Note this currently doesn't support VComp keys and is only meant to be used for the root component
 initComponent
   :: (Eq parent, Eq model)
   => Events
@@ -1881,7 +1938,7 @@ initComponent
   -> IO ()
 initComponent events hydrate vcomp_@Component {..} = withJS $ do
   root <- Diff.mountElement (getMountPoint mountPoint)
-  void $ initialize events rootComponentId hydrate True vcomp_ (pure root)
+  void $ initialize events rootComponentId hydrate True Nothing vcomp_ (pure root)
 #if __GLASGOW_HASKELL__ > 865
   flip labelThread "scheduler" =<< forkIO scheduler
 #else

--- a/src/Miso/Types.hs
+++ b/src/Miso/Types.hs
@@ -163,6 +163,20 @@ data Component parent model action
   -- ^ action to execute during t'Miso.Types.Component' unmount phase.
   --
   -- @since 1.9.0.0
+  , reactiveRendering :: Bool
+  -- ^ This makes your component:
+  -- - Render whenever its parent renders
+  -- - Always use fresh view and update functions, if they were defined
+  -- in terms of ancestor state.
+  -- Similar to React's, if you're passing props to your component like...
+  --
+  -- > "component-key" +> Child.component someProps someOtherProps
+  --
+  -- ...and then using those props in your view or update functions, the view
+  -- and update functions will always be called with the latest props.
+  --
+  -- Note this currently requires a component key,
+  -- meaning @mount_@ is unsupported.
   }
 -----------------------------------------------------------------------------
 -- | @mountPoint@ for t'Miso.Types.Component', e.g "body"
@@ -241,6 +255,7 @@ component m u v = Component
   , eventPropagation = False
   , mount = Nothing
   , unmount = Nothing
+  , reactiveRendering = False
   }
 -----------------------------------------------------------------------------
 -- | Synonym for 'component'


### PR DESCRIPTION
## Summary

This commit makes it so, by setting a new `reactiveRendering` boolean field on `Component` (default `False`), you can now feed state-derived parameters to your components, and your component will always be rendered with the latest version of your parameters. The parameters can be derived from parent, or even from ancestors higher up the component tree.

The way you would do this is simply like this, where in the below snippet `childComponent` parameters would previously become stale on state change (a notorious footgun in 1.9):

```hs
viewModel :: Model -> View Model Action
viewModel model = "child" +> childComponent (modelToInt model) (modelToBool model)

childComponent :: Int -> Bool -> Component parent Child ChildAction
childComponent statefulInt statefulBool =
    (component 0 (updateChild statefulBool) (viewChild statefulInt statefulBool))
        { reactiveRendering = True
        }
```

## Demo

The code for this demo can be found here: https://github.com/mtamc/miso-sampler/blob/experiment/reactive_component_props/app/Main.hs

### Before / `reactiveRendering = False`

[reactive_prop_fail-2026-04-25_20.29.26.webm](https://github.com/user-attachments/assets/96862828-9344-4cf2-8a22-d85389cfc297)

### After

[reactive_prop_success-2026-04-25_19.25.37.webm](https://github.com/user-attachments/assets/78e39490-8f79-4965-a915-0308052409d5)

## Method explanation

This is achieved with the following strategy:

[1] `scheduler` marks dirty not just the dirty component, but also any child with `reactiveRendering` set to `True`, recursing down to descendants.
[2] `_componentDraw` no longer draws using the `view` function enclosed on mount, instead grabbing the latest view function from a new `_componentView` prop in `ComponentState` (if component `reactiveRendering` is `True`)
[3] `_componentApplyAction` similarly, no longer uses the `update` function enclosed on mount, instead grabbing the latest update function from a new `_componentUpdate` prop in `ComponentState` (if component `reactiveRendering` is `True`)
[4] `_componentView` and `_componentUpdate` are kept updated whenever `buildVTree` is run. When `buildVTree` processes a parent `VComp`, it already has access to the latest `viewModel` and `updateModel` functions with the latest dependencies, however it currently only uses them if it ends up performing a full component mount. Now, even if not performing a full component mount, we update the `ComponentState` with the latest `view` and `update` functions.

I'm not sure if performing this action inside `buildVTree` like would cause any issue with the Miso architecture, need feedback.

## Caveats / Potential for future improvement

[1] This currently requires the child to have a component key and therefore does not work with `mount_`. Perhaps this could be improved not to require a component key by finding children by mount order or something, but it didn't seem worth the headache.

[2] As of this commit, there still are some niche scenarios where data you pass into your component function become stale. I wanted to keep this commit clean for now, but there are other fields that could be updated by `buildVTree` in order for them not to get stale when defined in terms of your component props: `styles`, `scripts`, `logLevel`, `mailbox`, `eventPropagation`, `unmount`.

The following fields do not make sense to make reactive in this way: `model`, `hydrateModel`, `mountPoint,` `bindings`, `mount`

Finally, `subs` could be risky to kill and re-create on every re-render. Might have to pass on making `subs` reactive in this same way.

I can work on the above props in a later commit if needed.

[3] `reactiveRendering` means a component re-renders any time its parent is re-rendered. This is the default behavior on React (and the only behavior in Elm and legacy Zoom-style TEA-Miso), and is fine performance-wise for the vast majority of applications. It makes sense as well: children are a part of their parents, not offshoot.

That said, React provides the `memo` function which causes re-renders to only happen when a component "props" have changed. This ostensibly is not the default behavior because equality checks can actually be more costly than re-renders. `memo` also provides a parameter to supply a `arePropsEqual` function which mirrors how we'd use a custom `Eq` instance in Haskell.

~~Although I don't believe this option is crucial to have, if we decided to add it to Miso components, then the very nice and natural pattern of `component_ a b c = component initModel (updateModel b) (viewModel a b c)` would not be compatible with it and become a footgun again, because component dependencies would have to be one single typed expression with an `Eq` instance, stored as a record field (say `props`). (I would love to be proven wrong with some variadic type trickery or something...)~~

edit: I believe we already have the option to have `memo`-like rendering behavior using `Miso.Binding`, see followup post https://github.com/dmjio/miso/pull/1504#issuecomment-4322212478