### PR TITLE
WASM `repl-watch` boot `:main` on `--after-startup-ghci`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -122,7 +122,7 @@
                      --repl-options='-fghci-browser -fghci-browser-port=8080'
                 }
                 function repl-watch () {
-                   ghciwatch --after-reload-ghci :main --watch . --debounce 50ms --command 'wasm32-wasi-cabal repl app -finteractive --repl-options="-fghci$
+                   ghciwatch --after-startup :main --after-reload-ghci :main --watch . --debounce 50ms --command 'wasm32-wasi-cabal repl app -finteractive --repl-options="-fghci$
                 }
               '';
             };

--- a/flake.nix
+++ b/flake.nix
@@ -122,7 +122,7 @@
                      --repl-options='-fghci-browser -fghci-browser-port=8080'
                 }
                 function repl-watch () {
-                   ghciwatch --after-startup :main --after-reload-ghci :main --watch . --debounce 50ms --command 'wasm32-wasi-cabal repl app -finteractive --repl-options="-fghci$
+                   ghciwatch --after-startup-ghci :main --after-reload-ghci :main --watch . --debounce 50ms --command 'wasm32-wasi-cabal repl app -finteractive --repl-options="-fghci$
                 }
               '';
             };
@@ -154,7 +154,7 @@
                      --repl-options='-fghci-browser -fghci-browser-port=8080'
                 }
                 function repl-watch () {
-                   ghciwatch --after-reload-ghci :main --watch . --debounce 50ms --command 'wasm32-wasi-cabal repl app -finteractive --repl-options="-fghci-browser -fghci-browser-port=8080"'
+                   ghciwatch --after-startup-ghci :main --after-reload-ghci :main --watch . --debounce 50ms --command 'wasm32-wasi-cabal repl app -finteractive --repl-options="-fghci-browser -fghci-browser-port=8080"'
                 }
               '';
             };


### PR DESCRIPTION
 The WASM `repl-watch` function which starts a development server does not seem to start `:main` in some environments when the page is first loaded, requiring the introduction of `ghciwatch` flag `--after-startup-ghci :main`.

