### PR TITLE
Support overloaded labels for Miso.Lens

### DIFF
--- a/miso.cabal
+++ b/miso.cabal
@@ -135,6 +135,7 @@ library
     Miso.JSON.Parser
     Miso.JSON.Types
     Miso.Lens
+    Miso.Lens.Generic
     Miso.Mathml
     Miso.Mathml.Element
     Miso.Mathml.Property

--- a/src/Miso/Lens/Generic.hs
+++ b/src/Miso/Lens/Generic.hs
@@ -11,7 +11,7 @@
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Miso.Lens.Generic where
+module Miso.Lens.Generic () where
 
 import Data.Kind (Constraint, Type)
 import GHC.Generics (C1, D1, Generic (..), K1 (..), M1 (..), Meta (..), Rec0, S1, U1, V1, (:*:) (..), (:+:) (..))

--- a/src/Miso/Lens/Generic.hs
+++ b/src/Miso/Lens/Generic.hs
@@ -17,8 +17,7 @@ import Data.Kind (Constraint, Type)
 import GHC.Generics (C1, D1, Generic (..), K1 (..), M1 (..), Meta (..), Rec0, S1, U1, V1, (:*:) (..), (:+:) (..))
 import GHC.OverloadedLabels (IsLabel (..))
 import GHC.Records (HasField (..))
-import GHC.TypeError (ErrorMessage (..), TypeError)
-import GHC.TypeLits (Symbol)
+import GHC.TypeLits (ErrorMessage (..), Symbol, TypeError)
 import Miso.Lens (Lens, lens)
 
 instance
@@ -28,7 +27,6 @@ instance
   fromLabel :: (HasField name s a, Generic s, GSet name a (Rep s)) => Lens s a
   fromLabel = lens (getField @name) (\s v -> to . gSet @name v . from $ s)
   {-# INLINE fromLabel #-}
-
 
 class GSet (name :: Symbol) typ f where
   gSet :: typ -> f x -> f x
@@ -42,16 +40,13 @@ instance (GSet name typ a, GSet name typ b) => GSet name typ (a :+: b) where
   gSet v (R1 r) = R1 $ gSet @name v r
   {-# INLINE gSet #-}
 
-
 instance (GSet name typ f) => GSet name typ (C1 x f) where
   gSet v (M1 f) = M1 $ gSet @name v f
   {-# INLINE gSet #-}
 
-
 instance (GSet name typ f) => GSet name typ (D1 x f) where
   gSet v (M1 f) = M1 $ gSet @name v f
   {-# INLINE gSet #-}
-
 
 instance {-# OVERLAPPING #-} GSet name typ (S1 (MetaSel ('Just name) b c d) (Rec0 typ)) where
   gSet v (M1 (K1 _)) = M1 (K1 v)
@@ -59,7 +54,6 @@ instance {-# OVERLAPPING #-} GSet name typ (S1 (MetaSel ('Just name) b c d) (Rec
 instance {-# OVERLAPPABLE #-} GSet name typ (S1 (MetaSel ('Just anotherName) b c d) x) where
   gSet _ f = f
   {-# INLINE gSet #-}
-
 
 type family ErrorCheck (name :: Symbol) r a (res :: Maybe Type) :: Constraint where
   ErrorCheck _ _ _ ('Just _) = ()

--- a/src/Miso/Lens/Generic.hs
+++ b/src/Miso/Lens/Generic.hs
@@ -1,0 +1,92 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE InstanceSigs #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Miso.Lens.Generic where
+
+import Data.Kind (Constraint, Type)
+import GHC.Generics (C1, D1, Generic (..), K1 (..), M1 (..), Meta (..), Rec0, S1, U1, V1, (:*:) (..), (:+:) (..))
+import GHC.OverloadedLabels (IsLabel (..))
+import GHC.Records (HasField (..))
+import GHC.TypeError (ErrorMessage (..), TypeError)
+import GHC.TypeLits (Symbol)
+import Miso.Lens (Lens, lens)
+
+instance
+  (HasField name s a, Generic s, GSet name a (Rep s), ErrorCheck name s a (HasFieldPred name (Rep s))) =>
+  IsLabel name (Lens s a)
+  where
+  fromLabel :: (HasField name s a, Generic s, GSet name a (Rep s)) => Lens s a
+  fromLabel = lens (getField @name) (\s v -> to . gSet @name v . from $ s)
+  {-# INLINE fromLabel #-}
+
+
+class GSet (name :: Symbol) typ f where
+  gSet :: typ -> f x -> f x
+
+instance (GSet name typ a, GSet name typ b) => GSet name typ (a :*: b) where
+  gSet v (l :*: r) = gSet @name v l :*: gSet @name v r
+  {-# INLINE gSet #-}
+
+instance (GSet name typ a, GSet name typ b) => GSet name typ (a :+: b) where
+  gSet v (L1 l) = L1 $ gSet @name v l
+  gSet v (R1 r) = R1 $ gSet @name v r
+  {-# INLINE gSet #-}
+
+
+instance (GSet name typ f) => GSet name typ (C1 x f) where
+  gSet v (M1 f) = M1 $ gSet @name v f
+  {-# INLINE gSet #-}
+
+
+instance (GSet name typ f) => GSet name typ (D1 x f) where
+  gSet v (M1 f) = M1 $ gSet @name v f
+  {-# INLINE gSet #-}
+
+
+instance {-# OVERLAPPING #-} GSet name typ (S1 (MetaSel ('Just name) b c d) (Rec0 typ)) where
+  gSet v (M1 (K1 _)) = M1 (K1 v)
+
+instance {-# OVERLAPPABLE #-} GSet name typ (S1 (MetaSel ('Just anotherName) b c d) x) where
+  gSet _ f = f
+  {-# INLINE gSet #-}
+
+
+type family ErrorCheck (name :: Symbol) r a (res :: Maybe Type) :: Constraint where
+  ErrorCheck _ _ _ ('Just _) = ()
+  ErrorCheck name r a 'Nothing =
+    TypeError
+      ( 'ShowType r
+          ':<>: 'Text ": "
+          ':<>: 'Text name
+          ':<>: 'Text " field missing or not in all constructors"
+      )
+
+type family HasFieldPred (field :: Symbol) f :: Maybe Type where
+  HasFieldPred field (S1 ('MetaSel ('Just field) _ _ _) (Rec0 t)) =
+    'Just t
+  HasFieldPred field (S1 _ _) = 'Nothing
+  HasFieldPred field (l :*: r) = Alt (HasFieldPred field l) (HasFieldPred field r)
+  HasFieldPred field (l :+: r) = Both (HasFieldPred field l) (HasFieldPred field r)
+  HasFieldPred field (C1 _ f) = HasFieldPred field f
+  HasFieldPred field (D1 _ f) = HasFieldPred field f
+  HasFieldPred field (K1 _ _) = 'Nothing
+  HasFieldPred field U1 = 'Nothing
+  HasFieldPred field V1 = 'Nothing
+
+type family Both (m1 :: Maybe Type) (m2 :: Maybe Type) :: Maybe Type where
+  Both ('Just a) ('Just a) = 'Just a
+  Both x y = 'Nothing
+
+type family Alt (m1 :: Maybe Type) (m2 :: Maybe Type) :: Maybe Type where
+  Alt ('Just a) _ = 'Just a
+  Alt _ b = b

--- a/src/Miso/Lens/Generic.hs
+++ b/src/Miso/Lens/Generic.hs
@@ -48,10 +48,10 @@ instance (GSet name typ f) => GSet name typ (D1 x f) where
   gSet v (M1 f) = M1 $ gSet @name v f
   {-# INLINE gSet #-}
 
-instance {-# OVERLAPPING #-} GSet name typ (S1 (MetaSel ('Just name) b c d) (Rec0 typ)) where
+instance {-# OVERLAPPING #-} GSet name typ (S1 ('MetaSel ('Just name) b c d) (Rec0 typ)) where
   gSet v (M1 (K1 _)) = M1 (K1 v)
 
-instance {-# OVERLAPPABLE #-} GSet name typ (S1 (MetaSel ('Just anotherName) b c d) x) where
+instance {-# OVERLAPPABLE #-} GSet name typ (S1 ('MetaSel ('Just anotherName) b c d) x) where
   gSet _ f = f
   {-# INLINE gSet #-}
 

--- a/src/Miso/Lens/Generic.hs
+++ b/src/Miso/Lens/Generic.hs
@@ -1,32 +1,53 @@
+-----------------------------------------------------------------------------
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE InstanceSigs #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
+{-# LANGUAGE UndecidableSuperClasses #-}
+{-# LANGUAGE FunctionalDependencies #-}
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Miso.Lens.Generic
+-- Copyright   :  (C) 2016-2026 David M. Johnson
+-- License     :  BSD3-style (see the file LICENSE)
+-- Maintainer  :  David M. Johnson <code@dmj.io>
+-- Stability   :  experimental
+-- Portability :  non-portable
+-----------------------------------------------------------------------------
+module Miso.Lens.Generic (HasLens(..), field) where
 
-module Miso.Lens.Generic () where
-
+-----------------------------------------------------------------------------
 import Data.Kind (Constraint, Type)
-import GHC.Generics (C1, D1, Generic (..), K1 (..), M1 (..), Meta (..), Rec0, S1, U1, V1, (:*:) (..), (:+:) (..))
+import GHC.Generics (C1, D1, Generic (..), K1 (..), M1 (..), Meta (..), Rec0, S1, (:*:) (..), (:+:) (..))
 import GHC.OverloadedLabels (IsLabel (..))
 import GHC.Records (HasField (..))
 import GHC.TypeLits (ErrorMessage (..), Symbol, TypeError)
+-----------------------------------------------------------------------------
 import Miso.Lens (Lens, lens)
+-----------------------------------------------------------------------------
 
-instance
-  (HasField name s a, Generic s, GSet name a (Rep s), ErrorCheck name s a (HasFieldPred name (Rep s))) =>
-  IsLabel name (Lens s a)
-  where
-  fromLabel :: (HasField name s a, Generic s, GSet name a (Rep s)) => Lens s a
-  fromLabel = lens (getField @name) (\s v -> to . gSet @name v . from $ s)
-  {-# INLINE fromLabel #-}
+class Generic s => HasLens (name :: Symbol) s a | name s -> a where 
+  getLens :: Lens s a
+
+instance 
+  (HasField name s a, TotalityCheck name s a (GetFieldType name (Rep s)), GSet name a (Rep s), Generic s) => 
+  HasLens name s a where
+  getLens = lens (getField @name) (\s v -> to . gSet @name v . from $ s)
+  {-# INLINE getLens #-}
+
+instance HasLens name s a => IsLabel name (Lens s a)
+  where fromLabel = getLens @name
+
+{-# INLINE field #-}
+field :: forall name s a. HasLens name s a => Lens s a 
+field = fromLabel @name
 
 class GSet (name :: Symbol) typ f where
   gSet :: typ -> f x -> f x
@@ -55,9 +76,9 @@ instance {-# OVERLAPPABLE #-} GSet name typ (S1 ('MetaSel ('Just anotherName) b 
   gSet _ f = f
   {-# INLINE gSet #-}
 
-type family ErrorCheck (name :: Symbol) r a (res :: Maybe Type) :: Constraint where
-  ErrorCheck _ _ _ ('Just _) = ()
-  ErrorCheck name r a 'Nothing =
+type family TotalityCheck (name :: Symbol) r a (res :: Maybe Type) :: Constraint where
+  TotalityCheck _ _ _ ('Just _) = ()
+  TotalityCheck name r a 'Nothing =
     TypeError
       ( 'ShowType r
           ':<>: 'Text ": "
@@ -65,22 +86,18 @@ type family ErrorCheck (name :: Symbol) r a (res :: Maybe Type) :: Constraint wh
           ':<>: 'Text " field missing or not in all constructors"
       )
 
-type family HasFieldPred (field :: Symbol) f :: Maybe Type where
-  HasFieldPred field (S1 ('MetaSel ('Just field) _ _ _) (Rec0 t)) =
-    'Just t
-  HasFieldPred field (S1 _ _) = 'Nothing
-  HasFieldPred field (l :*: r) = Alt (HasFieldPred field l) (HasFieldPred field r)
-  HasFieldPred field (l :+: r) = Both (HasFieldPred field l) (HasFieldPred field r)
-  HasFieldPred field (C1 _ f) = HasFieldPred field f
-  HasFieldPred field (D1 _ f) = HasFieldPred field f
-  HasFieldPred field (K1 _ _) = 'Nothing
-  HasFieldPred field U1 = 'Nothing
-  HasFieldPred field V1 = 'Nothing
+type family GetFieldType (field :: Symbol) f :: Maybe Type where
+  GetFieldType field (S1 ('MetaSel ('Just field) _ _ _) (Rec0 t)) ='Just t
+  GetFieldType field (l :*: r) = Or (GetFieldType field l) (GetFieldType field r)
+  GetFieldType field (l :+: r) = And (GetFieldType field l) (GetFieldType field r)
+  GetFieldType field (C1 _ f) = GetFieldType field f
+  GetFieldType field (D1 _ f) = GetFieldType field f
+  GetFieldType field x = 'Nothing
 
-type family Both (m1 :: Maybe Type) (m2 :: Maybe Type) :: Maybe Type where
-  Both ('Just a) ('Just a) = 'Just a
-  Both x y = 'Nothing
+type family And (l :: Maybe Type) (r :: Maybe Type) :: Maybe Type where
+  And ('Just a) ('Just a) = 'Just a
+  And l r = 'Nothing
 
-type family Alt (m1 :: Maybe Type) (m2 :: Maybe Type) :: Maybe Type where
-  Alt ('Just a) _ = 'Just a
-  Alt _ b = b
+type family Or (l :: Maybe Type) (r :: Maybe Type) :: Maybe Type where
+  Or ('Just l) _ = 'Just l
+  Or _ r = r

--- a/tests/app/Main.hs
+++ b/tests/app/Main.hs
@@ -46,6 +46,7 @@ import           Miso.DSL
 #ifndef GHCJS_OLD
 import           Miso.FFI.QQ (js)
 #endif
+import           Miso.Lens.Generic
 import           Miso.Lens
 import           Miso.Storage
 import           Miso.Test
@@ -126,6 +127,12 @@ square n = [js|
 main :: IO ()
 main = withJS $ do
   runTests $ beforeEach clearBody $ afterEach clearComponentState $ do
+    describe "Miso.Lens.Generic tests" $ do
+      it "Should update field generically" $ do
+        let john = Person "john" 30
+        (john ^. field @"name") `shouldBe` "john"
+        let bob = john & field @"name" .~ "bob"
+        (bob ^. field @"name") `shouldBe` "bob"
     describe "Miso.Storage tests" $ do
       it "Should get and set in localStorage" $ do
         (`shouldBe` 0) =<< liftIO localStorageLength


### PR DESCRIPTION
Adds an `IsLabel` instance for `Miso.Lens`, allowing the use of `#label` syntax as lenses when `OverloadedLabels` is enabled.

This is a small quality-of-life improvement. No strong feelings if this is deemed unnecessary or inappropriate for the project — happy to discuss or have this declined.
