### PR TITLE
Add `keyed`

### DIFF
--- a/src/Miso/Types.hs
+++ b/src/Miso/Types.hs
@@ -66,6 +66,9 @@ module Miso.Types
   -- ** Component mounting
   , (+>)
   , mount_
+  -- ** Key combinators
+  , (++>)
+  , keyed
   -- ** Utils
   , getMountPoint
   , optionalAttrs
@@ -303,6 +306,41 @@ data View model action
 data SomeComponent parent
    = forall model action . Eq model
   => SomeComponent (Component parent model action)
+-----------------------------------------------------------------------------
+-- | Like '+>' but operates on any 'View', not just 'Component'.
+--
+-- This appends a 'Key' to any 'View'.
+--
+-- @
+-- keyed "key" ("some text" :: View model action)
+-- keyed "key" $ div_ [ id_ "container" ] [ "content" ]
+-- keyed "key" (mount_ calendarComponent)
+-- @
+--
+-- @since 1.10.0.0
+keyed
+  :: MisoString
+  -> View model action
+  -> View model action
+keyed key = \case
+    VText _ txt ->
+      VText (Just (Key key)) txt
+    VComp _ comp ->
+      VComp (Just (Key key)) comp
+    VNode ns tag attrs kids ->
+      VNode ns tag (Property "key" (toJSON key) : attrs) kids
+-----------------------------------------------------------------------------
+-- | Infix form of 'keyed'.
+--
+-- @
+-- "key" ++> ("some text" :: View model action)
+-- "key" ++> div_ [ id_ "container" ] [ "content" ]
+-- "key" ++> (mount_ calendarComponent)
+-- @
+--
+infixr 0 ++>
+(++>) :: MisoString -> View model action -> View model action
+(++>) = keyed
 -----------------------------------------------------------------------------
 -- | t'Miso.Types.Component' mounting combinator
 --

--- a/src/Miso/Types.hs
+++ b/src/Miso/Types.hs
@@ -67,7 +67,6 @@ module Miso.Types
   , (+>)
   , mount_
   -- ** Key combinators
-  , (++>)
   , keyed
   -- ** Utils
   , getMountPoint
@@ -329,18 +328,6 @@ keyed key = \case
       VComp (Just (Key key)) comp
     VNode ns tag attrs kids ->
       VNode ns tag (Property "key" (toJSON key) : attrs) kids
------------------------------------------------------------------------------
--- | Infix form of 'keyed'.
---
--- @
--- "key" ++> ("some text" :: View model action)
--- "key" ++> div_ [ id_ "container" ] [ "content" ]
--- "key" ++> (mount_ calendarComponent)
--- @
---
-infixr 0 ++>
-(++>) :: MisoString -> View model action -> View model action
-(++>) = keyed
 -----------------------------------------------------------------------------
 -- | t'Miso.Types.Component' mounting combinator
 --


### PR DESCRIPTION
Allows the appending of `Key` to any `View`

```haskell
keyed "key" ("some text" :: View model action)
keyed "key" $ div_ [ id_ "container" ] [ "content" ]
keyed "key" (mount_ calendarComponent)
```