### PR TITLE
Remove superfluous render.

### DIFF
--- a/src/Miso/Runtime.hs
+++ b/src/Miso/Runtime.hs
@@ -277,13 +277,6 @@ inheritChildBindings compParentId childState bindings = do
          isDirty .= True
      _ -> do
        pure ()
-  when (any isChildToParent bindings) $ do
-    renderComponents (IS.singleton compParentId)
-  where
-    isChildToParent :: Binding parent model -> Bool
-    isChildToParent = \case
-      ChildToParent {} -> True
-      _ -> False
 -----------------------------------------------------------------------------
 initSubs :: [Sub action] -> IORef (Map MisoString ThreadId) -> Sink action -> IO ()
 initSubs subs_ _componentSubThreads _componentSink = do


### PR DESCRIPTION
This call is redundant and creates an infinite loop when a parent `Binding` is set to inherit child state on init. The `isDirty` bit set to `True` already guarantees that a render will occur. This fixes `miso-reactive`.