### PR TITLE
Add `mailAncestors` function.

### DIFF
--- a/src/Miso.hs
+++ b/src/Miso.hs
@@ -470,6 +470,8 @@
 -- * 'broadcast'
 -- * 'mail'
 -- * 'mailParent'
+-- * 'mailChildren'
+-- * 'mailAncestors'
 --
 -- All t'Component' have a 'mailbox' that can receive messages (as t'Miso.JSON.Value') from other t'Component'.
 -- This is meant to be used with the 'checkMail' function. The 'mail' function allows a 'Component' to send a specific message (as 'Value') to another t'Component' via its t'ComponentId'.
@@ -720,6 +722,7 @@ module Miso
   , parent
   , mailParent
   , mailChildren
+  , mailAncestors
   , broadcast
     -- ** Subscriptions
   , startSub

--- a/src/Miso/Runtime.hs
+++ b/src/Miso/Runtime.hs
@@ -51,6 +51,7 @@ module Miso.Runtime
   , parent
   , mailParent
   , mailChildren
+  , mailAncestors
   -- ** WebSocket
   , websocketConnect
   , websocketConnectJSON
@@ -1313,7 +1314,34 @@ mailParent msg = do
   ComponentInfo {..} <- ask
   io_ (mail _componentInfoParentId msg)
 -----------------------------------------------------------------------------
+-- | Send any @ToJSON message => message@ to all ancestor t'Miso.Types.Component' 'mailbox'.
+--
+-- This function walks the t'Miso.Types.Component' ancestor hierarchy, delivering mail
+-- along the way.
+--
+-- @
+-- mailAncestors ("test message" :: MisoString) :: Effect parent model action
+-- @
+--
+-- @since 1.11.0.0
+mailAncestors
+  :: ToJSON message
+  => message
+  -- ^ Message to send
+  -> Effect parent model action
+mailAncestors msg = do
+  ComponentInfo {..} <- ask
+  io_ (climb _componentInfoParentId)
+    where
+      climb vcompId = do
+        mail vcompId msg
+        IM.lookup vcompId <$> readIORef components >>= \case
+          Nothing -> pure ()
+          Just cs -> climb (_componentParentId cs)
+-----------------------------------------------------------------------------
 -- | Send any @ToJSON message => message@ to the children's t'Miso.Types.Component' mailbox
+--
+-- N.B. this is only relevant for immediate descendants (not all descendants).
 --
 -- @
 -- mailChildren ("test message" :: MisoString) :: Effect parent model action


### PR DESCRIPTION
Like `mailChildren`, `mail`, etc. this function sends any `Value` to all ancestors along the `Component` hierarchy.