### PR TITLE
Add React `props` hook.

### DIFF
--- a/src/Miso/Runtime.hs
+++ b/src/Miso/Runtime.hs
@@ -232,7 +232,7 @@ initialize events _componentParentId hydrate isRoot initialProps comp@Component 
         , _componentModel = initializedModel
         , _prevComponentProps = _componentProps
         , _componentPropsPhase = \oldProps newProps ->
-            case props of
+            case onPropsChanged of
               Just f -> _componentSink (f oldProps newProps)
               _ -> pure ()
         , ..

--- a/src/Miso/Runtime.hs
+++ b/src/Miso/Runtime.hs
@@ -196,10 +196,10 @@ initialize events _componentParentId hydrate isRoot initialProps comp@Component 
       putMVar frame =<< fromJSValUnchecked jsval
 
   let _componentDraw = \newModel -> do
-        props <- (^. componentProps) . (IM.! _componentId) <$> readIORef components
+        currentProps <- (^. componentProps) . (IM.! _componentId) <$> readIORef components
         newVTree <-
           buildVTree events _componentParentId _componentId Draw
-            _componentSink logLevel (view props newModel)
+            _componentSink logLevel (view currentProps newModel)
         oldVTree <- liftIO (readIORef _componentVTree)
         _frame <- requestAnimationFrame rAFCallback
         _timestamp :: Double <- takeMVar frame
@@ -208,8 +208,8 @@ initialize events _componentParentId hydrate isRoot initialProps comp@Component 
         liftIO (atomicWriteIORef _componentVTree newVTree)
         FFI.flush
 
-  let _componentApplyActions = \(actions :: [action]) model_ comps props -> do 
-        let info = ComponentInfo _componentId _componentParentId _componentDOMRef props
+  let _componentApplyActions = \(actions :: [action]) model_ comps currentProps -> do
+        let info = ComponentInfo _componentId _componentParentId _componentDOMRef currentProps
         List.foldl' (\(vcomps, m, ss, dirtySet) a ->
           case runEffect (update a) info m of
             (n, sss) ->
@@ -230,6 +230,11 @@ initialize events _componentParentId hydrate isRoot initialProps comp@Component 
         , _componentModelDirty = modelCheck
         , _componentChildren = mempty
         , _componentModel = initializedModel
+        , _prevComponentProps = _componentProps
+        , _componentPropsPhase = \oldProps newProps ->
+            case props of
+              Just f -> _componentSink (f oldProps newProps)
+              _ -> pure ()
         , ..
         }
 
@@ -317,9 +322,10 @@ scheduler =
         | vcompId < 0 -> do
             -- props propagation, negated 'ComponentId' indicates render-phase only.
             vcomps <- liftIO (readIORef components)
-            forM_ (IM.lookup (negate vcompId) vcomps) $ \ComponentState {..} ->
+            forM_ (IM.lookup (negate vcompId) vcomps) $ \ComponentState {..} -> do
               _componentDraw _componentModel
-                             
+              _componentPropsPhase _prevComponentProps _componentProps
+
       Just (vcompId, actions) -> do
         mounted <- isMounted vcompId
         when mounted (run vcompId actions)
@@ -612,7 +618,7 @@ dequeue
 dequeue q =
   case q ^. queueSchedule of
     S.Empty -> Nothing
-    sched@(vcompId S.:<| leftover) ->
+    sched@(vcompId S.:<| _) ->
       case q ^. queue . at vcompId of
         Nothing ->
           let (_, remaining) = S.spanl (== vcompId) sched
@@ -675,6 +681,9 @@ componentBindings = lens _componentBindings $ \record field -> record { _compone
 componentProps :: Lens (ComponentState parent props model action) props
 componentProps = lens _componentProps $ \record field -> record { _componentProps = field }
 -----------------------------------------------------------------------------
+prevComponentProps :: Lens (ComponentState parent props model action) props
+prevComponentProps = lens _prevComponentProps $ \record field -> record { _prevComponentProps = field }
+-----------------------------------------------------------------------------
 -- | Hydrate avoids calling @diff@, and instead calls @hydrate@
 -- 'Draw' invokes 'Miso.Diff.diff'
 data Hydrate
@@ -691,6 +700,8 @@ data ComponentState parent props model action
   -- ^ The ID of the t'Miso.Types.Component''s parent
   , _componentProps :: props
   -- ^ The current props passed to this t'Miso.Types.Component'
+  , _prevComponentProps :: props
+  -- ^ The previous Component props passed to this t'Miso.Types.Component'
   , _componentSubThreads :: IORef (Map MisoString ThreadId)
   -- ^ Mapping of all 'Sub' in use by t'Miso.Types.Component'
   , _componentDOMRef :: DOMRef
@@ -713,6 +724,8 @@ data ComponentState parent props model action
   -- ^ Mailbox for asynchronous t'Miso.Types.Component' communication
   , _componentDraw :: model -> IO ()
   -- ^ Helper function for t'Miso.Types.Component' rendering
+  , _componentPropsPhase :: props -> props -> IO ()
+  -- ^ Helper function for t'Miso.Types.Component' props changed phase.
   , _componentModelDirty :: model -> model -> Bool
   -- ^ Model diffing
   , _componentApplyActions
@@ -1088,6 +1101,7 @@ buildVTree events_ parentId_ vcompId hydrate snk logLevel_ = \case
         currentProps <- _componentProps . (IM.! componentId_) <$> readIORef components
         when (currentProps /= newProps) $ do
           modifyComponent componentId_ (componentProps .= newProps)
+          modifyComponent componentId_ (prevComponentProps .= currentProps)
           enqueueSchedule componentId_
 
     FFI.set "diffProps" diffPropsCallback vcomp_

--- a/src/Miso/Runtime.hs
+++ b/src/Miso/Runtime.hs
@@ -1100,8 +1100,9 @@ buildVTree events_ parentId_ vcompId hydrate snk logLevel_ = \case
         componentId_ <- fromJSValUnchecked =<< vcomp_ ! ("componentId" :: MisoString)
         currentProps <- _componentProps . (IM.! componentId_) <$> readIORef components
         when (currentProps /= newProps) $ do
-          modifyComponent componentId_ (componentProps .= newProps)
-          modifyComponent componentId_ (prevComponentProps .= currentProps)
+          modifyComponent componentId_ $ do 
+            componentProps .= newProps
+            prevComponentProps .= currentProps
           enqueueSchedule componentId_
 
     FFI.set "diffProps" diffPropsCallback vcomp_

--- a/src/Miso/Types.hs
+++ b/src/Miso/Types.hs
@@ -172,6 +172,11 @@ data Component parent props model action
   -- ^ action to execute during t'Miso.Types.Component' unmount phase.
   --
   -- @since 1.9.0.0
+  , props :: Maybe (props -> props -> action)
+  -- ^ action to execute when 'Component' @props@ have changed (a.k.a. @props@ phase).
+  -- Receives previous @props@ and current @props@ as arguments.
+  --
+  -- @since 1.11.0.0
   }
 -----------------------------------------------------------------------------
 -- | @mountPoint@ for t'Miso.Types.Component', e.g "body"
@@ -250,6 +255,7 @@ component m u v = Component
   , eventPropagation = False
   , mount = Nothing
   , unmount = Nothing
+  , props = Nothing
   }
 -----------------------------------------------------------------------------
 -- | Synonym for 'component'

--- a/src/Miso/Types.hs
+++ b/src/Miso/Types.hs
@@ -172,7 +172,7 @@ data Component parent props model action
   -- ^ action to execute during t'Miso.Types.Component' unmount phase.
   --
   -- @since 1.9.0.0
-  , props :: Maybe (props -> props -> action)
+  , onPropsChanged :: Maybe (props -> props -> action)
   -- ^ action to execute when 'Component' @props@ have changed (a.k.a. @props@ phase).
   -- Receives previous @props@ and current @props@ as arguments.
   --
@@ -255,7 +255,7 @@ component m u v = Component
   , eventPropagation = False
   , mount = Nothing
   , unmount = Nothing
-  , props = Nothing
+  , onPropsChanged = Nothing
   }
 -----------------------------------------------------------------------------
 -- | Synonym for 'component'


### PR DESCRIPTION
`props` hook 🪝 
==============

This is useful for a descendant `Component` to react to changes in its parent `Component`. Currently, hooks just alter the child `View`, without invoking the `update` function. Like `mount` / `unmount`, the `props` phase allows one to "hook" into `props` as they alter over time and process an `action` in response to these changes.

This further aligns miso w/ React specification parity. The `props` phase is an action that executes post `Component` draw. It receives both old props and new props as arguments.

Sharing should be preserved between old and new props.

```haskell
-- defaults to 'Nothing'

-- | Interface proposal
onPropsChanged :: Maybe (props -> props -> action)
               -- ^ old   ^ new

-- | Example 'Action'
data Action = PropsChanged ButtonProps ButtonProps

-- | Example usage
test :: Component parent ButtonProps model Action
test = myComponent { onPropsChanged = Just PropsChanged }
```

- [x] Extend 'Component' to receive `props` phase callback function
- [x] Add `prevComponentProps`
- [x] Extend `ComponentState` with `_componentPropsPhase`
- [x] Add `prevComponentProps` `Lens`.

The analog in React would be to track the previous props manually using a hook (`useRef`).

```javascript
import { useEffect, useRef } from 'react';

function usePrevious(value) {
  const ref = useRef();
  useEffect(() => {
    ref.current = value;
  }, [value]);
  return ref.current;
}

// Usage in your component
function MyComponent({ userId }) {
  const prevUserId = usePrevious(userId);

  useEffect(() => {
    if (prevUserId !== userId) {
      console.log(`User ID changed from ${prevUserId} to ${userId}`);
      // Fetch new user data here
    }
  }, [userId, prevUserId]);
}
```