### PR TITLE
Add `requestAnimationFrame()` `Sub`.

### DIFF
--- a/miso.cabal
+++ b/miso.cabal
@@ -153,9 +153,10 @@ library
     Miso.Subscription.History
     Miso.Subscription.Keyboard
     Miso.Subscription.Mouse
-    Miso.Subscription.Window
     Miso.Subscription.OnLine
+    Miso.Subscription.RAF
     Miso.Subscription.Util
+    Miso.Subscription.Window
     Miso.Svg
     Miso.Svg.Property
     Miso.Svg.Element

--- a/src/Miso/Subscription.hs
+++ b/src/Miso/Subscription.hs
@@ -20,6 +20,8 @@ module Miso.Subscription
   , module Miso.Subscription.Window
     -- ** OnLine
   , module Miso.Subscription.OnLine
+    -- ** requestForAnimationFrame
+  , module Miso.Subscription.RAF
   ) where
 -----------------------------------------------------------------------------
 import Miso.Subscription.Mouse
@@ -27,4 +29,5 @@ import Miso.Subscription.Keyboard
 import Miso.Subscription.History
 import Miso.Subscription.Window
 import Miso.Subscription.OnLine
+import Miso.Subscription.RAF
 -----------------------------------------------------------------------------

--- a/src/Miso/Subscription/RAF.hs
+++ b/src/Miso/Subscription/RAF.hs
@@ -1,0 +1,52 @@
+-----------------------------------------------------------------------------
+{-# LANGUAGE BangPatterns      #-}
+{-# LANGUAGE OverloadedStrings #-}
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Miso.Subscription.RAF
+-- Copyright   :  (C) 2016-2026 David M. Johnson
+-- License     :  BSD3-style (see the file LICENSE)
+-- Maintainer  :  David M. Johnson <code@dmj.io>
+-- Stability   :  experimental
+-- Portability :  non-portable
+--
+-- A `Sub` for `requestAnimationFrame`. Meant to be used in Canvas based
+-- animations / games to achieve 60fps.
+--
+-- @
+-- main :: IO ()
+-- main = startApp defaultEvents comp { subs = [ rAFSub Tick ] }
+--
+-- data Action = Tick Double
+-- @
+--
+----------------------------------------------------------------------------
+module Miso.Subscription.RAF where
+----------------------------------------------------------------------------
+import           Control.Monad (void)
+import           Data.IORef
+----------------------------------------------------------------------------
+import           Miso.DSL
+import           Miso.Effect (Sub)
+import           Miso.Subscription.Util (createSub)
+----------------------------------------------------------------------------
+-- | A 'Sub' for 60FPS animations when using 'requestForAnimationFrame'.
+--
+-- The 'Double' returned is a [DOMHighResTimeStamp](https://developer.mozilla.org/en-US/docs/Web/API/DOMHighResTimeStamp) expressed in milliseconds.
+--
+rAFSub :: (Double -> action) -> Sub action
+rAFSub toAction sink = createSub acquire release sink
+  where
+    acquire = do
+      ref <- newIORef (error "rAFSub: uninitialized, impossible")
+      callback <-
+        syncCallback1 $ \jsval -> do
+          sink =<< toAction <$> fromJSValUnchecked jsval
+          void (requestAnimationFrame =<< readIORef ref)
+
+      writeIORef ref callback
+      void (requestAnimationFrame callback)
+      pure callback
+
+    release callback = freeFunction (Function callback)
+----------------------------------------------------------------------------


### PR DESCRIPTION
A `Sub` for `requestAnimationFrame`. Meant to be used in `Canvas`-based animations / games to achieve 60fps. The `Double` returned is expressed in milliseconds.

- [x] Add `Miso.Subscription.RAF` module
- [x] Add `rAFSub` `Sub` that uses `requestAnimationFrame`

```haskell
main :: IO ()
main = startApp defaultEvents comp { subs = [ rAFSub Tick ] }

data Action = Tick Double
```