### PR TITLE
Prefer `toJSONList` to `OVERLAPPABLE`.

### DIFF
--- a/src/Miso/JSON.hs
+++ b/src/Miso/JSON.hs
@@ -164,6 +164,12 @@ class ToJSON a where
   toJSON :: a -> Value
   default toJSON :: (Generic a, GToJSON (Rep a)) => a -> Value
   toJSON = genericToJSON defaultOptions
+
+  -- | Encode a list of @a@. Defaults to a JSON 'Array'; overridden by the
+  -- 'Char' instance so that @[Char]@ (i.e. 'String') serializes as a JSON
+  -- string. This mirrors aeson and avoids overlapping @ToJSON [a]@ instances.
+  toJSONList :: [a] -> Value
+  toJSONList = Array . Prelude.map toJSON
 ----------------------------------------------------------------------------
 genericToJSON :: (Generic a, GToJSON (Rep a)) => Options -> a -> Value
 genericToJSON opts = gToJSON opts . from
@@ -375,15 +381,13 @@ instance ToJSON Value where
 ----------------------------------------------------------------------------
 instance ToJSON Char where
   toJSON c = String (singleton c)
+  toJSONList = String . MS.pack
 ----------------------------------------------------------------------------
 instance ToJSON Bool where
   toJSON = Bool
 ----------------------------------------------------------------------------
-instance {-# OVERLAPPING #-} ToJSON String where
-  toJSON = toJSON . MS.pack
-----------------------------------------------------------------------------
-instance {-# OVERLAPPABLE #-} ToJSON a => ToJSON [a] where
-  toJSON = Array . Prelude.map toJSON
+instance ToJSON a => ToJSON [a] where
+  toJSON = toJSONList
 ----------------------------------------------------------------------------
 instance ToJSON v => ToJSON (M.Map MisoString v) where
   toJSON = Object . M.map toJSON
@@ -655,7 +659,7 @@ instance FromJSON LT.Text where
 instance {-# OVERLAPPING #-} FromJSON String where
   parseJSON = withText "String" (pure . MS.unpack)
 ----------------------------------------------------------------------------
-instance {-# OVERLAPPABLE #-} FromJSON a => FromJSON [a] where
+instance FromJSON a => FromJSON [a] where
   parseJSON = withArray "[a]" (mapM parseJSON)
 ----------------------------------------------------------------------------
 instance FromJSON Double where

--- a/tests/app/Main.hs
+++ b/tests/app/Main.hs
@@ -581,6 +581,70 @@ main = withJS $ do
         JSON.encodePure (JSON.object [("ke\"y", JSON.Bool True)])
           `shouldBe` "{\"ke\\\"y\":true}"
 
+    -- toJSONList: String (i.e. [Char]) serializes as a JSON string while
+    -- other lists serialize as JSON arrays. This replaces the old
+    -- OVERLAPPING/OVERLAPPABLE ToJSON String / ToJSON [a] instances.
+    describe "Miso.JSON String vs list encoding (toJSONList) tests" $ do
+      -- String ([Char]) encodes as a JSON string, not an array of chars
+      it "encodes String as a JSON string" $ do
+        JSON.toJSON ("hello" :: String) `shouldBe` JSON.String "hello"
+      it "encodes a Char as a single-character JSON string" $ do
+        JSON.toJSON 'a' `shouldBe` JSON.String "a"
+      -- the empty String is "" (a string), not [] (an array): the Char
+      -- toJSONList specialization wins over the default Array encoding
+      it "encodes empty String as an empty JSON string, not an empty array" $ do
+        JSON.toJSON ("" :: String) `shouldBe` JSON.String ""
+      -- [a] for non-Char encodes as a JSON array (default toJSONList)
+      it "encodes [Int] as a JSON array" $ do
+        JSON.toJSON ([1,2,3] :: [Int])
+          `shouldBe` JSON.Array [JSON.Number 1, JSON.Number 2, JSON.Number 3]
+      it "encodes empty [Int] as an empty JSON array" $ do
+        JSON.toJSON ([] :: [Int]) `shouldBe` JSON.Array []
+      -- [String] is an array of JSON strings (each element via the Char path)
+      it "encodes [String] as an array of JSON strings" $ do
+        JSON.toJSON (["foo", "bar"] :: [String])
+          `shouldBe` JSON.Array [JSON.String "foo", JSON.String "bar"]
+      -- nested lists still nest as arrays
+      it "encodes [[Int]] as a JSON array of arrays" $ do
+        JSON.toJSON ([[1,2],[3]] :: [[Int]])
+          `shouldBe` JSON.Array
+            [ JSON.Array [JSON.Number 1, JSON.Number 2]
+            , JSON.Array [JSON.Number 3]
+            ]
+      -- round-trips through toJSON/fromJSON
+      it "round-trips String through toJSON/fromJSON" $ do
+        (JSON.fromJSON (JSON.toJSON ("hello world" :: String)) :: JSON.Result String)
+          `shouldBe` JSON.Success "hello world"
+      it "round-trips empty String through toJSON/fromJSON" $ do
+        (JSON.fromJSON (JSON.toJSON ("" :: String)) :: JSON.Result String)
+          `shouldBe` JSON.Success ""
+      it "round-trips [Int] through toJSON/fromJSON" $ do
+        (JSON.fromJSON (JSON.toJSON ([1,2,3] :: [Int])) :: JSON.Result [Int])
+          `shouldBe` JSON.Success [1,2,3]
+      it "round-trips [String] through toJSON/fromJSON" $ do
+        (JSON.fromJSON (JSON.toJSON (["foo","bar"] :: [String])) :: JSON.Result [String])
+          `shouldBe` JSON.Success ["foo","bar"]
+      it "round-trips [[Int]] through toJSON/fromJSON" $ do
+        (JSON.fromJSON (JSON.toJSON ([[1,2],[3]] :: [[Int]])) :: JSON.Result [[Int]])
+          `shouldBe` JSON.Success [[1,2],[3]]
+      -- full string round-trips via encodePure / decodePure
+      it "round-trips String through encodePure/decodePure" $ do
+        let s = JSON.encodePure ("a \"quoted\" string" :: String)
+            result = do
+              v <- decodePure s
+              case JSON.fromJSON v of
+                JSON.Success x -> Right (x :: String)
+                JSON.Error e   -> Left (S.unpack e)
+        result `shouldBe` Right "a \"quoted\" string"
+      it "round-trips [Int] through encodePure/decodePure" $ do
+        let s = JSON.encodePure ([1,2,3] :: [Int])
+            result = do
+              v <- decodePure s
+              case JSON.fromJSON v of
+                JSON.Success x -> Right (x :: [Int])
+                JSON.Error e   -> Left (S.unpack e)
+        result `shouldBe` Right [1,2,3]
+
     describe "Miso.Data.Map tests" $ do
       it "should construct a Map from a list and perform operations" $ do
         m <- liftIO (MDM.fromList [(1 :: Int, "foo" :: MisoString), (2 :: Int, "bar" :: MisoString)])


### PR DESCRIPTION
This gets around instance ambiguity between `String` and `[a]` that cannot be cleanly resolved with `OVERLAP` pragmas.

- [x] Add `toJSONList` to `ToJSON` class
- [x] Add tests to serialize / deserialize `String`