### PR TITLE
docs: flesh out Haddock sections in Miso.hs

### DIFF
--- a/src/Miso.hs
+++ b/src/Miso.hs
@@ -966,8 +966,6 @@
 -- Three approaches, pick one:
 --
 -- * __Template Haskell__ ("Miso.Lens.TH"): 'makeLenses' / 'makeClassy' splice lenses for each record field.
--- * __Generics__ ("Miso.Lens.Generic"): 'field' \/ 'HasLens' derive lenses without TH.
--- * __Hand-written__: construct a 'Lens' directly using the @Lens s a@ synonym.
 --
 -- @
 -- {-# LANGUAGE TemplateHaskell #-}
@@ -980,6 +978,28 @@
 --   Increment -> count '+=' 1
 --   Rename n  -> name '.~' n
 -- @
+--
+-- * __Generics__ ("Miso.Lens.Generic"): 'field' \/ 'HasLens' derive lenses at compile time
+--   using @GHC.Generics@ — no TH splice required. Requires @TypeApplications@ and,
+--   optionally, @OverloadedLabels@ for the @#field@ shorthand.
+--
+-- @
+-- {-# LANGUAGE DataKinds          #-}
+-- {-# LANGUAGE DeriveGeneric      #-}
+-- {-# LANGUAGE OverloadedLabels   #-}
+-- {-# LANGUAGE TypeApplications   #-}
+-- import GHC.Generics (Generic)
+-- import Miso.Lens.Generic (field)
+--
+-- data Model = Model { count :: Int, name :: MisoString }
+--   deriving (Eq, Generic)
+--
+-- update = \\case
+--   Increment -> 'field' \@\"count\" '+=' 1          -- via TypeApplications
+--   Rename n  -> #name '.~' n                     -- via OverloadedLabels
+-- @
+--
+-- * __Hand-written__: construct a 'Lens' directly using the @'Lens' s a@ synonym.
 --
 -- = HTML
 --

--- a/src/Miso.hs
+++ b/src/Miso.hs
@@ -7,14 +7,6 @@
 -----------------------------------------------------------------------------
 {-# OPTIONS_GHC -Wno-duplicate-exports #-}
 -----------------------------------------------------------------------------
--- |
--- Module      :  Miso
--- Copyright   :  (C) 2016-2026 David M. Johnson (@dmjio)
--- License     :  BSD3-style (see the file LICENSE)
--- Maintainer  :  David M. Johnson <code@dmj.io>
--- Stability   :  experimental
--- Portability :  non-portable
---
 -- = miso 🍜
 --
 -- @miso@ is a library for building web and native user interface applications in Haskell. See the [GitHub group](https://github.com/haskell-miso).
@@ -118,7 +110,223 @@
 --
 -- A full list of element smart constructors built on 'node' (e.g. 'Miso.Html.Element.div_') can be found in "Miso.Html.Element".
 --
--- = Your first t'Component'
+-- == 'VNode' (Element nodes)
+--
+-- A 'VNode' represents a [DOM element node](https://developer.mozilla.org/en-US/docs/Web/API/Element) — the most common kind of virtual DOM node.
+-- It carries a 'Namespace', a tag name, a list of 'Attribute' values, and a list of child 'View' nodes:
+--
+-- @
+-- 'VNode' 'HTML' "div" [ 'id_' "container" ] [ "Hello, world!" ]
+-- @
+--
+-- In practice you will rarely construct 'VNode' directly. Instead use the element smart constructors
+-- from "Miso.Html.Element", which fix the namespace and tag for you:
+--
+-- @
+-- 'div_'    [ 'id_' "container" ] [ "Hello, world!" ]
+-- 'button_' [ 'onClick' DoSomething ] [ "Click me" ]
+-- 'h1_'     [ 'className' "title" ] [ 'text' (ms pageTitle) ]
+-- @
+--
+-- For elements not covered by "Miso.Html.Element", use 'node' (or its synonym 'vnode') directly:
+--
+-- @
+-- 'node' 'HTML' "details" [] [ 'node' 'HTML' "summary" [] [ "More info" ] ]
+-- @
+--
+-- SVG and MathML elements use the 'SVG' and 'MATHML' namespaces respectively,
+-- and are covered by the smart constructors in "Miso.Svg.Element" and "Miso.Mathml.Element".
+--
+-- Unlike 'VComp' and 'VFrag', 'VNode' has a one-to-one correspondence with a physical DOM element:
+-- each 'VNode' in the virtual DOM maps to exactly one element in the browser.
+--
+-- The smart constructors for 'VNode' are:
+--
+-- * 'node'  — raw constructor, takes 'Namespace', tag, attributes, children
+-- * 'vnode' — synonym for 'node'
+-- * All combinators in "Miso.Html.Element", "Miso.Svg.Element", "Miso.Mathml.Element"
+--
+-- === 'VNode' lifecycle hooks
+--
+-- Similar to t'Component' lifecycle hooks, all 'Miso.Types.VNode' also expose lifecycle hooks.
+--
+-- * 'Miso.Event.onBeforeCreated'
+-- * 'Miso.Event.onCreated' / 'Miso.Event.onCreatedWith'
+-- * 'Miso.Event.onBeforeDestroyed' / 'Miso.Event.onBeforeDestroyedWith'
+-- * 'Miso.Event.onDestroyed'
+--
+-- These are convenient for initializing and deinitializing third-party libraries (as seen below with [highlight.js](https://highlightjs.org/))
+--
+-- @
+-- {-# LANGUAGE QuasiQuotes -#}
+-- {-# LANGUAGE MultilineStrings -#}
+--
+-- import Miso
+-- import Miso.FFI.QQ (js)
+--
+-- data Action = Highlight DOMRef
+--
+-- update :: Action -> 'Effect' parent props model Action
+-- update = \\case
+--   Highlight domRef -> 'io_' $ do
+--     ['js'| hljs.highlight(${domRef}) |]
+--
+-- view :: props -> model -> 'View' model Action
+-- view _ x =
+--   'code_'
+--   [ 'onCreatedWith' Highlight
+--   ]
+--   [ """
+--     function addOne (x) { return x + 1; }
+--     """
+--   ]
+-- @
+--
+-- As a convention, the @*with@ variant of 'VNode' lifecycle hooks (e.g. 'Miso.Event.onCreatedWith') provide the target 'DOMRef' in the callback function (shown above).
+--
+-- === Attributes / Properties
+--
+-- The 'Attribute' type carries everything that can be attached to a DOM element:
+--
+-- @
+-- data 'Attribute' action
+--   = 'Property' 'MisoString' 'Miso.JSON.Value'          -- ^ DOM property (key/value)
+--   | 'ClassList' ['MisoString']                         -- ^ CSS class list
+--   | 'On' ('Sink' action -> ...)                        -- ^ Event handler
+--   | 'Styles' ('Data.Map.Strict.Map' 'MisoString' 'MisoString') -- ^ Inline style map
+-- @
+--
+-- In practice you never construct these directly. Use the smart constructors from
+-- "Miso.Html.Property", "Miso.Html.Event", "Miso.Property", and "Miso.CSS":
+--
+-- @
+-- 'div_'
+--   [ 'id_' "container"                    -- textProp "id"
+--   , 'className' "card active"            -- textProp "class"
+--   , 'classList' ["card", "active"]       -- ClassList (alternative)
+--   , 'disabled_'                          -- boolProp "disabled" True
+--   , 'onClick' MyAction                   -- On event handler
+--   , 'Miso.CSS.style_' [ 'Miso.CSS.display' "flex" ] -- Styles map
+--   ]
+--   []
+-- @
+--
+-- ==== Custom properties
+--
+-- Use 'prop' (or the typed variants 'textProp', 'boolProp', 'intProp', 'doubleProp',
+-- 'objectProp') from "Miso.Property" to set arbitrary DOM properties:
+--
+-- @
+-- 'prop' "data-index" (42 :: Int)      -- sets element.data-index = 42
+-- 'textProp' "placeholder" "Search…"  -- sets element.placeholder
+-- 'boolProp' "checked" True            -- sets element.checked = true
+-- @
+--
+-- Note that DOM /properties/ and HTML /attributes/ are distinct. Miso sets
+-- properties on the DOM node object (e.g. @node.checked@) rather than the
+-- HTML attribute (e.g. @setAttribute("checked", ...)@). This matches what
+-- the browser actually exposes in JavaScript and avoids common pitfalls with
+-- boolean attributes.
+--
+-- ==== Keys
+--
+-- 'key_' (and its alias 'keyProp') attaches a reconciliation key to any element.
+-- See the @'Key'@ section for details.
+--
+-- @
+-- 'li_' [ 'key_' (itemId item) ] [ 'text' (itemLabel item) ]
+-- @
+--
+-- == 'VText' (Text nodes)
+--
+-- A 'VText' node represents a [DOM text node](https://developer.mozilla.org/en-US/docs/Web/API/Text).
+-- Unlike 'VComp' and 'VFrag', 'VText' has a one-to-one correspondence with a physical DOM node:
+-- each 'VText' in the virtual DOM maps to exactly one @Text@ node in the browser.
+--
+-- The simplest way to produce a 'VText' is via the 'IsString' instance on @'View' model action@.
+-- String literals inside a child list are automatically promoted to 'VText' nodes without
+-- any extra imports:
+--
+-- @
+-- 'div_' [] [ "Hello, world!" ]
+-- @
+--
+-- For dynamic content, use the 'text' smart constructor with a 'MisoString':
+--
+-- @
+-- 'div_' [] [ 'text' (ms userName) ]
+-- @
+--
+-- === HTML Encoding
+--
+-- When compiling with the @ssr@ flag (server-side rendering), 'text' automatically
+-- HTML-encodes its argument — @\<@, @\>@, @&@, @\"@, and @\'@ are replaced with their
+-- respective HTML entities. This prevents accidental XSS when rendering user-supplied
+-- strings on the server.
+--
+-- @
+-- -- SSR output: &lt;b&gt;bold&lt;\/b&gt;
+-- 'text' "\<b\>bold\<\/b\>"
+-- @
+--
+-- To embed pre-rendered or trusted content without escaping, use 'textRaw'. It is a
+-- no-op on the client and bypasses encoding on the server:
+--
+-- @
+-- 'textRaw' "\<b\>bold\<\/b\>"   -- server and client: \<b\>bold\<\/b\>
+-- @
+--
+-- === Concatenating Multiple Strings
+--
+-- 'text_' accepts a list of 'MisoString' values and joins them with a single space,
+-- which is useful when building text from multiple pieces without manual concatenation:
+--
+-- @
+-- -- Renders: Hello world
+-- 'div_' [] [ 'text_' [ "Hello", "world" ] ]
+-- @
+--
+-- === Keyed Text Nodes
+--
+-- A 'VText' may optionally carry a 'Key'. Keyed text nodes participate in the same
+-- reconciliation algorithm as keyed 'VNode' and 'VFrag' nodes. Providing a stable key
+-- lets the differ identify the node across renders, preventing unnecessary DOM text node
+-- replacement when sibling order changes.
+--
+-- @
+-- 'ul_' [] (map renderItem items)
+--
+-- renderItem :: Item -> 'View' model Action
+-- renderItem item = 'li_' [] [ 'textKey' (itemId item) (itemLabel item) ]
+-- @
+--
+-- 'keyed' can also attach a key to any existing 'View', including a 'VText' produced
+-- by a string literal or 'text':
+--
+-- @
+-- 'keyed' "greeting" ("Hello!" :: 'View' model action)
+-- @
+--
+-- The smart constructors for 'VText' are:
+--
+-- * 'text'     — single string, HTML-encoded on the server
+-- * 'vtext'    — synonym for 'text'
+-- * 'textRaw'  — single string, never HTML-encoded
+-- * 'text_'    — list of strings joined with a space
+-- * 'textKey'  — single keyed string
+-- * 'textKey_' — list of keyed strings joined with a space
+-- * 'keyed'    — attach a key to any 'View', including 'VText'
+--
+-- == 'VComp'
+--
+-- === 'VComp' lifecycle hooks
+--
+-- 'Component' are mounted on the fly during diffing. All t'Component` are equipped with `mount` and `unmount` hooks. This allows the defining of custom actions that will be processed in response to lifecycle events.
+--
+-- * 'Miso.Types.mount'
+-- * 'Miso.Types.unmount'
+--
+-- == Your first t'Component'
 --
 -- To define a 'Component' the 'component' smart constructor can be used.
 -- Below is an example of a simple counter 'Component'.
@@ -170,7 +378,7 @@
 -- -----------------------------------------------------------------------------
 -- @
 --
--- = Running your first t'Component'
+-- == Running your first t'Component'
 --
 -- The 'startApp' (or 'miso') functions are used to run the above t'Component'.
 --
@@ -200,7 +408,7 @@
 --   Init -> 'io_' ('consoleLog' "hello world!")
 -- @
 --
--- = 'Component' composition
+-- == 'Component' composition
 --
 -- @miso@ 'Component' can contain other 'Component'. This is
 -- accomplished through the 'Component' mounting combinator ('+>'). This combinator
@@ -256,168 +464,7 @@
 --
 -- 'startApp' and 'miso' will always infer @parent@ as 'ROOT'.
 --
--- = 'VComp' lifecycle hooks
---
--- 'Component' are mounted on the fly during diffing. All t'Component` are equipped with `mount` and `unmount` hooks. This allows the defining of custom actions that will be processed in response to lifecycle events.
---
--- * 'Miso.Types.mount'
--- * 'Miso.Types.unmount'
---
--- = 'VNode' lifecycle hooks
---
--- Similar to t'Component' lifecycle hooks, all 'Miso.Types.VNode' also expose lifecycle hooks.
---
--- * 'Miso.Event.onBeforeCreated'
--- * 'Miso.Event.onCreated' / 'Miso.Event.onCreatedWith'
--- * 'Miso.Event.onBeforeDestroyed' / 'Miso.Event.onBeforeDestroyedWith'
--- * 'Miso.Event.onDestroyed'
---
--- These are convenient for initializing and deinitializing third-party libraries (as seen below with [highlight.js](https://highlightjs.org/))
---
--- @
--- {-# LANGUAGE QuasiQuotes -#}
--- {-# LANGUAGE MultilineStrings -#}
---
--- import Miso
--- import Miso.FFI.QQ (js)
---
--- data Action = Highlight DOMRef
---
--- update :: Action -> 'Effect' parent props model Action
--- update = \\case
---   Highlight domRef -> 'io_' $ do
---     ['js'| hljs.highlight(${domRef}) |]
---
--- view :: props -> model -> 'View' model Action
--- view _ x =
---   'code_'
---   [ 'onCreatedWith' Highlight
---   ]
---   [ """
---     function addOne (x) { return x + 1; }
---     """
---   ]
--- @
---
--- As a convention, the @*with@ variant of 'VNode' lifecycle hooks (e.g. 'Miso.Event.onCreatedWith') provide the target 'DOMRef' in the callback function (shown above).
---
--- = 'VNode' (Element nodes)
---
--- A 'VNode' represents a [DOM element node](https://developer.mozilla.org/en-US/docs/Web/API/Element) — the most common kind of virtual DOM node.
--- It carries a 'Namespace', a tag name, a list of 'Attribute' values, and a list of child 'View' nodes:
---
--- @
--- 'VNode' 'HTML' "div" [ 'id_' "container" ] [ "Hello, world!" ]
--- @
---
--- In practice you will rarely construct 'VNode' directly. Instead use the element smart constructors
--- from "Miso.Html.Element", which fix the namespace and tag for you:
---
--- @
--- 'div_'    [ 'id_' "container" ] [ "Hello, world!" ]
--- 'button_' [ 'onClick' DoSomething ] [ "Click me" ]
--- 'h1_'     [ 'className' "title" ] [ 'text' (ms pageTitle) ]
--- @
---
--- For elements not covered by "Miso.Html.Element", use 'node' (or its synonym 'vnode') directly:
---
--- @
--- 'node' 'HTML' "details" [] [ 'node' 'HTML' "summary" [] [ "More info" ] ]
--- @
---
--- SVG and MathML elements use the 'SVG' and 'MATHML' namespaces respectively,
--- and are covered by the smart constructors in "Miso.Svg.Element" and "Miso.Mathml.Element".
---
--- Unlike 'VComp' and 'VFrag', 'VNode' has a one-to-one correspondence with a physical DOM element:
--- each 'VNode' in the virtual DOM maps to exactly one element in the browser.
---
--- The smart constructors for 'VNode' are:
---
--- * 'node'  — raw constructor, takes 'Namespace', tag, attributes, children
--- * 'vnode' — synonym for 'node'
--- * All combinators in "Miso.Html.Element", "Miso.Svg.Element", "Miso.Mathml.Element"
---
--- = 'VText' (Text nodes)
---
--- A 'VText' node represents a [DOM text node](https://developer.mozilla.org/en-US/docs/Web/API/Text).
--- Unlike 'VComp' and 'VFrag', 'VText' has a one-to-one correspondence with a physical DOM node:
--- each 'VText' in the virtual DOM maps to exactly one @Text@ node in the browser.
---
--- The simplest way to produce a 'VText' is via the 'IsString' instance on @'View' model action@.
--- String literals inside a child list are automatically promoted to 'VText' nodes without
--- any extra imports:
---
--- @
--- 'div_' [] [ "Hello, world!" ]
--- @
---
--- For dynamic content, use the 'text' smart constructor with a 'MisoString':
---
--- @
--- 'div_' [] [ 'text' (ms userName) ]
--- @
---
--- == HTML Encoding
---
--- When compiling with the @ssr@ flag (server-side rendering), 'text' automatically
--- HTML-encodes its argument — @\<@, @\>@, @&@, @\"@, and @\'@ are replaced with their
--- respective HTML entities. This prevents accidental XSS when rendering user-supplied
--- strings on the server.
---
--- @
--- -- SSR output: &lt;b&gt;bold&lt;\/b&gt;
--- 'text' "\<b\>bold\<\/b\>"
--- @
---
--- To embed pre-rendered or trusted content without escaping, use 'textRaw'. It is a
--- no-op on the client and bypasses encoding on the server:
---
--- @
--- 'textRaw' "\<b\>bold\<\/b\>"   -- server and client: \<b\>bold\<\/b\>
--- @
---
--- == Concatenating Multiple Strings
---
--- 'text_' accepts a list of 'MisoString' values and joins them with a single space,
--- which is useful when building text from multiple pieces without manual concatenation:
---
--- @
--- -- Renders: Hello world
--- 'div_' [] [ 'text_' [ "Hello", "world" ] ]
--- @
---
--- == Keyed Text Nodes
---
--- A 'VText' may optionally carry a 'Key'. Keyed text nodes participate in the same
--- reconciliation algorithm as keyed 'VNode' and 'VFrag' nodes. Providing a stable key
--- lets the differ identify the node across renders, preventing unnecessary DOM text node
--- replacement when sibling order changes.
---
--- @
--- 'ul_' [] (map renderItem items)
---
--- renderItem :: Item -> 'View' model Action
--- renderItem item = 'li_' [] [ 'textKey' (itemId item) (itemLabel item) ]
--- @
---
--- 'keyed' can also attach a key to any existing 'View', including a 'VText' produced
--- by a string literal or 'text':
---
--- @
--- 'keyed' "greeting" ("Hello!" :: 'View' model action)
--- @
---
--- The smart constructors for 'VText' are:
---
--- * 'text'     — single string, HTML-encoded on the server
--- * 'vtext'    — synonym for 'text'
--- * 'textRaw'  — single string, never HTML-encoded
--- * 'text_'    — list of strings joined with a space
--- * 'textKey'  — single keyed string
--- * 'textKey_' — list of keyed strings joined with a space
--- * 'keyed'    — attach a key to any 'View', including 'VText'
---
--- = 'VFrag' (Fragment nodes)
+-- == 'VFrag' (Fragment nodes)
 --
 -- Similar to the [React Fragment](https://react.dev/reference/react/Fragment) API (@\<Fragment\>@ or @\<\>\<\/\>@ syntax), and to @DocumentFragment@ in the browser DOM API. @miso@ provides a 'VFrag' constructor for grouping together sibling nodes without introducing an extra wrapper element in the DOM.
 --
@@ -449,7 +496,7 @@
 -- * 'fragment_'  — keyed fragment
 -- * 'vfrag_'     — keyed fragment (alias, infix-friendly: @\"key\" \`vfrag_\` [...]@)
 --
--- = 'Key'
+-- == 'Key'
 --
 -- A 'Key' is a unique identifier used to optimize diffing.
 --
@@ -476,7 +523,7 @@
 --   ]
 -- @
 --
--- = 'Events'
+-- == 'Events'
 --
 -- * Event Delegation
 --
@@ -525,59 +572,6 @@
 --   where
 --     decodeAt = 'DecodeTarget' ["target"]
 --     decoder = 'withObject' "target" $ \\o -> o .: "value"
--- @
---
--- = Attributes / Properties
---
--- The 'Attribute' type carries everything that can be attached to a DOM element:
---
--- @
--- data 'Attribute' action
---   = 'Property' 'MisoString' 'Miso.JSON.Value'          -- ^ DOM property (key/value)
---   | 'ClassList' ['MisoString']                         -- ^ CSS class list
---   | 'On' ('Sink' action -> ...)                        -- ^ Event handler
---   | 'Styles' ('Data.Map.Strict.Map' 'MisoString' 'MisoString') -- ^ Inline style map
--- @
---
--- In practice you never construct these directly. Use the smart constructors from
--- "Miso.Html.Property", "Miso.Html.Event", "Miso.Property", and "Miso.CSS":
---
--- @
--- 'div_'
---   [ 'id_' "container"                    -- textProp "id"
---   , 'className' "card active"            -- textProp "class"
---   , 'classList' ["card", "active"]       -- ClassList (alternative)
---   , 'disabled_'                          -- boolProp "disabled" True
---   , 'onClick' MyAction                   -- On event handler
---   , 'Miso.CSS.style_' [ 'Miso.CSS.display' "flex" ] -- Styles map
---   ]
---   []
--- @
---
--- == Custom properties
---
--- Use 'prop' (or the typed variants 'textProp', 'boolProp', 'intProp', 'doubleProp',
--- 'objectProp') from "Miso.Property" to set arbitrary DOM properties:
---
--- @
--- 'prop' "data-index" (42 :: Int)      -- sets element.data-index = 42
--- 'textProp' "placeholder" "Search…"  -- sets element.placeholder
--- 'boolProp' "checked" True            -- sets element.checked = true
--- @
---
--- Note that DOM /properties/ and HTML /attributes/ are distinct. Miso sets
--- properties on the DOM node object (e.g. @node.checked@) rather than the
--- HTML attribute (e.g. @setAttribute("checked", ...)@). This matches what
--- the browser actually exposes in JavaScript and avoids common pitfalls with
--- boolean attributes.
---
--- == Keys
---
--- 'key_' (and its alias 'keyProp') attaches a reconciliation key to any element.
--- See the @'Key'@ section for details.
---
--- @
--- 'li_' [ 'key_' (itemId item) ] [ 'text' (itemLabel item) ]
 -- @
 --
 -- = 'Effect'
@@ -639,13 +633,13 @@
 -- * __Async mailbox__ — message-passing via 'mail' / 'broadcast' / 'checkMail'; any 'Component' can send a t'Miso.JSON.Value' to any other by 'ComponentId'.
 -- * __PubSub__ ("Miso.PubSub") — publish\/subscribe for fan-out messaging across unrelated 'Component'.
 --
--- = Props
+-- == Props
 --
 -- Inspired by [React props](https://react.dev/learn/passing-props-to-a-component),
 -- @miso@ allows a parent 'Component' to pass read-only data down to a child 'Component'
 -- via a mechanism called /props/ (short for /properties/).
 --
--- == Props vs. Component-local state
+-- === Props vs. Component-local state
 --
 -- * __model__: Component-local state. It is owned and mutated exclusively by the 'Component'
 --   itself through its 'Miso.Types.update' function. No other 'Component' can write to it directly.
@@ -658,7 +652,7 @@
 -- This mirrors the distinction in React between component state (@useState@) and props
 -- received from above (@function MyComponent({ name }) { ... }@).
 --
--- === When to use props
+-- ==== When to use props
 --
 -- Props are best suited for /metadata/ — contextual or configuration data that the child needs
 -- to know about but should not own. Good examples: a user's display name, a theme token, a
@@ -670,7 +664,7 @@
 -- every change, creating unnecessary coupling. Prefer @props@ for \"what the child should
 -- know\" and @model@ for \"what the child should do\".
 --
--- == Props in 'Miso.Types.view'
+-- === Props in 'Miso.Types.view'
 --
 -- The 'Miso.Types.view' field of a 'Component' always takes @props@ as its first argument:
 --
@@ -685,7 +679,7 @@
 -- view _props model = …
 -- @
 --
--- == Props in 'Effect' \/ 'Miso.Types.update'
+-- === Props in 'Effect' \/ 'Miso.Types.update'
 --
 -- Use 'getProps' inside the 'Effect' monad to read the current value of @props@:
 --
@@ -706,7 +700,7 @@
 --     …
 -- @
 --
--- == 'ROOT' — the top-level 'Component'
+-- === 'ROOT' — the top-level 'Component'
 --
 -- When a 'Component' is passed to 'startApp' (or 'miso') it has no parent.
 -- The @parent@ type is specialized to 'ROOT' and @props@ is fixed to @()@:
@@ -719,7 +713,7 @@
 -- root-level 'Component'. You can simply ignore the first argument in 'view' and
 -- skip 'getProps' in 'Miso.Types.update'.
 --
--- == Passing props to a child 'Component'
+-- === Passing props to a child 'Component'
 --
 -- Use 'mountWithProps_' (keyed) or 'mountWithProps' (unkeyed) in the parent's 'view' to
 -- mount a child and supply its props:
@@ -733,7 +727,7 @@
 --   -> 'View' parent a
 -- @
 --
--- == Example: child reading parent-supplied props
+-- === Example: child reading parent-supplied props
 --
 -- The following shows a parent 'Component' that maintains a greeting string in its
 -- @model@ and passes it as @props@ to a child 'Component'. The child renders the
@@ -783,12 +777,12 @@
 -- * The root 'App' always has @props ~ ()@; no extra plumbing is needed when calling 'startApp'.
 --
 --
--- == Asynchronous communication
+-- === Asynchronous communication
 --
 -- Every 'Component' has a 'mailbox' — a slot that receives t'Miso.JSON.Value' messages
 -- sent by other components. Messages are dispatched asynchronously via the event queue.
 --
--- === Sending
+-- ==== Sending
 --
 -- * 'mail' @componentId msg@ — send to a specific 'ComponentId' (obtained via 'ask' inside 'Effect')
 -- * 'mailParent' @msg@ — send to the direct parent
@@ -796,7 +790,7 @@
 -- * 'mailAncestors' @msg@ — walk up the hierarchy, delivering to every ancestor
 -- * 'broadcast' @msg@ — deliver to every mounted 'Component' except the sender
 --
--- === Receiving with 'checkMail'
+-- ==== Receiving with 'checkMail'
 --
 -- Wire up the 'mailbox' field on 'Component' using 'checkMail', which handles
 -- JSON parsing and routes to success\/error actions:
@@ -811,7 +805,7 @@
 --   { 'mailbox' = 'checkMail' ReceivedMsg MailError }
 -- @
 --
--- === Looking up a 'ComponentId'
+-- ==== Looking up a 'ComponentId'
 --
 -- Inside 'Effect', use 'ask' to obtain a t'ComponentInfo':
 --
@@ -827,13 +821,13 @@
 --
 -- * "Miso.PubSub" — publish\/subscribe pattern for fan-out messaging across unrelated components.
 --
--- == Synchronous communication
+-- === Synchronous communication
 --
 -- * "Miso.Binding"
 --
 -- Experimental support for data bindings (where 'Component' model can synchronize fields via a 'Miso.Lens.Lens' in response to model differences along the parent-child relationship). See the "Miso.Binding" module for more information, and the [miso-reactive](https://github.com/haskell-miso/miso-reactive) example. *Warning*: This is still considered experimental.
 --
--- == Parent access
+-- === Parent access
 --
 -- * 'parent'
 --
@@ -895,63 +889,6 @@
 -- This ensures that event listeners can be unregistered when a 'Component' unmounts. For example usage
 -- please see the "Miso.Subscription" sub modules. 'createSub' is only meant to be used in scenarios where
 -- custom event listeners are required.
---
--- = (2D/3D) Canvas support
---
--- Miso has full 2D and 3D canvas support via "Miso.Canvas". See also the
--- [miso-canvas](https://github.com/haskell-miso/miso-canvas2d) example and the
--- [three-miso](https://github.com/haskell-miso/three-miso) package for Three.js integration.
---
--- == The 'Miso.Canvas.Canvas' monad
---
--- Drawing commands run in the 'Miso.Canvas.Canvas' monad, which is a 'ReaderT' over a
--- @CanvasContext2D@ (the raw JavaScript @CanvasRenderingContext2D@):
---
--- @
--- type Canvas a = ReaderT CanvasContext2D IO a
--- @
---
--- == Embedding a canvas in the view
---
--- Use the 'Miso.Canvas.canvas' smart constructor.
--- It takes an /init/ callback (runs once on mount, returns state) and a
--- /draw/ callback (runs on every render with the current state):
---
--- @
--- 'Miso.Canvas.canvas'
---   [ HP.'width_' "800", HP.'height_' "480" ]
---   (\\_ -> pure ())                   -- init: no per-canvas state
---   (\\() -> drawScene myModel)        -- draw: closure over current model
--- @
---
--- 'Miso.Canvas.canvas_' is the variant that threads no init state at all (always passes @()@).
---
--- == Drawing commands
---
--- Common 2D primitives:
---
--- @
--- drawScene :: Model -> 'Miso.Canvas.Canvas' ()
--- drawScene model = do
---   'Miso.Canvas.clearRect' (0, 0, 800, 480)
---   'Miso.Canvas.fillStyle' ('Miso.CSS.Color.RGB' 30 144 255)
---   'Miso.Canvas.beginPath' ()
---   'Miso.Canvas.arc' (400, 240, 50, 0, 2 * pi)
---   'Miso.Canvas.fill' ()
---   'Miso.Canvas.font' "24px sans-serif"
---   'Miso.Canvas.fillText' ("Score: " \<\> ms (score model), 10, 30)
--- @
---
--- Available primitives include: 'Miso.Canvas.clearRect', 'Miso.Canvas.fillRect', 'Miso.Canvas.strokeRect',
--- 'Miso.Canvas.beginPath', 'Miso.Canvas.closePath', 'Miso.Canvas.moveTo', 'Miso.Canvas.lineTo',
--- 'Miso.Canvas.arc', 'Miso.Canvas.arcTo', 'Miso.Canvas.fill', 'Miso.Canvas.stroke',
--- 'Miso.Canvas.fillText', 'Miso.Canvas.drawImage', 'Miso.Canvas.drawImage''.
---
--- Style setters: 'Miso.Canvas.fillStyle', 'Miso.Canvas.strokeStyle', 'Miso.Canvas.lineWidth', 'Miso.Canvas.font'.
--- 'Miso.Canvas.fillStyle' and 'Miso.Canvas.strokeStyle' accept a 'Miso.Canvas.StyleArg' — use
--- 'Miso.Canvas.color' (not 'Miso.CSS.color') to construct one from a t'Miso.CSS.Color.Color' value.
--- See the __Canonical Import Pattern__ section for how to avoid the name collision
--- between 'Miso.Canvas.color' and 'Miso.CSS.color'.
 --
 -- = 'Control.Monad.State.State' management
 --
@@ -1031,44 +968,208 @@
 -- name = 'lens' _name $ \\p n -> p { _name = n }
 -- @
 --
--- = HTML
+-- == 'MisoString'
 --
--- Miso's 'View' type doubles as an HTML serialiser via the 'ToHtml' class in
--- "Miso.Html.Render". This is used for server-side rendering (SSR): build a
--- 'View' with the normal DSL and render it to a lazy 'Data.ByteString.Lazy.ByteString'
--- on the server.
+-- t'MisoString' is miso's canonical string type, chosen to minimise copying between
+-- the Haskell and JavaScript heaps:
 --
--- @
--- class 'ToHtml' a where
---   'toHtml' :: a -> 'Data.ByteString.Lazy.ByteString'
--- @
+-- * __JS / WASM backends__: t'MisoString' is @JSString@, a direct reference to a
+--   JavaScript string — no marshalling cost when passing to the DOM or FFI.
+-- * __Server / vanilla GHC__ (@ssr@ flag): t'MisoString' is t'Data.Text'.
 --
--- Instances are provided for @'View' m a@ and @['View' m a]@:
+-- Use t'MisoString' anywhere you would otherwise reach for 'String' or 'Text' in a
+-- miso application. See "Miso.String" for the full API.
 --
--- @
--- import Miso.Html.Render (toHtml)
+-- === Converting to 'MisoString'
 --
--- pageHtml :: 'Data.ByteString.Lazy.ByteString'
--- pageHtml = 'toHtml' $ 'div_' [ 'id_' "root" ] [ "Hello, world!" ]
--- @
---
--- This is typically wired into a Servant handler on the server using the
--- [servant-miso-html](https://github.com/haskell-miso/servant-miso-html) package,
--- which provides an @HTML@ content-type that serialises 'View' and 'Component'
--- values directly — no manual 'ByteString' conversion needed:
+-- The 'ms' function (shorthand for 'toMisoString') converts any type with a
+-- 'ToMisoString' instance:
 --
 -- @
--- import Servant.Miso.Html (HTML)
---
--- type Home    = \"home\"    :\> Get '[HTML] (Component model action)
--- type About   = \"about\"   :\> Get '[HTML] (View model action)
--- type Contact = \"contact\" :\> Get '[HTML] [View model action]
--- type API = Home :\<|\> About :\<|\> Contact
+-- ms "hello"          -- String    -> MisoString
+-- ms (42 :: Int)      -- Int       -> MisoString
+-- ms (3.14 :: Double) -- Double    -> MisoString
+-- ms myText           -- Data.Text -> MisoString
 -- @
 --
--- On the client, pass the matching 'Component' to 'miso' (instead of 'startApp')
--- so it hydrates the server-rendered markup rather than redrawing from scratch.
--- See the __Prerendering__ section for the full flow.
+-- 'ToMisoString' instances are provided for 'String', t'Data.Text.Text',
+-- t'Data.Text.Lazy.Text', t'Data.ByteString.ByteString', 'Int', 'Word',
+-- 'Double', 'Float', and 'Char'.
+--
+-- === Converting from 'MisoString'
+--
+-- 'fromMisoString' parses a t'MisoString' back into another type (throws on failure).
+-- Use 'fromMisoStringEither' for a safe variant:
+--
+-- @
+-- fromMisoString "42"     :: Int     -- 42
+-- fromMisoString "3.14"   :: Double  -- 3.14
+-- fromMisoStringEither s  :: Either String Int
+-- @
+--
+-- 'FromMisoString' instances are provided for 'String', t'Data.Text.Text',
+-- t'Data.Text.Lazy.Text', t'Data.ByteString.ByteString', 'Int', 'Word',
+-- 'Double', and 'Float'.
+--
+-- === Multiline literals
+--
+-- "Miso.String.QQ" provides a QuasiQuoter for multiline t'MisoString' literals:
+--
+-- @
+-- {-# LANGUAGE QuasiQuotes #-}
+--
+-- import Miso.String.QQ (misoString)
+--
+-- snippet :: MisoString
+-- snippet = [misoString|
+--   line one
+--   line two
+-- |]
+-- @
+--
+-- t'MisoString' is also the element type used throughout "Miso.Util.Lexer" and
+-- "Miso.Util.Parser".
+--
+-- == JSON
+--
+-- "Miso.JSON" is a [microaeson](https://hackage.haskell.org/package/microaeson)-inspired
+-- JSON library specialised to t'MisoString'. On the JS\/WASM backends it delegates
+-- encoding and decoding to the JavaScript runtime (@JSON.stringify@ \/ @JSON.parse@)
+-- for performance. On the server (@ssr@ flag) it uses a pure Haskell implementation.
+-- "Miso.JSON" is used internally by "Miso.Event.Decoder", "Miso.Fetch", and "Miso.WebSocket".
+--
+-- === 'Miso.JSON.Value'
+--
+-- The JSON t'Miso.JSON.Value' type mirrors the JSON specification:
+--
+-- @
+-- data 'Miso.JSON.Value'
+--   = 'Miso.JSON.Number' 'Double'
+--   | 'Miso.JSON.Bool'   'Bool'
+--   | 'Miso.JSON.String' 'MisoString'
+--   | 'Miso.JSON.Array'  ['Miso.JSON.Value']
+--   | 'Miso.JSON.Object' 'Miso.JSON.Object'
+--   | 'Miso.JSON.Null'
+-- @
+--
+-- === Encoding
+--
+-- Encode any 'ToJSON' instance to a t'MisoString':
+--
+-- @
+-- 'encode' value        -- uses JS runtime on client, pure on server
+-- 'encodePure' value    -- always uses pure Haskell implementation
+-- @
+--
+-- === Decoding
+--
+-- @
+-- 'decode' s            :: Maybe a      -- returns Nothing on failure
+-- 'eitherDecode' s      :: Either MisoString a
+-- @
+--
+-- === 'ToJSON' \/ 'FromJSON'
+--
+-- Derive instances via @GHC.Generics@:
+--
+-- @
+-- {-# LANGUAGE DeriveGeneric #-}
+--
+-- import GHC.Generics
+-- import Miso.JSON
+--
+-- data User = User { name :: MisoString, age :: Int }
+--   deriving (Generic)
+--
+-- instance ToJSON   User
+-- instance FromJSON User
+-- @
+--
+-- Use 'genericToJSON' \/ 'genericParseJSON' with 'Options' to customise field and
+-- constructor names. 'camelTo2' is provided for converting @camelCase@ to
+-- @snake_case@ (or any separator):
+--
+-- @
+-- instance ToJSON User where
+--   toJSON = 'genericToJSON' 'defaultOptions' { 'fieldLabelModifier' = 'camelTo2' \'_\' }
+-- @
+--
+-- === Building and Parsing Objects
+--
+-- @
+-- -- Build
+-- 'object' [ "name" '.=' ms "Alice", "age" '.=' (30 :: Int) ]
+--
+-- -- Parse (inside a 'withObject' callback or event decoder)
+-- 'withObject' "User" $ \\o -> User
+--   \<$\> o '.:' "name"     -- required field
+--   \<*\> o '.:' "age"
+--
+-- o '.:?' "nickname"    -- optional field → Maybe a
+-- o '.:!' "nickname"    -- optional field, explicit null → Maybe a
+-- p '.!=' "anon"        -- provide a default for a Maybe parser
+-- @
+--
+-- === Pretty-Printing
+--
+-- @
+-- 'encodePretty'  value          -- indented with 'defConfig' (2-space indent)
+-- 'encodePretty'' config value   -- indented with custom 'Config'
+-- @
+--
+-- === @miso-aeson@
+--
+-- If you prefer to use the [aeson](https://hackage.haskell.org/package/aeson) library directly,
+-- the [miso-aeson](https://github.com/haskell-miso/miso-aeson) package provides a compatibility
+-- shim that bridges @aeson@\'s 'Data.Aeson.ToJSON' \/ 'Data.Aeson.FromJSON' instances with miso\'s
+-- event decoder and fetch API, so existing @aeson@-derived instances can be used without rewriting them.
+--
+-- == Styles
+--
+-- Miso does not prescribe a single CSS strategy. Three approaches work out of the box:
+--
+-- === 1. Structured DSL ("Miso.CSS")
+--
+-- 'style_' takes a list of @'Style'@ values (which are @(MisoString, MisoString)@ pairs).
+-- Miso manages individual properties on the DOM node, merging and diffing them efficiently:
+--
+-- @
+-- import qualified Miso.CSS as CSS
+-- import           Miso.CSS.Color (RGB(..))
+--
+-- 'div_'
+--   [ CSS.'style_'
+--       [ CSS.'display' "flex"
+--       , CSS.'flexDirection' "column"
+--       , CSS.'backgroundColor' (RGB 30 30 30)
+--       , CSS.'color' (RGB 255 255 255)
+--       ]
+--   ]
+--   []
+-- @
+--
+-- Custom properties can be constructed with the '=:' operator (re-exported from "Miso.Util"):
+--
+-- @
+-- "user-select" '=:' "none"
+-- @
+--
+-- === 2. Inline string ('CSS.styleInline_')
+--
+-- For simple or dynamic style strings, 'styleInline_' sets the element's @style@
+-- attribute as a raw string:
+--
+-- @
+-- CSS.'styleInline_' "display:flex; gap:8px; padding:16px"
+-- @
+--
+-- === 3. External stylesheets
+--
+-- Link external CSS files from the @\<head\>@ via the 'styles' field on 'Component'
+-- (see the __Development__ section), or include them in your HTML template directly.
+-- This is the most common approach for production apps using Tailwind, Bootstrap, etc.
+--
+-- See [miso-ui](https://ui.haskell-miso.org) for a larger example.
 --
 -- = JavaScript EDSL
 --
@@ -1217,265 +1318,101 @@
 -- 'button_' [ 'Miso.Router.href_' (Widget (Capture 10) (QueryParam Nothing)) ] [ "Go to widget 10" ]
 -- @
 --
--- = 'MisoString'
+-- = (2D/3D) Canvas support
 --
--- t'MisoString' is miso's canonical string type, chosen to minimise copying between
--- the Haskell and JavaScript heaps:
+-- Miso has full 2D and 3D canvas support via "Miso.Canvas". See also the
+-- [miso-canvas](https://github.com/haskell-miso/miso-canvas2d) example and the
+-- [three-miso](https://github.com/haskell-miso/three-miso) package for Three.js integration.
 --
--- * __JS / WASM backends__: t'MisoString' is @JSString@, a direct reference to a
---   JavaScript string — no marshalling cost when passing to the DOM or FFI.
--- * __Server / vanilla GHC__ (@ssr@ flag): t'MisoString' is t'Data.Text'.
+-- == The 'Miso.Canvas.Canvas' monad
 --
--- Use t'MisoString' anywhere you would otherwise reach for 'String' or 'Text' in a
--- miso application. See "Miso.String" for the full API.
---
--- == Converting to 'MisoString'
---
--- The 'ms' function (shorthand for 'toMisoString') converts any type with a
--- 'ToMisoString' instance:
+-- Drawing commands run in the 'Miso.Canvas.Canvas' monad, which is a 'ReaderT' over a
+-- @CanvasContext2D@ (the raw JavaScript @CanvasRenderingContext2D@):
 --
 -- @
--- ms "hello"          -- String    -> MisoString
--- ms (42 :: Int)      -- Int       -> MisoString
--- ms (3.14 :: Double) -- Double    -> MisoString
--- ms myText           -- Data.Text -> MisoString
+-- type Canvas a = ReaderT CanvasContext2D IO a
 -- @
 --
--- 'ToMisoString' instances are provided for 'String', t'Data.Text.Text',
--- t'Data.Text.Lazy.Text', t'Data.ByteString.ByteString', 'Int', 'Word',
--- 'Double', 'Float', and 'Char'.
+-- == Embedding a canvas in the view
 --
--- == Converting from 'MisoString'
---
--- 'fromMisoString' parses a t'MisoString' back into another type (throws on failure).
--- Use 'fromMisoStringEither' for a safe variant:
+-- Use the 'Miso.Canvas.canvas' smart constructor.
+-- It takes an /init/ callback (runs once on mount, returns state) and a
+-- /draw/ callback (runs on every render with the current state):
 --
 -- @
--- fromMisoString "42"     :: Int     -- 42
--- fromMisoString "3.14"   :: Double  -- 3.14
--- fromMisoStringEither s  :: Either String Int
+-- 'Miso.Canvas.canvas'
+--   [ HP.'width_' "800", HP.'height_' "480" ]
+--   (\\_ -> pure ())                   -- init: no per-canvas state
+--   (\\() -> drawScene myModel)        -- draw: closure over current model
 -- @
 --
--- 'FromMisoString' instances are provided for 'String', t'Data.Text.Text',
--- t'Data.Text.Lazy.Text', t'Data.ByteString.ByteString', 'Int', 'Word',
--- 'Double', and 'Float'.
+-- 'Miso.Canvas.canvas_' is the variant that threads no init state at all (always passes @()@).
 --
--- == Multiline literals
+-- == Drawing commands
 --
--- "Miso.String.QQ" provides a QuasiQuoter for multiline t'MisoString' literals:
+-- Common 2D primitives:
 --
 -- @
--- {-# LANGUAGE QuasiQuotes #-}
---
--- import Miso.String.QQ (misoString)
---
--- snippet :: MisoString
--- snippet = [misoString|
---   line one
---   line two
--- |]
+-- drawScene :: Model -> 'Miso.Canvas.Canvas' ()
+-- drawScene model = do
+--   'Miso.Canvas.clearRect' (0, 0, 800, 480)
+--   'Miso.Canvas.fillStyle' ('Miso.CSS.Color.RGB' 30 144 255)
+--   'Miso.Canvas.beginPath' ()
+--   'Miso.Canvas.arc' (400, 240, 50, 0, 2 * pi)
+--   'Miso.Canvas.fill' ()
+--   'Miso.Canvas.font' "24px sans-serif"
+--   'Miso.Canvas.fillText' ("Score: " \<\> ms (score model), 10, 30)
 -- @
 --
--- t'MisoString' is also the element type used throughout "Miso.Util.Lexer" and
--- "Miso.Util.Parser".
+-- Available primitives include: 'Miso.Canvas.clearRect', 'Miso.Canvas.fillRect', 'Miso.Canvas.strokeRect',
+-- 'Miso.Canvas.beginPath', 'Miso.Canvas.closePath', 'Miso.Canvas.moveTo', 'Miso.Canvas.lineTo',
+-- 'Miso.Canvas.arc', 'Miso.Canvas.arcTo', 'Miso.Canvas.fill', 'Miso.Canvas.stroke',
+-- 'Miso.Canvas.fillText', 'Miso.Canvas.drawImage', 'Miso.Canvas.drawImage''.
 --
--- = JSON
+-- Style setters: 'Miso.Canvas.fillStyle', 'Miso.Canvas.strokeStyle', 'Miso.Canvas.lineWidth', 'Miso.Canvas.font'.
+-- 'Miso.Canvas.fillStyle' and 'Miso.Canvas.strokeStyle' accept a 'Miso.Canvas.StyleArg' — use
+-- 'Miso.Canvas.color' (not 'Miso.CSS.color') to construct one from a t'Miso.CSS.Color.Color' value.
+-- See the __Canonical Import Pattern__ section for how to avoid the name collision
+-- between 'Miso.Canvas.color' and 'Miso.CSS.color'.
 --
--- "Miso.JSON" is a [microaeson](https://hackage.haskell.org/package/microaeson)-inspired
--- JSON library specialised to t'MisoString'. On the JS\/WASM backends it delegates
--- encoding and decoding to the JavaScript runtime (@JSON.stringify@ \/ @JSON.parse@)
--- for performance. On the server (@ssr@ flag) it uses a pure Haskell implementation.
--- "Miso.JSON" is used internally by "Miso.Event.Decoder", "Miso.Fetch", and "Miso.WebSocket".
+-- = HTML
 --
--- == 'Miso.JSON.Value'
---
--- The JSON t'Miso.JSON.Value' type mirrors the JSON specification:
---
--- @
--- data 'Miso.JSON.Value'
---   = 'Miso.JSON.Number' 'Double'
---   | 'Miso.JSON.Bool'   'Bool'
---   | 'Miso.JSON.String' 'MisoString'
---   | 'Miso.JSON.Array'  ['Miso.JSON.Value']
---   | 'Miso.JSON.Object' 'Miso.JSON.Object'
---   | 'Miso.JSON.Null'
--- @
---
--- == Encoding
---
--- Encode any 'ToJSON' instance to a t'MisoString':
+-- Miso's 'View' type doubles as an HTML serialiser via the 'ToHtml' class in
+-- "Miso.Html.Render". This is used for server-side rendering (SSR): build a
+-- 'View' with the normal DSL and render it to a lazy 'Data.ByteString.Lazy.ByteString'
+-- on the server.
 --
 -- @
--- 'encode' value        -- uses JS runtime on client, pure on server
--- 'encodePure' value    -- always uses pure Haskell implementation
+-- class 'ToHtml' a where
+--   'toHtml' :: a -> 'Data.ByteString.Lazy.ByteString'
 -- @
 --
--- == Decoding
+-- Instances are provided for @'View' m a@ and @['View' m a]@:
 --
 -- @
--- 'decode' s            :: Maybe a      -- returns Nothing on failure
--- 'eitherDecode' s      :: Either MisoString a
+-- import Miso.Html.Render (toHtml)
+--
+-- pageHtml :: 'Data.ByteString.Lazy.ByteString'
+-- pageHtml = 'toHtml' $ 'div_' [ 'id_' "root" ] [ "Hello, world!" ]
 -- @
 --
--- == 'ToJSON' \/ 'FromJSON'
---
--- Derive instances via @GHC.Generics@:
---
--- @
--- {-# LANGUAGE DeriveGeneric #-}
---
--- import GHC.Generics
--- import Miso.JSON
---
--- data User = User { name :: MisoString, age :: Int }
---   deriving (Generic)
---
--- instance ToJSON   User
--- instance FromJSON User
--- @
---
--- Use 'genericToJSON' \/ 'genericParseJSON' with 'Options' to customise field and
--- constructor names. 'camelTo2' is provided for converting @camelCase@ to
--- @snake_case@ (or any separator):
+-- This is typically wired into a Servant handler on the server using the
+-- [servant-miso-html](https://github.com/haskell-miso/servant-miso-html) package,
+-- which provides an @HTML@ content-type that serialises 'View' and 'Component'
+-- values directly — no manual 'ByteString' conversion needed:
 --
 -- @
--- instance ToJSON User where
---   toJSON = 'genericToJSON' 'defaultOptions' { 'fieldLabelModifier' = 'camelTo2' \'_\' }
+-- import Servant.Miso.Html (HTML)
+--
+-- type Home    = \"home\"    :\> Get '[HTML] (Component model action)
+-- type About   = \"about\"   :\> Get '[HTML] (View model action)
+-- type Contact = \"contact\" :\> Get '[HTML] [View model action]
+-- type API = Home :\<|\> About :\<|\> Contact
 -- @
 --
--- == Building and Parsing Objects
---
--- @
--- -- Build
--- 'object' [ "name" '.=' ms "Alice", "age" '.=' (30 :: Int) ]
---
--- -- Parse (inside a 'withObject' callback or event decoder)
--- 'withObject' "User" $ \\o -> User
---   \<$\> o '.:' "name"     -- required field
---   \<*\> o '.:' "age"
---
--- o '.:?' "nickname"    -- optional field → Maybe a
--- o '.:!' "nickname"    -- optional field, explicit null → Maybe a
--- p '.!=' "anon"        -- provide a default for a Maybe parser
--- @
---
--- == Pretty-Printing
---
--- @
--- 'encodePretty'  value          -- indented with 'defConfig' (2-space indent)
--- 'encodePretty'' config value   -- indented with custom 'Config'
--- @
---
--- == @miso-aeson@
---
--- If you prefer to use the [aeson](https://hackage.haskell.org/package/aeson) library directly,
--- the [miso-aeson](https://github.com/haskell-miso/miso-aeson) package provides a compatibility
--- shim that bridges @aeson@\'s 'Data.Aeson.ToJSON' \/ 'Data.Aeson.FromJSON' instances with miso\'s
--- event decoder and fetch API, so existing @aeson@-derived instances can be used without rewriting them.
---
--- = Styles
---
--- Miso does not prescribe a single CSS strategy. Three approaches work out of the box:
---
--- == 1. Structured DSL ("Miso.CSS")
---
--- 'style_' takes a list of @'Style'@ values (which are @(MisoString, MisoString)@ pairs).
--- Miso manages individual properties on the DOM node, merging and diffing them efficiently:
---
--- @
--- import qualified Miso.CSS as CSS
--- import           Miso.CSS.Color (RGB(..))
---
--- 'div_'
---   [ CSS.'style_'
---       [ CSS.'display' "flex"
---       , CSS.'flexDirection' "column"
---       , CSS.'backgroundColor' (RGB 30 30 30)
---       , CSS.'color' (RGB 255 255 255)
---       ]
---   ]
---   []
--- @
---
--- Custom properties can be constructed with the '=:' operator (re-exported from "Miso.Util"):
---
--- @
--- "user-select" '=:' "none"
--- @
---
--- == 2. Inline string ('CSS.styleInline_')
---
--- For simple or dynamic style strings, 'styleInline_' sets the element's @style@
--- attribute as a raw string:
---
--- @
--- CSS.'styleInline_' "display:flex; gap:8px; padding:16px"
--- @
---
--- == 3. External stylesheets
---
--- Link external CSS files from the @\<head\>@ via the 'styles' field on 'Component'
--- (see the __Development__ section), or include them in your HTML template directly.
--- This is the most common approach for production apps using Tailwind, Bootstrap, etc.
---
--- See [miso-ui](https://ui.haskell-miso.org) for a larger example.
---
--- = Development
---
--- When developing miso applications interactively it is possible to append 'styles' and 'scripts' to the @\<head\>@ portion of
--- the page when the 'Component' mounts. This is a convenience only meant to be used in development. We recommend guarding the usage behind a flag.
---
--- @
--- main :: 'IO' ()
--- main = 'startApp' 'defaultEvents' counter
---  where
---    app = counter
--- #ifdef INTERACTIVE
---      { 'scripts' = [ 'Src' "https://ajax.googleapis.com/ajax/libs/jquery/3.7.1/jquery.min.js" ('False' :: 'CacheBust') ]
---      , 'styles' = [ 'Href' "https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" ('False' :: 'CacheBust')  ]
---      }
--- #endif
--- @
---
--- See the [miso-sampler](https://github.com/haskell-miso/miso-sampler) repository for more information.
---
--- = Debugging
---
--- Sometimes things can go wrong. Common errors like using `onClick` but not listening for the 'click' event are common.
--- These are errors that cannot be caught statically (unless we use a dependently-typed language like [Idris](https://idris-lang.org)). These can be detected by enabling 'DebugAll'. Currently, debugging event delegation and page hydration is supported.
---
--- * 'DebugHydrate'
--- * 'DebugEvents'
---
--- @
--- counter { 'logLevel' = 'DebugAll' }
--- @
---
--- = Internals
---
--- Internally miso uses a global event queue and a scheduler to process all
--- events raised by 'Component' throughout the lifetime of an application.
--- Events are processed in FIFO order, batched by the 'Component' that raised them.
---
--- * __Event queue__: All actions dispatched via a 'Sink' (from event handlers,
---   subscriptions, or 'io' callbacks) are enqueued and drained by the scheduler.
---
--- * __Scheduler__: The scheduler pulls actions off the queue one batch at a time,
---   runs the 'update' function for each, collects the resulting 'IO' work, and
---   executes it. Rendering (VDOM diff + patch) is triggered after each batch.
---
--- * __'Waiter'__: A 'Miso.Concurrent.Waiter' is a synchronization primitive used
---   internally to coordinate the event loop — it blocks the scheduler thread until
---   new work arrives, avoiding busy-waiting.
---
--- * __Event delegation__: Rather than attaching listeners to individual DOM nodes,
---   miso attaches a single capture and a single bubble listener to @\<body\>@.
---   Incoming events are routed through the virtual DOM tree to the matching handler.
---   This minimises listener churn when the VDOM is patched.
---
--- * __VDOM diffing__: The diff algorithm in "Miso.Diff" compares old and new
---   'View' trees and emits the minimal set of DOM mutations. Keyed children (see
---   the 'Key' section) significantly speed up child list reconciliation.
+-- On the client, pass the matching 'Component' to 'miso' (instead of 'startApp')
+-- so it hydrates the server-rendered markup rather than redrawing from scratch.
+-- See the __Prerendering__ section for the full flow.
 --
 -- = Prerendering
 --
@@ -1541,6 +1478,63 @@
 -- equivalent to static prerendering.
 --
 -----------------------------------------------------------------------------
+
+-- = Development
+--
+-- When developing miso applications interactively it is possible to append 'styles' and 'scripts' to the @\<head\>@ portion of
+-- the page when the 'Component' mounts. This is a convenience only meant to be used in development. We recommend guarding the usage behind a flag.
+--
+-- @
+-- main :: 'IO' ()
+-- main = 'startApp' 'defaultEvents' counter
+--  where
+--    app = counter
+-- #ifdef INTERACTIVE
+--      { 'scripts' = [ 'Src' "https://ajax.googleapis.com/ajax/libs/jquery/3.7.1/jquery.min.js" ('False' :: 'CacheBust') ]
+--      , 'styles' = [ 'Href' "https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" ('False' :: 'CacheBust')  ]
+--      }
+-- #endif
+-- @
+--
+-- See the [miso-sampler](https://github.com/haskell-miso/miso-sampler) repository for more information.
+--
+-- = Debugging
+--
+-- Sometimes things can go wrong. Common errors like using `onClick` but not listening for the 'click' event are common.
+-- These are errors that cannot be caught statically (unless we use a dependently-typed language like [Idris](https://idris-lang.org)). These can be detected by enabling 'DebugAll'. Currently, debugging event delegation and page hydration is supported.
+--
+-- * 'DebugHydrate'
+-- * 'DebugEvents'
+--
+-- @
+-- counter { 'logLevel' = 'DebugAll' }
+-- @
+--
+-- = Internals
+--
+-- Internally miso uses a global event queue and a scheduler to process all
+-- events raised by 'Component' throughout the lifetime of an application.
+-- Events are processed in FIFO order, batched by the 'Component' that raised them.
+--
+-- * __Event queue__: All actions dispatched via a 'Sink' (from event handlers,
+--   subscriptions, or 'io' callbacks) are enqueued and drained by the scheduler.
+--
+-- * __Scheduler__: The scheduler pulls actions off the queue one batch at a time,
+--   runs the 'update' function for each, collects the resulting 'IO' work, and
+--   executes it. Rendering (VDOM diff + patch) is triggered after each batch.
+--
+-- * __'Waiter'__: A 'Miso.Concurrent.Waiter' is a synchronization primitive used
+--   internally to coordinate the event loop — it blocks the scheduler thread until
+--   new work arrives, avoiding busy-waiting.
+--
+-- * __Event delegation__: Rather than attaching listeners to individual DOM nodes,
+--   miso attaches a single capture and a single bubble listener to @\<body\>@.
+--   Incoming events are routed through the virtual DOM tree to the matching handler.
+--   This minimises listener churn when the VDOM is patched.
+--
+-- * __VDOM diffing__: The diff algorithm in "Miso.Diff" compares old and new
+--   'View' trees and emits the minimal set of DOM mutations. Keyed children (see
+--   the 'Key' section) significantly speed up child list reconciliation.
 module Miso
   ( -- * API
     -- ** Miso

--- a/src/Miso.hs
+++ b/src/Miso.hs
@@ -1195,13 +1195,13 @@
 -- The JSON t'Miso.JSON.Value' type mirrors the JSON specification:
 --
 -- @
--- data Value
---   = Number Double
---   | Bool   Bool
---   | String MisoString
---   | Array  [Value]
---   | Object (Map MisoString Value)
---   | Null
+-- data 'Miso.JSON.Value'
+--   = 'Miso.JSON.Number' 'Double'
+--   | 'Miso.JSON.Bool'   'Bool'
+--   | 'Miso.JSON.String' 'MisoString'
+--   | 'Miso.JSON.Array'  ['Miso.JSON.Value']
+--   | 'Miso.JSON.Object' 'Miso.JSON.Object'
+--   | 'Miso.JSON.Null'
 -- @
 --
 -- == Encoding

--- a/src/Miso.hs
+++ b/src/Miso.hs
@@ -7,6 +7,14 @@
 -----------------------------------------------------------------------------
 {-# OPTIONS_GHC -Wno-duplicate-exports #-}
 -----------------------------------------------------------------------------
+-- |
+-- Module      :  Miso
+-- Copyright   :  (C) 2016-2026 David M. Johnson (@dmjio)
+-- License     :  BSD3-style (see the file LICENSE)
+-- Maintainer  :  David M. Johnson <code@dmj.io>
+-- Stability   :  experimental
+-- Portability :  non-portable
+--
 -- = miso 🍜
 --
 -- @miso@ is a library for building web and native user interface applications in Haskell. See the [GitHub group](https://github.com/haskell-miso).
@@ -110,223 +118,7 @@
 --
 -- A full list of element smart constructors built on 'node' (e.g. 'Miso.Html.Element.div_') can be found in "Miso.Html.Element".
 --
--- == 'VNode' (Element nodes)
---
--- A 'VNode' represents a [DOM element node](https://developer.mozilla.org/en-US/docs/Web/API/Element) — the most common kind of virtual DOM node.
--- It carries a 'Namespace', a tag name, a list of 'Attribute' values, and a list of child 'View' nodes:
---
--- @
--- 'VNode' 'HTML' "div" [ 'id_' "container" ] [ "Hello, world!" ]
--- @
---
--- In practice you will rarely construct 'VNode' directly. Instead use the element smart constructors
--- from "Miso.Html.Element", which fix the namespace and tag for you:
---
--- @
--- 'div_'    [ 'id_' "container" ] [ "Hello, world!" ]
--- 'button_' [ 'onClick' DoSomething ] [ "Click me" ]
--- 'h1_'     [ 'className' "title" ] [ 'text' (ms pageTitle) ]
--- @
---
--- For elements not covered by "Miso.Html.Element", use 'node' (or its synonym 'vnode') directly:
---
--- @
--- 'node' 'HTML' "details" [] [ 'node' 'HTML' "summary" [] [ "More info" ] ]
--- @
---
--- SVG and MathML elements use the 'SVG' and 'MATHML' namespaces respectively,
--- and are covered by the smart constructors in "Miso.Svg.Element" and "Miso.Mathml.Element".
---
--- Unlike 'VComp' and 'VFrag', 'VNode' has a one-to-one correspondence with a physical DOM element:
--- each 'VNode' in the virtual DOM maps to exactly one element in the browser.
---
--- The smart constructors for 'VNode' are:
---
--- * 'node'  — raw constructor, takes 'Namespace', tag, attributes, children
--- * 'vnode' — synonym for 'node'
--- * All combinators in "Miso.Html.Element", "Miso.Svg.Element", "Miso.Mathml.Element"
---
--- === 'VNode' lifecycle hooks
---
--- Similar to t'Component' lifecycle hooks, all 'Miso.Types.VNode' also expose lifecycle hooks.
---
--- * 'Miso.Event.onBeforeCreated'
--- * 'Miso.Event.onCreated' / 'Miso.Event.onCreatedWith'
--- * 'Miso.Event.onBeforeDestroyed' / 'Miso.Event.onBeforeDestroyedWith'
--- * 'Miso.Event.onDestroyed'
---
--- These are convenient for initializing and deinitializing third-party libraries (as seen below with [highlight.js](https://highlightjs.org/))
---
--- @
--- {-# LANGUAGE QuasiQuotes -#}
--- {-# LANGUAGE MultilineStrings -#}
---
--- import Miso
--- import Miso.FFI.QQ (js)
---
--- data Action = Highlight DOMRef
---
--- update :: Action -> 'Effect' parent props model Action
--- update = \\case
---   Highlight domRef -> 'io_' $ do
---     ['js'| hljs.highlight(${domRef}) |]
---
--- view :: props -> model -> 'View' model Action
--- view _ x =
---   'code_'
---   [ 'onCreatedWith' Highlight
---   ]
---   [ """
---     function addOne (x) { return x + 1; }
---     """
---   ]
--- @
---
--- As a convention, the @*with@ variant of 'VNode' lifecycle hooks (e.g. 'Miso.Event.onCreatedWith') provide the target 'DOMRef' in the callback function (shown above).
---
--- === Attributes / Properties
---
--- The 'Attribute' type carries everything that can be attached to a DOM element:
---
--- @
--- data 'Attribute' action
---   = 'Property' 'MisoString' 'Miso.JSON.Value'          -- ^ DOM property (key/value)
---   | 'ClassList' ['MisoString']                         -- ^ CSS class list
---   | 'On' ('Sink' action -> ...)                        -- ^ Event handler
---   | 'Styles' ('Data.Map.Strict.Map' 'MisoString' 'MisoString') -- ^ Inline style map
--- @
---
--- In practice you never construct these directly. Use the smart constructors from
--- "Miso.Html.Property", "Miso.Html.Event", "Miso.Property", and "Miso.CSS":
---
--- @
--- 'div_'
---   [ 'id_' "container"                    -- textProp "id"
---   , 'className' "card active"            -- textProp "class"
---   , 'classList' ["card", "active"]       -- ClassList (alternative)
---   , 'disabled_'                          -- boolProp "disabled" True
---   , 'onClick' MyAction                   -- On event handler
---   , 'Miso.CSS.style_' [ 'Miso.CSS.display' "flex" ] -- Styles map
---   ]
---   []
--- @
---
--- ==== Custom properties
---
--- Use 'prop' (or the typed variants 'textProp', 'boolProp', 'intProp', 'doubleProp',
--- 'objectProp') from "Miso.Property" to set arbitrary DOM properties:
---
--- @
--- 'prop' "data-index" (42 :: Int)      -- sets element.data-index = 42
--- 'textProp' "placeholder" "Search…"  -- sets element.placeholder
--- 'boolProp' "checked" True            -- sets element.checked = true
--- @
---
--- Note that DOM /properties/ and HTML /attributes/ are distinct. Miso sets
--- properties on the DOM node object (e.g. @node.checked@) rather than the
--- HTML attribute (e.g. @setAttribute("checked", ...)@). This matches what
--- the browser actually exposes in JavaScript and avoids common pitfalls with
--- boolean attributes.
---
--- ==== Keys
---
--- 'key_' (and its alias 'keyProp') attaches a reconciliation key to any element.
--- See the @'Key'@ section for details.
---
--- @
--- 'li_' [ 'key_' (itemId item) ] [ 'text' (itemLabel item) ]
--- @
---
--- == 'VText' (Text nodes)
---
--- A 'VText' node represents a [DOM text node](https://developer.mozilla.org/en-US/docs/Web/API/Text).
--- Unlike 'VComp' and 'VFrag', 'VText' has a one-to-one correspondence with a physical DOM node:
--- each 'VText' in the virtual DOM maps to exactly one @Text@ node in the browser.
---
--- The simplest way to produce a 'VText' is via the 'IsString' instance on @'View' model action@.
--- String literals inside a child list are automatically promoted to 'VText' nodes without
--- any extra imports:
---
--- @
--- 'div_' [] [ "Hello, world!" ]
--- @
---
--- For dynamic content, use the 'text' smart constructor with a 'MisoString':
---
--- @
--- 'div_' [] [ 'text' (ms userName) ]
--- @
---
--- === HTML Encoding
---
--- When compiling with the @ssr@ flag (server-side rendering), 'text' automatically
--- HTML-encodes its argument — @\<@, @\>@, @&@, @\"@, and @\'@ are replaced with their
--- respective HTML entities. This prevents accidental XSS when rendering user-supplied
--- strings on the server.
---
--- @
--- -- SSR output: &lt;b&gt;bold&lt;\/b&gt;
--- 'text' "\<b\>bold\<\/b\>"
--- @
---
--- To embed pre-rendered or trusted content without escaping, use 'textRaw'. It is a
--- no-op on the client and bypasses encoding on the server:
---
--- @
--- 'textRaw' "\<b\>bold\<\/b\>"   -- server and client: \<b\>bold\<\/b\>
--- @
---
--- === Concatenating Multiple Strings
---
--- 'text_' accepts a list of 'MisoString' values and joins them with a single space,
--- which is useful when building text from multiple pieces without manual concatenation:
---
--- @
--- -- Renders: Hello world
--- 'div_' [] [ 'text_' [ "Hello", "world" ] ]
--- @
---
--- === Keyed Text Nodes
---
--- A 'VText' may optionally carry a 'Key'. Keyed text nodes participate in the same
--- reconciliation algorithm as keyed 'VNode' and 'VFrag' nodes. Providing a stable key
--- lets the differ identify the node across renders, preventing unnecessary DOM text node
--- replacement when sibling order changes.
---
--- @
--- 'ul_' [] (map renderItem items)
---
--- renderItem :: Item -> 'View' model Action
--- renderItem item = 'li_' [] [ 'textKey' (itemId item) (itemLabel item) ]
--- @
---
--- 'keyed' can also attach a key to any existing 'View', including a 'VText' produced
--- by a string literal or 'text':
---
--- @
--- 'keyed' "greeting" ("Hello!" :: 'View' model action)
--- @
---
--- The smart constructors for 'VText' are:
---
--- * 'text'     — single string, HTML-encoded on the server
--- * 'vtext'    — synonym for 'text'
--- * 'textRaw'  — single string, never HTML-encoded
--- * 'text_'    — list of strings joined with a space
--- * 'textKey'  — single keyed string
--- * 'textKey_' — list of keyed strings joined with a space
--- * 'keyed'    — attach a key to any 'View', including 'VText'
---
--- == 'VComp'
---
--- === 'VComp' lifecycle hooks
---
--- 'Component' are mounted on the fly during diffing. All t'Component` are equipped with `mount` and `unmount` hooks. This allows the defining of custom actions that will be processed in response to lifecycle events.
---
--- * 'Miso.Types.mount'
--- * 'Miso.Types.unmount'
---
--- == Your first t'Component'
+-- = Your first t'Component'
 --
 -- To define a 'Component' the 'component' smart constructor can be used.
 -- Below is an example of a simple counter 'Component'.
@@ -378,7 +170,7 @@
 -- -----------------------------------------------------------------------------
 -- @
 --
--- == Running your first t'Component'
+-- = Running your first t'Component'
 --
 -- The 'startApp' (or 'miso') functions are used to run the above t'Component'.
 --
@@ -408,7 +200,7 @@
 --   Init -> 'io_' ('consoleLog' "hello world!")
 -- @
 --
--- == 'Component' composition
+-- = 'Component' composition
 --
 -- @miso@ 'Component' can contain other 'Component'. This is
 -- accomplished through the 'Component' mounting combinator ('+>'). This combinator
@@ -464,7 +256,168 @@
 --
 -- 'startApp' and 'miso' will always infer @parent@ as 'ROOT'.
 --
--- == 'VFrag' (Fragment nodes)
+-- = 'VComp' lifecycle hooks
+--
+-- 'Component' are mounted on the fly during diffing. All t'Component` are equipped with `mount` and `unmount` hooks. This allows the defining of custom actions that will be processed in response to lifecycle events.
+--
+-- * 'Miso.Types.mount'
+-- * 'Miso.Types.unmount'
+--
+-- = 'VNode' lifecycle hooks
+--
+-- Similar to t'Component' lifecycle hooks, all 'Miso.Types.VNode' also expose lifecycle hooks.
+--
+-- * 'Miso.Event.onBeforeCreated'
+-- * 'Miso.Event.onCreated' / 'Miso.Event.onCreatedWith'
+-- * 'Miso.Event.onBeforeDestroyed' / 'Miso.Event.onBeforeDestroyedWith'
+-- * 'Miso.Event.onDestroyed'
+--
+-- These are convenient for initializing and deinitializing third-party libraries (as seen below with [highlight.js](https://highlightjs.org/))
+--
+-- @
+-- {-# LANGUAGE QuasiQuotes -#}
+-- {-# LANGUAGE MultilineStrings -#}
+--
+-- import Miso
+-- import Miso.FFI.QQ (js)
+--
+-- data Action = Highlight DOMRef
+--
+-- update :: Action -> 'Effect' parent props model Action
+-- update = \\case
+--   Highlight domRef -> 'io_' $ do
+--     ['js'| hljs.highlight(${domRef}) |]
+--
+-- view :: props -> model -> 'View' model Action
+-- view _ x =
+--   'code_'
+--   [ 'onCreatedWith' Highlight
+--   ]
+--   [ """
+--     function addOne (x) { return x + 1; }
+--     """
+--   ]
+-- @
+--
+-- As a convention, the @*with@ variant of 'VNode' lifecycle hooks (e.g. 'Miso.Event.onCreatedWith') provide the target 'DOMRef' in the callback function (shown above).
+--
+-- = 'VNode' (Element nodes)
+--
+-- A 'VNode' represents a [DOM element node](https://developer.mozilla.org/en-US/docs/Web/API/Element) — the most common kind of virtual DOM node.
+-- It carries a 'Namespace', a tag name, a list of 'Attribute' values, and a list of child 'View' nodes:
+--
+-- @
+-- 'VNode' 'HTML' "div" [ 'id_' "container" ] [ "Hello, world!" ]
+-- @
+--
+-- In practice you will rarely construct 'VNode' directly. Instead use the element smart constructors
+-- from "Miso.Html.Element", which fix the namespace and tag for you:
+--
+-- @
+-- 'div_'    [ 'id_' "container" ] [ "Hello, world!" ]
+-- 'button_' [ 'onClick' DoSomething ] [ "Click me" ]
+-- 'h1_'     [ 'className' "title" ] [ 'text' (ms pageTitle) ]
+-- @
+--
+-- For elements not covered by "Miso.Html.Element", use 'node' (or its synonym 'vnode') directly:
+--
+-- @
+-- 'node' 'HTML' "details" [] [ 'node' 'HTML' "summary" [] [ "More info" ] ]
+-- @
+--
+-- SVG and MathML elements use the 'SVG' and 'MATHML' namespaces respectively,
+-- and are covered by the smart constructors in "Miso.Svg.Element" and "Miso.Mathml.Element".
+--
+-- Unlike 'VComp' and 'VFrag', 'VNode' has a one-to-one correspondence with a physical DOM element:
+-- each 'VNode' in the virtual DOM maps to exactly one element in the browser.
+--
+-- The smart constructors for 'VNode' are:
+--
+-- * 'node'  — raw constructor, takes 'Namespace', tag, attributes, children
+-- * 'vnode' — synonym for 'node'
+-- * All combinators in "Miso.Html.Element", "Miso.Svg.Element", "Miso.Mathml.Element"
+--
+-- = 'VText' (Text nodes)
+--
+-- A 'VText' node represents a [DOM text node](https://developer.mozilla.org/en-US/docs/Web/API/Text).
+-- Unlike 'VComp' and 'VFrag', 'VText' has a one-to-one correspondence with a physical DOM node:
+-- each 'VText' in the virtual DOM maps to exactly one @Text@ node in the browser.
+--
+-- The simplest way to produce a 'VText' is via the 'IsString' instance on @'View' model action@.
+-- String literals inside a child list are automatically promoted to 'VText' nodes without
+-- any extra imports:
+--
+-- @
+-- 'div_' [] [ "Hello, world!" ]
+-- @
+--
+-- For dynamic content, use the 'text' smart constructor with a 'MisoString':
+--
+-- @
+-- 'div_' [] [ 'text' (ms userName) ]
+-- @
+--
+-- == HTML Encoding
+--
+-- When compiling with the @ssr@ flag (server-side rendering), 'text' automatically
+-- HTML-encodes its argument — @\<@, @\>@, @&@, @\"@, and @\'@ are replaced with their
+-- respective HTML entities. This prevents accidental XSS when rendering user-supplied
+-- strings on the server.
+--
+-- @
+-- -- SSR output: &lt;b&gt;bold&lt;\/b&gt;
+-- 'text' "\<b\>bold\<\/b\>"
+-- @
+--
+-- To embed pre-rendered or trusted content without escaping, use 'textRaw'. It is a
+-- no-op on the client and bypasses encoding on the server:
+--
+-- @
+-- 'textRaw' "\<b\>bold\<\/b\>"   -- server and client: \<b\>bold\<\/b\>
+-- @
+--
+-- == Concatenating Multiple Strings
+--
+-- 'text_' accepts a list of 'MisoString' values and joins them with a single space,
+-- which is useful when building text from multiple pieces without manual concatenation:
+--
+-- @
+-- -- Renders: Hello world
+-- 'div_' [] [ 'text_' [ "Hello", "world" ] ]
+-- @
+--
+-- == Keyed Text Nodes
+--
+-- A 'VText' may optionally carry a 'Key'. Keyed text nodes participate in the same
+-- reconciliation algorithm as keyed 'VNode' and 'VFrag' nodes. Providing a stable key
+-- lets the differ identify the node across renders, preventing unnecessary DOM text node
+-- replacement when sibling order changes.
+--
+-- @
+-- 'ul_' [] (map renderItem items)
+--
+-- renderItem :: Item -> 'View' model Action
+-- renderItem item = 'li_' [] [ 'textKey' (itemId item) (itemLabel item) ]
+-- @
+--
+-- 'keyed' can also attach a key to any existing 'View', including a 'VText' produced
+-- by a string literal or 'text':
+--
+-- @
+-- 'keyed' "greeting" ("Hello!" :: 'View' model action)
+-- @
+--
+-- The smart constructors for 'VText' are:
+--
+-- * 'text'     — single string, HTML-encoded on the server
+-- * 'vtext'    — synonym for 'text'
+-- * 'textRaw'  — single string, never HTML-encoded
+-- * 'text_'    — list of strings joined with a space
+-- * 'textKey'  — single keyed string
+-- * 'textKey_' — list of keyed strings joined with a space
+-- * 'keyed'    — attach a key to any 'View', including 'VText'
+--
+-- = 'VFrag' (Fragment nodes)
 --
 -- Similar to the [React Fragment](https://react.dev/reference/react/Fragment) API (@\<Fragment\>@ or @\<\>\<\/\>@ syntax), and to @DocumentFragment@ in the browser DOM API. @miso@ provides a 'VFrag' constructor for grouping together sibling nodes without introducing an extra wrapper element in the DOM.
 --
@@ -496,7 +449,7 @@
 -- * 'fragment_'  — keyed fragment
 -- * 'vfrag_'     — keyed fragment (alias, infix-friendly: @\"key\" \`vfrag_\` [...]@)
 --
--- == 'Key'
+-- = 'Key'
 --
 -- A 'Key' is a unique identifier used to optimize diffing.
 --
@@ -523,7 +476,7 @@
 --   ]
 -- @
 --
--- == 'Events'
+-- = 'Events'
 --
 -- * Event Delegation
 --
@@ -572,6 +525,59 @@
 --   where
 --     decodeAt = 'DecodeTarget' ["target"]
 --     decoder = 'withObject' "target" $ \\o -> o .: "value"
+-- @
+--
+-- = Attributes / Properties
+--
+-- The 'Attribute' type carries everything that can be attached to a DOM element:
+--
+-- @
+-- data 'Attribute' action
+--   = 'Property' 'MisoString' 'Miso.JSON.Value'          -- ^ DOM property (key/value)
+--   | 'ClassList' ['MisoString']                         -- ^ CSS class list
+--   | 'On' ('Sink' action -> ...)                        -- ^ Event handler
+--   | 'Styles' ('Data.Map.Strict.Map' 'MisoString' 'MisoString') -- ^ Inline style map
+-- @
+--
+-- In practice you never construct these directly. Use the smart constructors from
+-- "Miso.Html.Property", "Miso.Html.Event", "Miso.Property", and "Miso.CSS":
+--
+-- @
+-- 'div_'
+--   [ 'id_' "container"                    -- textProp "id"
+--   , 'className' "card active"            -- textProp "class"
+--   , 'classList' ["card", "active"]       -- ClassList (alternative)
+--   , 'disabled_'                          -- boolProp "disabled" True
+--   , 'onClick' MyAction                   -- On event handler
+--   , 'Miso.CSS.style_' [ 'Miso.CSS.display' "flex" ] -- Styles map
+--   ]
+--   []
+-- @
+--
+-- == Custom properties
+--
+-- Use 'prop' (or the typed variants 'textProp', 'boolProp', 'intProp', 'doubleProp',
+-- 'objectProp') from "Miso.Property" to set arbitrary DOM properties:
+--
+-- @
+-- 'prop' "data-index" (42 :: Int)      -- sets element.data-index = 42
+-- 'textProp' "placeholder" "Search…"  -- sets element.placeholder
+-- 'boolProp' "checked" True            -- sets element.checked = true
+-- @
+--
+-- Note that DOM /properties/ and HTML /attributes/ are distinct. Miso sets
+-- properties on the DOM node object (e.g. @node.checked@) rather than the
+-- HTML attribute (e.g. @setAttribute("checked", ...)@). This matches what
+-- the browser actually exposes in JavaScript and avoids common pitfalls with
+-- boolean attributes.
+--
+-- == Keys
+--
+-- 'key_' (and its alias 'keyProp') attaches a reconciliation key to any element.
+-- See the @'Key'@ section for details.
+--
+-- @
+-- 'li_' [ 'key_' (itemId item) ] [ 'text' (itemLabel item) ]
 -- @
 --
 -- = 'Effect'
@@ -633,13 +639,13 @@
 -- * __Async mailbox__ — message-passing via 'mail' / 'broadcast' / 'checkMail'; any 'Component' can send a t'Miso.JSON.Value' to any other by 'ComponentId'.
 -- * __PubSub__ ("Miso.PubSub") — publish\/subscribe for fan-out messaging across unrelated 'Component'.
 --
--- == Props
+-- = Props
 --
 -- Inspired by [React props](https://react.dev/learn/passing-props-to-a-component),
 -- @miso@ allows a parent 'Component' to pass read-only data down to a child 'Component'
 -- via a mechanism called /props/ (short for /properties/).
 --
--- === Props vs. Component-local state
+-- == Props vs. Component-local state
 --
 -- * __model__: Component-local state. It is owned and mutated exclusively by the 'Component'
 --   itself through its 'Miso.Types.update' function. No other 'Component' can write to it directly.
@@ -652,7 +658,7 @@
 -- This mirrors the distinction in React between component state (@useState@) and props
 -- received from above (@function MyComponent({ name }) { ... }@).
 --
--- ==== When to use props
+-- === When to use props
 --
 -- Props are best suited for /metadata/ — contextual or configuration data that the child needs
 -- to know about but should not own. Good examples: a user's display name, a theme token, a
@@ -664,7 +670,7 @@
 -- every change, creating unnecessary coupling. Prefer @props@ for \"what the child should
 -- know\" and @model@ for \"what the child should do\".
 --
--- === Props in 'Miso.Types.view'
+-- == Props in 'Miso.Types.view'
 --
 -- The 'Miso.Types.view' field of a 'Component' always takes @props@ as its first argument:
 --
@@ -679,7 +685,7 @@
 -- view _props model = …
 -- @
 --
--- === Props in 'Effect' \/ 'Miso.Types.update'
+-- == Props in 'Effect' \/ 'Miso.Types.update'
 --
 -- Use 'getProps' inside the 'Effect' monad to read the current value of @props@:
 --
@@ -700,7 +706,7 @@
 --     …
 -- @
 --
--- === 'ROOT' — the top-level 'Component'
+-- == 'ROOT' — the top-level 'Component'
 --
 -- When a 'Component' is passed to 'startApp' (or 'miso') it has no parent.
 -- The @parent@ type is specialized to 'ROOT' and @props@ is fixed to @()@:
@@ -713,7 +719,7 @@
 -- root-level 'Component'. You can simply ignore the first argument in 'view' and
 -- skip 'getProps' in 'Miso.Types.update'.
 --
--- === Passing props to a child 'Component'
+-- == Passing props to a child 'Component'
 --
 -- Use 'mountWithProps_' (keyed) or 'mountWithProps' (unkeyed) in the parent's 'view' to
 -- mount a child and supply its props:
@@ -727,7 +733,7 @@
 --   -> 'View' parent a
 -- @
 --
--- === Example: child reading parent-supplied props
+-- == Example: child reading parent-supplied props
 --
 -- The following shows a parent 'Component' that maintains a greeting string in its
 -- @model@ and passes it as @props@ to a child 'Component'. The child renders the
@@ -777,12 +783,12 @@
 -- * The root 'App' always has @props ~ ()@; no extra plumbing is needed when calling 'startApp'.
 --
 --
--- === Asynchronous communication
+-- == Asynchronous communication
 --
 -- Every 'Component' has a 'mailbox' — a slot that receives t'Miso.JSON.Value' messages
 -- sent by other components. Messages are dispatched asynchronously via the event queue.
 --
--- ==== Sending
+-- === Sending
 --
 -- * 'mail' @componentId msg@ — send to a specific 'ComponentId' (obtained via 'ask' inside 'Effect')
 -- * 'mailParent' @msg@ — send to the direct parent
@@ -790,7 +796,7 @@
 -- * 'mailAncestors' @msg@ — walk up the hierarchy, delivering to every ancestor
 -- * 'broadcast' @msg@ — deliver to every mounted 'Component' except the sender
 --
--- ==== Receiving with 'checkMail'
+-- === Receiving with 'checkMail'
 --
 -- Wire up the 'mailbox' field on 'Component' using 'checkMail', which handles
 -- JSON parsing and routes to success\/error actions:
@@ -805,7 +811,7 @@
 --   { 'mailbox' = 'checkMail' ReceivedMsg MailError }
 -- @
 --
--- ==== Looking up a 'ComponentId'
+-- === Looking up a 'ComponentId'
 --
 -- Inside 'Effect', use 'ask' to obtain a t'ComponentInfo':
 --
@@ -821,13 +827,13 @@
 --
 -- * "Miso.PubSub" — publish\/subscribe pattern for fan-out messaging across unrelated components.
 --
--- === Synchronous communication
+-- == Synchronous communication
 --
 -- * "Miso.Binding"
 --
 -- Experimental support for data bindings (where 'Component' model can synchronize fields via a 'Miso.Lens.Lens' in response to model differences along the parent-child relationship). See the "Miso.Binding" module for more information, and the [miso-reactive](https://github.com/haskell-miso/miso-reactive) example. *Warning*: This is still considered experimental.
 --
--- === Parent access
+-- == Parent access
 --
 -- * 'parent'
 --
@@ -889,6 +895,63 @@
 -- This ensures that event listeners can be unregistered when a 'Component' unmounts. For example usage
 -- please see the "Miso.Subscription" sub modules. 'createSub' is only meant to be used in scenarios where
 -- custom event listeners are required.
+--
+-- = (2D/3D) Canvas support
+--
+-- Miso has full 2D and 3D canvas support via "Miso.Canvas". See also the
+-- [miso-canvas](https://github.com/haskell-miso/miso-canvas2d) example and the
+-- [three-miso](https://github.com/haskell-miso/three-miso) package for Three.js integration.
+--
+-- == The 'Miso.Canvas.Canvas' monad
+--
+-- Drawing commands run in the 'Miso.Canvas.Canvas' monad, which is a 'ReaderT' over a
+-- @CanvasContext2D@ (the raw JavaScript @CanvasRenderingContext2D@):
+--
+-- @
+-- type Canvas a = ReaderT CanvasContext2D IO a
+-- @
+--
+-- == Embedding a canvas in the view
+--
+-- Use the 'Miso.Canvas.canvas' smart constructor.
+-- It takes an /init/ callback (runs once on mount, returns state) and a
+-- /draw/ callback (runs on every render with the current state):
+--
+-- @
+-- 'Miso.Canvas.canvas'
+--   [ HP.'width_' "800", HP.'height_' "480" ]
+--   (\\_ -> pure ())                   -- init: no per-canvas state
+--   (\\() -> drawScene myModel)        -- draw: closure over current model
+-- @
+--
+-- 'Miso.Canvas.canvas_' is the variant that threads no init state at all (always passes @()@).
+--
+-- == Drawing commands
+--
+-- Common 2D primitives:
+--
+-- @
+-- drawScene :: Model -> 'Miso.Canvas.Canvas' ()
+-- drawScene model = do
+--   'Miso.Canvas.clearRect' (0, 0, 800, 480)
+--   'Miso.Canvas.fillStyle' ('Miso.CSS.Color.RGB' 30 144 255)
+--   'Miso.Canvas.beginPath' ()
+--   'Miso.Canvas.arc' (400, 240, 50, 0, 2 * pi)
+--   'Miso.Canvas.fill' ()
+--   'Miso.Canvas.font' "24px sans-serif"
+--   'Miso.Canvas.fillText' ("Score: " \<\> ms (score model), 10, 30)
+-- @
+--
+-- Available primitives include: 'Miso.Canvas.clearRect', 'Miso.Canvas.fillRect', 'Miso.Canvas.strokeRect',
+-- 'Miso.Canvas.beginPath', 'Miso.Canvas.closePath', 'Miso.Canvas.moveTo', 'Miso.Canvas.lineTo',
+-- 'Miso.Canvas.arc', 'Miso.Canvas.arcTo', 'Miso.Canvas.fill', 'Miso.Canvas.stroke',
+-- 'Miso.Canvas.fillText', 'Miso.Canvas.drawImage', 'Miso.Canvas.drawImage''.
+--
+-- Style setters: 'Miso.Canvas.fillStyle', 'Miso.Canvas.strokeStyle', 'Miso.Canvas.lineWidth', 'Miso.Canvas.font'.
+-- 'Miso.Canvas.fillStyle' and 'Miso.Canvas.strokeStyle' accept a 'Miso.Canvas.StyleArg' — use
+-- 'Miso.Canvas.color' (not 'Miso.CSS.color') to construct one from a t'Miso.CSS.Color.Color' value.
+-- See the __Canonical Import Pattern__ section for how to avoid the name collision
+-- between 'Miso.Canvas.color' and 'Miso.CSS.color'.
 --
 -- = 'Control.Monad.State.State' management
 --
@@ -968,208 +1031,44 @@
 -- name = 'lens' _name $ \\p n -> p { _name = n }
 -- @
 --
--- == 'MisoString'
+-- = HTML
 --
--- t'MisoString' is miso's canonical string type, chosen to minimise copying between
--- the Haskell and JavaScript heaps:
---
--- * __JS / WASM backends__: t'MisoString' is @JSString@, a direct reference to a
---   JavaScript string — no marshalling cost when passing to the DOM or FFI.
--- * __Server / vanilla GHC__ (@ssr@ flag): t'MisoString' is t'Data.Text'.
---
--- Use t'MisoString' anywhere you would otherwise reach for 'String' or 'Text' in a
--- miso application. See "Miso.String" for the full API.
---
--- === Converting to 'MisoString'
---
--- The 'ms' function (shorthand for 'toMisoString') converts any type with a
--- 'ToMisoString' instance:
+-- Miso's 'View' type doubles as an HTML serialiser via the 'ToHtml' class in
+-- "Miso.Html.Render". This is used for server-side rendering (SSR): build a
+-- 'View' with the normal DSL and render it to a lazy 'Data.ByteString.Lazy.ByteString'
+-- on the server.
 --
 -- @
--- ms "hello"          -- String    -> MisoString
--- ms (42 :: Int)      -- Int       -> MisoString
--- ms (3.14 :: Double) -- Double    -> MisoString
--- ms myText           -- Data.Text -> MisoString
+-- class 'ToHtml' a where
+--   'toHtml' :: a -> 'Data.ByteString.Lazy.ByteString'
 -- @
 --
--- 'ToMisoString' instances are provided for 'String', t'Data.Text.Text',
--- t'Data.Text.Lazy.Text', t'Data.ByteString.ByteString', 'Int', 'Word',
--- 'Double', 'Float', and 'Char'.
---
--- === Converting from 'MisoString'
---
--- 'fromMisoString' parses a t'MisoString' back into another type (throws on failure).
--- Use 'fromMisoStringEither' for a safe variant:
+-- Instances are provided for @'View' m a@ and @['View' m a]@:
 --
 -- @
--- fromMisoString "42"     :: Int     -- 42
--- fromMisoString "3.14"   :: Double  -- 3.14
--- fromMisoStringEither s  :: Either String Int
+-- import Miso.Html.Render (toHtml)
+--
+-- pageHtml :: 'Data.ByteString.Lazy.ByteString'
+-- pageHtml = 'toHtml' $ 'div_' [ 'id_' "root" ] [ "Hello, world!" ]
 -- @
 --
--- 'FromMisoString' instances are provided for 'String', t'Data.Text.Text',
--- t'Data.Text.Lazy.Text', t'Data.ByteString.ByteString', 'Int', 'Word',
--- 'Double', and 'Float'.
---
--- === Multiline literals
---
--- "Miso.String.QQ" provides a QuasiQuoter for multiline t'MisoString' literals:
+-- This is typically wired into a Servant handler on the server using the
+-- [servant-miso-html](https://github.com/haskell-miso/servant-miso-html) package,
+-- which provides an @HTML@ content-type that serialises 'View' and 'Component'
+-- values directly — no manual 'ByteString' conversion needed:
 --
 -- @
--- {-# LANGUAGE QuasiQuotes #-}
+-- import Servant.Miso.Html (HTML)
 --
--- import Miso.String.QQ (misoString)
---
--- snippet :: MisoString
--- snippet = [misoString|
---   line one
---   line two
--- |]
+-- type Home    = \"home\"    :\> Get '[HTML] (Component model action)
+-- type About   = \"about\"   :\> Get '[HTML] (View model action)
+-- type Contact = \"contact\" :\> Get '[HTML] [View model action]
+-- type API = Home :\<|\> About :\<|\> Contact
 -- @
 --
--- t'MisoString' is also the element type used throughout "Miso.Util.Lexer" and
--- "Miso.Util.Parser".
---
--- == JSON
---
--- "Miso.JSON" is a [microaeson](https://hackage.haskell.org/package/microaeson)-inspired
--- JSON library specialised to t'MisoString'. On the JS\/WASM backends it delegates
--- encoding and decoding to the JavaScript runtime (@JSON.stringify@ \/ @JSON.parse@)
--- for performance. On the server (@ssr@ flag) it uses a pure Haskell implementation.
--- "Miso.JSON" is used internally by "Miso.Event.Decoder", "Miso.Fetch", and "Miso.WebSocket".
---
--- === 'Miso.JSON.Value'
---
--- The JSON t'Miso.JSON.Value' type mirrors the JSON specification:
---
--- @
--- data 'Miso.JSON.Value'
---   = 'Miso.JSON.Number' 'Double'
---   | 'Miso.JSON.Bool'   'Bool'
---   | 'Miso.JSON.String' 'MisoString'
---   | 'Miso.JSON.Array'  ['Miso.JSON.Value']
---   | 'Miso.JSON.Object' 'Miso.JSON.Object'
---   | 'Miso.JSON.Null'
--- @
---
--- === Encoding
---
--- Encode any 'ToJSON' instance to a t'MisoString':
---
--- @
--- 'encode' value        -- uses JS runtime on client, pure on server
--- 'encodePure' value    -- always uses pure Haskell implementation
--- @
---
--- === Decoding
---
--- @
--- 'decode' s            :: Maybe a      -- returns Nothing on failure
--- 'eitherDecode' s      :: Either MisoString a
--- @
---
--- === 'ToJSON' \/ 'FromJSON'
---
--- Derive instances via @GHC.Generics@:
---
--- @
--- {-# LANGUAGE DeriveGeneric #-}
---
--- import GHC.Generics
--- import Miso.JSON
---
--- data User = User { name :: MisoString, age :: Int }
---   deriving (Generic)
---
--- instance ToJSON   User
--- instance FromJSON User
--- @
---
--- Use 'genericToJSON' \/ 'genericParseJSON' with 'Options' to customise field and
--- constructor names. 'camelTo2' is provided for converting @camelCase@ to
--- @snake_case@ (or any separator):
---
--- @
--- instance ToJSON User where
---   toJSON = 'genericToJSON' 'defaultOptions' { 'fieldLabelModifier' = 'camelTo2' \'_\' }
--- @
---
--- === Building and Parsing Objects
---
--- @
--- -- Build
--- 'object' [ "name" '.=' ms "Alice", "age" '.=' (30 :: Int) ]
---
--- -- Parse (inside a 'withObject' callback or event decoder)
--- 'withObject' "User" $ \\o -> User
---   \<$\> o '.:' "name"     -- required field
---   \<*\> o '.:' "age"
---
--- o '.:?' "nickname"    -- optional field → Maybe a
--- o '.:!' "nickname"    -- optional field, explicit null → Maybe a
--- p '.!=' "anon"        -- provide a default for a Maybe parser
--- @
---
--- === Pretty-Printing
---
--- @
--- 'encodePretty'  value          -- indented with 'defConfig' (2-space indent)
--- 'encodePretty'' config value   -- indented with custom 'Config'
--- @
---
--- === @miso-aeson@
---
--- If you prefer to use the [aeson](https://hackage.haskell.org/package/aeson) library directly,
--- the [miso-aeson](https://github.com/haskell-miso/miso-aeson) package provides a compatibility
--- shim that bridges @aeson@\'s 'Data.Aeson.ToJSON' \/ 'Data.Aeson.FromJSON' instances with miso\'s
--- event decoder and fetch API, so existing @aeson@-derived instances can be used without rewriting them.
---
--- == Styles
---
--- Miso does not prescribe a single CSS strategy. Three approaches work out of the box:
---
--- === 1. Structured DSL ("Miso.CSS")
---
--- 'style_' takes a list of @'Style'@ values (which are @(MisoString, MisoString)@ pairs).
--- Miso manages individual properties on the DOM node, merging and diffing them efficiently:
---
--- @
--- import qualified Miso.CSS as CSS
--- import           Miso.CSS.Color (RGB(..))
---
--- 'div_'
---   [ CSS.'style_'
---       [ CSS.'display' "flex"
---       , CSS.'flexDirection' "column"
---       , CSS.'backgroundColor' (RGB 30 30 30)
---       , CSS.'color' (RGB 255 255 255)
---       ]
---   ]
---   []
--- @
---
--- Custom properties can be constructed with the '=:' operator (re-exported from "Miso.Util"):
---
--- @
--- "user-select" '=:' "none"
--- @
---
--- === 2. Inline string ('CSS.styleInline_')
---
--- For simple or dynamic style strings, 'styleInline_' sets the element's @style@
--- attribute as a raw string:
---
--- @
--- CSS.'styleInline_' "display:flex; gap:8px; padding:16px"
--- @
---
--- === 3. External stylesheets
---
--- Link external CSS files from the @\<head\>@ via the 'styles' field on 'Component'
--- (see the __Development__ section), or include them in your HTML template directly.
--- This is the most common approach for production apps using Tailwind, Bootstrap, etc.
---
--- See [miso-ui](https://ui.haskell-miso.org) for a larger example.
+-- On the client, pass the matching 'Component' to 'miso' (instead of 'startApp')
+-- so it hydrates the server-rendered markup rather than redrawing from scratch.
+-- See the __Prerendering__ section for the full flow.
 --
 -- = JavaScript EDSL
 --
@@ -1318,101 +1217,265 @@
 -- 'button_' [ 'Miso.Router.href_' (Widget (Capture 10) (QueryParam Nothing)) ] [ "Go to widget 10" ]
 -- @
 --
--- = (2D/3D) Canvas support
+-- = 'MisoString'
 --
--- Miso has full 2D and 3D canvas support via "Miso.Canvas". See also the
--- [miso-canvas](https://github.com/haskell-miso/miso-canvas2d) example and the
--- [three-miso](https://github.com/haskell-miso/three-miso) package for Three.js integration.
+-- t'MisoString' is miso's canonical string type, chosen to minimise copying between
+-- the Haskell and JavaScript heaps:
 --
--- == The 'Miso.Canvas.Canvas' monad
+-- * __JS / WASM backends__: t'MisoString' is @JSString@, a direct reference to a
+--   JavaScript string — no marshalling cost when passing to the DOM or FFI.
+-- * __Server / vanilla GHC__ (@ssr@ flag): t'MisoString' is t'Data.Text'.
 --
--- Drawing commands run in the 'Miso.Canvas.Canvas' monad, which is a 'ReaderT' over a
--- @CanvasContext2D@ (the raw JavaScript @CanvasRenderingContext2D@):
+-- Use t'MisoString' anywhere you would otherwise reach for 'String' or 'Text' in a
+-- miso application. See "Miso.String" for the full API.
 --
--- @
--- type Canvas a = ReaderT CanvasContext2D IO a
--- @
+-- == Converting to 'MisoString'
 --
--- == Embedding a canvas in the view
---
--- Use the 'Miso.Canvas.canvas' smart constructor.
--- It takes an /init/ callback (runs once on mount, returns state) and a
--- /draw/ callback (runs on every render with the current state):
+-- The 'ms' function (shorthand for 'toMisoString') converts any type with a
+-- 'ToMisoString' instance:
 --
 -- @
--- 'Miso.Canvas.canvas'
---   [ HP.'width_' "800", HP.'height_' "480" ]
---   (\\_ -> pure ())                   -- init: no per-canvas state
---   (\\() -> drawScene myModel)        -- draw: closure over current model
+-- ms "hello"          -- String    -> MisoString
+-- ms (42 :: Int)      -- Int       -> MisoString
+-- ms (3.14 :: Double) -- Double    -> MisoString
+-- ms myText           -- Data.Text -> MisoString
 -- @
 --
--- 'Miso.Canvas.canvas_' is the variant that threads no init state at all (always passes @()@).
+-- 'ToMisoString' instances are provided for 'String', t'Data.Text.Text',
+-- t'Data.Text.Lazy.Text', t'Data.ByteString.ByteString', 'Int', 'Word',
+-- 'Double', 'Float', and 'Char'.
 --
--- == Drawing commands
+-- == Converting from 'MisoString'
 --
--- Common 2D primitives:
---
--- @
--- drawScene :: Model -> 'Miso.Canvas.Canvas' ()
--- drawScene model = do
---   'Miso.Canvas.clearRect' (0, 0, 800, 480)
---   'Miso.Canvas.fillStyle' ('Miso.CSS.Color.RGB' 30 144 255)
---   'Miso.Canvas.beginPath' ()
---   'Miso.Canvas.arc' (400, 240, 50, 0, 2 * pi)
---   'Miso.Canvas.fill' ()
---   'Miso.Canvas.font' "24px sans-serif"
---   'Miso.Canvas.fillText' ("Score: " \<\> ms (score model), 10, 30)
--- @
---
--- Available primitives include: 'Miso.Canvas.clearRect', 'Miso.Canvas.fillRect', 'Miso.Canvas.strokeRect',
--- 'Miso.Canvas.beginPath', 'Miso.Canvas.closePath', 'Miso.Canvas.moveTo', 'Miso.Canvas.lineTo',
--- 'Miso.Canvas.arc', 'Miso.Canvas.arcTo', 'Miso.Canvas.fill', 'Miso.Canvas.stroke',
--- 'Miso.Canvas.fillText', 'Miso.Canvas.drawImage', 'Miso.Canvas.drawImage''.
---
--- Style setters: 'Miso.Canvas.fillStyle', 'Miso.Canvas.strokeStyle', 'Miso.Canvas.lineWidth', 'Miso.Canvas.font'.
--- 'Miso.Canvas.fillStyle' and 'Miso.Canvas.strokeStyle' accept a 'Miso.Canvas.StyleArg' — use
--- 'Miso.Canvas.color' (not 'Miso.CSS.color') to construct one from a t'Miso.CSS.Color.Color' value.
--- See the __Canonical Import Pattern__ section for how to avoid the name collision
--- between 'Miso.Canvas.color' and 'Miso.CSS.color'.
---
--- = HTML
---
--- Miso's 'View' type doubles as an HTML serialiser via the 'ToHtml' class in
--- "Miso.Html.Render". This is used for server-side rendering (SSR): build a
--- 'View' with the normal DSL and render it to a lazy 'Data.ByteString.Lazy.ByteString'
--- on the server.
+-- 'fromMisoString' parses a t'MisoString' back into another type (throws on failure).
+-- Use 'fromMisoStringEither' for a safe variant:
 --
 -- @
--- class 'ToHtml' a where
---   'toHtml' :: a -> 'Data.ByteString.Lazy.ByteString'
+-- fromMisoString "42"     :: Int     -- 42
+-- fromMisoString "3.14"   :: Double  -- 3.14
+-- fromMisoStringEither s  :: Either String Int
 -- @
 --
--- Instances are provided for @'View' m a@ and @['View' m a]@:
+-- 'FromMisoString' instances are provided for 'String', t'Data.Text.Text',
+-- t'Data.Text.Lazy.Text', t'Data.ByteString.ByteString', 'Int', 'Word',
+-- 'Double', and 'Float'.
+--
+-- == Multiline literals
+--
+-- "Miso.String.QQ" provides a QuasiQuoter for multiline t'MisoString' literals:
 --
 -- @
--- import Miso.Html.Render (toHtml)
+-- {-# LANGUAGE QuasiQuotes #-}
 --
--- pageHtml :: 'Data.ByteString.Lazy.ByteString'
--- pageHtml = 'toHtml' $ 'div_' [ 'id_' "root" ] [ "Hello, world!" ]
+-- import Miso.String.QQ (misoString)
+--
+-- snippet :: MisoString
+-- snippet = [misoString|
+--   line one
+--   line two
+-- |]
 -- @
 --
--- This is typically wired into a Servant handler on the server using the
--- [servant-miso-html](https://github.com/haskell-miso/servant-miso-html) package,
--- which provides an @HTML@ content-type that serialises 'View' and 'Component'
--- values directly — no manual 'ByteString' conversion needed:
+-- t'MisoString' is also the element type used throughout "Miso.Util.Lexer" and
+-- "Miso.Util.Parser".
+--
+-- = JSON
+--
+-- "Miso.JSON" is a [microaeson](https://hackage.haskell.org/package/microaeson)-inspired
+-- JSON library specialised to t'MisoString'. On the JS\/WASM backends it delegates
+-- encoding and decoding to the JavaScript runtime (@JSON.stringify@ \/ @JSON.parse@)
+-- for performance. On the server (@ssr@ flag) it uses a pure Haskell implementation.
+-- "Miso.JSON" is used internally by "Miso.Event.Decoder", "Miso.Fetch", and "Miso.WebSocket".
+--
+-- == 'Miso.JSON.Value'
+--
+-- The JSON t'Miso.JSON.Value' type mirrors the JSON specification:
 --
 -- @
--- import Servant.Miso.Html (HTML)
---
--- type Home    = \"home\"    :\> Get '[HTML] (Component model action)
--- type About   = \"about\"   :\> Get '[HTML] (View model action)
--- type Contact = \"contact\" :\> Get '[HTML] [View model action]
--- type API = Home :\<|\> About :\<|\> Contact
+-- data 'Miso.JSON.Value'
+--   = 'Miso.JSON.Number' 'Double'
+--   | 'Miso.JSON.Bool'   'Bool'
+--   | 'Miso.JSON.String' 'MisoString'
+--   | 'Miso.JSON.Array'  ['Miso.JSON.Value']
+--   | 'Miso.JSON.Object' 'Miso.JSON.Object'
+--   | 'Miso.JSON.Null'
 -- @
 --
--- On the client, pass the matching 'Component' to 'miso' (instead of 'startApp')
--- so it hydrates the server-rendered markup rather than redrawing from scratch.
--- See the __Prerendering__ section for the full flow.
+-- == Encoding
+--
+-- Encode any 'ToJSON' instance to a t'MisoString':
+--
+-- @
+-- 'encode' value        -- uses JS runtime on client, pure on server
+-- 'encodePure' value    -- always uses pure Haskell implementation
+-- @
+--
+-- == Decoding
+--
+-- @
+-- 'decode' s            :: Maybe a      -- returns Nothing on failure
+-- 'eitherDecode' s      :: Either MisoString a
+-- @
+--
+-- == 'ToJSON' \/ 'FromJSON'
+--
+-- Derive instances via @GHC.Generics@:
+--
+-- @
+-- {-# LANGUAGE DeriveGeneric #-}
+--
+-- import GHC.Generics
+-- import Miso.JSON
+--
+-- data User = User { name :: MisoString, age :: Int }
+--   deriving (Generic)
+--
+-- instance ToJSON   User
+-- instance FromJSON User
+-- @
+--
+-- Use 'genericToJSON' \/ 'genericParseJSON' with 'Options' to customise field and
+-- constructor names. 'camelTo2' is provided for converting @camelCase@ to
+-- @snake_case@ (or any separator):
+--
+-- @
+-- instance ToJSON User where
+--   toJSON = 'genericToJSON' 'defaultOptions' { 'fieldLabelModifier' = 'camelTo2' \'_\' }
+-- @
+--
+-- == Building and Parsing Objects
+--
+-- @
+-- -- Build
+-- 'object' [ "name" '.=' ms "Alice", "age" '.=' (30 :: Int) ]
+--
+-- -- Parse (inside a 'withObject' callback or event decoder)
+-- 'withObject' "User" $ \\o -> User
+--   \<$\> o '.:' "name"     -- required field
+--   \<*\> o '.:' "age"
+--
+-- o '.:?' "nickname"    -- optional field → Maybe a
+-- o '.:!' "nickname"    -- optional field, explicit null → Maybe a
+-- p '.!=' "anon"        -- provide a default for a Maybe parser
+-- @
+--
+-- == Pretty-Printing
+--
+-- @
+-- 'encodePretty'  value          -- indented with 'defConfig' (2-space indent)
+-- 'encodePretty'' config value   -- indented with custom 'Config'
+-- @
+--
+-- == @miso-aeson@
+--
+-- If you prefer to use the [aeson](https://hackage.haskell.org/package/aeson) library directly,
+-- the [miso-aeson](https://github.com/haskell-miso/miso-aeson) package provides a compatibility
+-- shim that bridges @aeson@\'s 'Data.Aeson.ToJSON' \/ 'Data.Aeson.FromJSON' instances with miso\'s
+-- event decoder and fetch API, so existing @aeson@-derived instances can be used without rewriting them.
+--
+-- = Styles
+--
+-- Miso does not prescribe a single CSS strategy. Three approaches work out of the box:
+--
+-- == 1. Structured DSL ("Miso.CSS")
+--
+-- 'style_' takes a list of @'Style'@ values (which are @(MisoString, MisoString)@ pairs).
+-- Miso manages individual properties on the DOM node, merging and diffing them efficiently:
+--
+-- @
+-- import qualified Miso.CSS as CSS
+-- import           Miso.CSS.Color (RGB(..))
+--
+-- 'div_'
+--   [ CSS.'style_'
+--       [ CSS.'display' "flex"
+--       , CSS.'flexDirection' "column"
+--       , CSS.'backgroundColor' (RGB 30 30 30)
+--       , CSS.'color' (RGB 255 255 255)
+--       ]
+--   ]
+--   []
+-- @
+--
+-- Custom properties can be constructed with the '=:' operator (re-exported from "Miso.Util"):
+--
+-- @
+-- "user-select" '=:' "none"
+-- @
+--
+-- == 2. Inline string ('CSS.styleInline_')
+--
+-- For simple or dynamic style strings, 'styleInline_' sets the element's @style@
+-- attribute as a raw string:
+--
+-- @
+-- CSS.'styleInline_' "display:flex; gap:8px; padding:16px"
+-- @
+--
+-- == 3. External stylesheets
+--
+-- Link external CSS files from the @\<head\>@ via the 'styles' field on 'Component'
+-- (see the __Development__ section), or include them in your HTML template directly.
+-- This is the most common approach for production apps using Tailwind, Bootstrap, etc.
+--
+-- See [miso-ui](https://ui.haskell-miso.org) for a larger example.
+--
+-- = Development
+--
+-- When developing miso applications interactively it is possible to append 'styles' and 'scripts' to the @\<head\>@ portion of
+-- the page when the 'Component' mounts. This is a convenience only meant to be used in development. We recommend guarding the usage behind a flag.
+--
+-- @
+-- main :: 'IO' ()
+-- main = 'startApp' 'defaultEvents' counter
+--  where
+--    app = counter
+-- #ifdef INTERACTIVE
+--      { 'scripts' = [ 'Src' "https://ajax.googleapis.com/ajax/libs/jquery/3.7.1/jquery.min.js" ('False' :: 'CacheBust') ]
+--      , 'styles' = [ 'Href' "https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" ('False' :: 'CacheBust')  ]
+--      }
+-- #endif
+-- @
+--
+-- See the [miso-sampler](https://github.com/haskell-miso/miso-sampler) repository for more information.
+--
+-- = Debugging
+--
+-- Sometimes things can go wrong. Common errors like using `onClick` but not listening for the 'click' event are common.
+-- These are errors that cannot be caught statically (unless we use a dependently-typed language like [Idris](https://idris-lang.org)). These can be detected by enabling 'DebugAll'. Currently, debugging event delegation and page hydration is supported.
+--
+-- * 'DebugHydrate'
+-- * 'DebugEvents'
+--
+-- @
+-- counter { 'logLevel' = 'DebugAll' }
+-- @
+--
+-- = Internals
+--
+-- Internally miso uses a global event queue and a scheduler to process all
+-- events raised by 'Component' throughout the lifetime of an application.
+-- Events are processed in FIFO order, batched by the 'Component' that raised them.
+--
+-- * __Event queue__: All actions dispatched via a 'Sink' (from event handlers,
+--   subscriptions, or 'io' callbacks) are enqueued and drained by the scheduler.
+--
+-- * __Scheduler__: The scheduler pulls actions off the queue one batch at a time,
+--   runs the 'update' function for each, collects the resulting 'IO' work, and
+--   executes it. Rendering (VDOM diff + patch) is triggered after each batch.
+--
+-- * __'Waiter'__: A 'Miso.Concurrent.Waiter' is a synchronization primitive used
+--   internally to coordinate the event loop — it blocks the scheduler thread until
+--   new work arrives, avoiding busy-waiting.
+--
+-- * __Event delegation__: Rather than attaching listeners to individual DOM nodes,
+--   miso attaches a single capture and a single bubble listener to @\<body\>@.
+--   Incoming events are routed through the virtual DOM tree to the matching handler.
+--   This minimises listener churn when the VDOM is patched.
+--
+-- * __VDOM diffing__: The diff algorithm in "Miso.Diff" compares old and new
+--   'View' trees and emits the minimal set of DOM mutations. Keyed children (see
+--   the 'Key' section) significantly speed up child list reconciliation.
 --
 -- = Prerendering
 --
@@ -1478,63 +1541,6 @@
 -- equivalent to static prerendering.
 --
 -----------------------------------------------------------------------------
-
--- = Development
---
--- When developing miso applications interactively it is possible to append 'styles' and 'scripts' to the @\<head\>@ portion of
--- the page when the 'Component' mounts. This is a convenience only meant to be used in development. We recommend guarding the usage behind a flag.
---
--- @
--- main :: 'IO' ()
--- main = 'startApp' 'defaultEvents' counter
---  where
---    app = counter
--- #ifdef INTERACTIVE
---      { 'scripts' = [ 'Src' "https://ajax.googleapis.com/ajax/libs/jquery/3.7.1/jquery.min.js" ('False' :: 'CacheBust') ]
---      , 'styles' = [ 'Href' "https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" ('False' :: 'CacheBust')  ]
---      }
--- #endif
--- @
---
--- See the [miso-sampler](https://github.com/haskell-miso/miso-sampler) repository for more information.
---
--- = Debugging
---
--- Sometimes things can go wrong. Common errors like using `onClick` but not listening for the 'click' event are common.
--- These are errors that cannot be caught statically (unless we use a dependently-typed language like [Idris](https://idris-lang.org)). These can be detected by enabling 'DebugAll'. Currently, debugging event delegation and page hydration is supported.
---
--- * 'DebugHydrate'
--- * 'DebugEvents'
---
--- @
--- counter { 'logLevel' = 'DebugAll' }
--- @
---
--- = Internals
---
--- Internally miso uses a global event queue and a scheduler to process all
--- events raised by 'Component' throughout the lifetime of an application.
--- Events are processed in FIFO order, batched by the 'Component' that raised them.
---
--- * __Event queue__: All actions dispatched via a 'Sink' (from event handlers,
---   subscriptions, or 'io' callbacks) are enqueued and drained by the scheduler.
---
--- * __Scheduler__: The scheduler pulls actions off the queue one batch at a time,
---   runs the 'update' function for each, collects the resulting 'IO' work, and
---   executes it. Rendering (VDOM diff + patch) is triggered after each batch.
---
--- * __'Waiter'__: A 'Miso.Concurrent.Waiter' is a synchronization primitive used
---   internally to coordinate the event loop — it blocks the scheduler thread until
---   new work arrives, avoiding busy-waiting.
---
--- * __Event delegation__: Rather than attaching listeners to individual DOM nodes,
---   miso attaches a single capture and a single bubble listener to @\<body\>@.
---   Incoming events are routed through the virtual DOM tree to the matching handler.
---   This minimises listener churn when the VDOM is patched.
---
--- * __VDOM diffing__: The diff algorithm in "Miso.Diff" compares old and new
---   'View' trees and emits the minimal set of DOM mutations. Keyed children (see
---   the 'Key' section) significantly speed up child list reconciliation.
 module Miso
   ( -- * API
     -- ** Miso

--- a/src/Miso.hs
+++ b/src/Miso.hs
@@ -1000,7 +1000,12 @@
 --   Rename n  -> #name '.~' n                     -- via OverloadedLabels
 -- @
 --
--- * __Hand-written__: construct a 'Lens' directly using the @'Lens' s a@ synonym.
+-- * __Hand-written__: construct a 'Lens' directly using 'lens' and the @'Lens' s a@ synonym.
+--
+-- @
+-- name :: 'Lens' Person 'MisoString'
+-- name = 'lens' _name $ \\p n -> p { _name = n }
+-- @
 --
 -- = HTML
 --

--- a/src/Miso.hs
+++ b/src/Miso.hs
@@ -1511,30 +1511,34 @@
 -- client can hydrate from a meaningful initial state rather than a blank model.
 -- The @-fssr@ Cabal flag must be enabled when compiling the server.
 --
--- The 'hydrateModel' field on 'Component' accepts an optional @IO model@ action
--- that is run once during hydration to load the initial model (e.g. by reading
--- JSON embedded in the page). It is ignored on subsequent remounts.
+-- The 'hydrateModel' field on 'Component' is @Maybe (IO model)@. When set, the
+-- action runs once at hydration time to produce the initial model; it is ignored
+-- on subsequent remounts. A typical pattern embeds the model as JSON in the
+-- server response and reads it back on the client via the JS DSL:
 --
 -- @
--- -- Server: embed the model as JSON in the HTML response
--- serverView :: model -> 'View' model action
--- serverView m =
---   'div_' []
---     [ 'script_' [ 'id_' "initial-model" ] [ 'textRaw' ('encode' m) ]
---     , appView m
---     ]
---
--- -- Client: read it back during hydration
--- myComp :: 'App' model Action
+-- myComp :: 'App' Model Action
 -- myComp = ('vcomp' defaultModel updateFn viewFn)
 --   { 'hydrateModel' = Just $ do
---       json <- 'Miso.FFI.getElementById' "initial-model" >>= 'Miso.FFI.getBody'
---       pure $ 'fromMisoString' json
+--       val <- 'Miso.DSL.jsg' "window" 'Miso.DSL.!' "__initialModel__"
+--       'Miso.DSL.fromJSValUnchecked' val
 --   }
 -- @
 --
--- When 'hydrateModel' is @Nothing@, hydration uses the static 'model' field — this
--- is equivalent to static prerendering.
+-- On the server, populate @window.__initialModel__@ by embedding the JSON
+-- in a @\<script\>@ tag alongside the rendered HTML:
+--
+-- @
+-- serverView :: Model -> 'View' Model Action
+-- serverView m =
+--   'div_' []
+--     [ 'script_' [] [ 'textRaw' ("window.__initialModel__ = " \<\> 'encode' m) ]
+--     , appView m
+--     ]
+-- @
+--
+-- When 'hydrateModel' is @Nothing@, the static 'model' field is used instead —
+-- equivalent to static prerendering.
 --
 -----------------------------------------------------------------------------
 module Miso

--- a/src/Miso.hs
+++ b/src/Miso.hs
@@ -110,13 +110,13 @@
 --
 -- The smart constructors:
 --
--- * 'node', 'vnode'
--- * 'text', 'vtext'
--- * 'component', 'vcomp'
--- * 'fragment_', 'fragment', 'vfrag', 'vfrag_'
--- * ('+>')
+-- * 'node', 'vnode' — build a 'VNode'
+-- * 'text', 'vtext' — build a 'VText'
+-- * 'component', 'vcomp' — build a 'VComp' ('vcomp' is a synonym for 'component')
+-- * 'fragment', 'vfrag', 'fragment_', 'vfrag_' — build a 'VFrag'
+-- * ('+>') — key and mount a child 'Component'
 --
--- are used to build 'VNode', 'VText', 'VFrag' and 'VComp' respectively. A list of all the smart constructors defined in terms of 'node' (e.g. 'Miso.Html.Element.div_') can be found in "Miso.Html.Element".
+-- A full list of element smart constructors built on 'node' (e.g. 'Miso.Html.Element.div_') can be found in "Miso.Html.Element".
 --
 -- = Your first t'Component'
 --
@@ -533,10 +533,10 @@
 --
 -- @
 -- data 'Attribute' action
---   = 'Property' MisoString Value        -- ^ DOM property (key/value)
---   | 'ClassList' [MisoString]           -- ^ CSS class list
---   | 'On' (Sink action -> ...)          -- ^ Event handler
---   | 'Styles' (Map MisoString MisoString) -- ^ Inline style map
+--   = 'Property' 'MisoString' 'Miso.JSON.Value'          -- ^ DOM property (key/value)
+--   | 'ClassList' ['MisoString']                         -- ^ CSS class list
+--   | 'On' ('Sink' action -> ...)                        -- ^ Event handler
+--   | 'Styles' ('Data.Map.Strict.Map' 'MisoString' 'MisoString') -- ^ Inline style map
 -- @
 --
 -- In practice you never construct these directly. Use the smart constructors from
@@ -544,12 +544,12 @@
 --
 -- @
 -- 'div_'
---   [ 'id_' "container"          -- textProp "id"
---   , 'className' "card active"  -- textProp "class"
---   , 'classList' ["card", "active"] -- ClassList (alternative)
---   , 'disabled_' True           -- boolProp "disabled"
---   , 'onClick' MyAction         -- On event handler
---   , 'style_' [ 'CSS.display' "flex" ]  -- Styles map
+--   [ 'id_' "container"                    -- textProp "id"
+--   , 'className' "card active"            -- textProp "class"
+--   , 'classList' ["card", "active"]       -- ClassList (alternative)
+--   , 'disabled_'                          -- boolProp "disabled" True
+--   , 'onClick' MyAction                   -- On event handler
+--   , 'Miso.CSS.style_' [ 'Miso.CSS.display' "flex" ] -- Styles map
 --   ]
 --   []
 -- @
@@ -864,11 +864,11 @@
 -- 'onLineSub' f sink = 'Miso.Subscription.Util.createSub' acquire release sink
 --   where
 --     release (cb1, cb2) = do
---       FFI.windowRemoveEventListener "online" cb1
---       FFI.windowRemoveEventListener "offline" cb2
+--       'Miso.FFI.windowRemoveEventListener' "online"  cb1
+--       'Miso.FFI.windowRemoveEventListener' "offline" cb2
 --     acquire = do
---       cb1 <- FFI.windowAddEventListener "online" (const $ sink (f True))
---       cb2 <- FFI.windowAddEventListener "offline" (const $ sink (f False))
+--       cb1 <- 'Miso.FFI.windowAddEventListener' "online"  (const $ sink (f True))
+--       cb2 <- 'Miso.FFI.windowAddEventListener' "offline" (const $ sink (f False))
 --       pure (cb1, cb2)
 -- @
 --
@@ -1484,7 +1484,7 @@
 --
 -- == Static prerendering
 --
--- miso provides the 'prerender' and 'miso' functions to facilitate static prerendering. Any page can be generated from a miso 'View' using the 'Miso.Render.toHtml' instance.
+-- miso provides the 'prerender' and 'miso' functions to facilitate static prerendering. Any page can be generated from a miso 'View' using the 'Miso.Html.Render.toHtml' instance.
 --
 -- A simple example of static prerendering would be an @index.html@ page with some HTML
 --

--- a/src/Miso.hs
+++ b/src/Miso.hs
@@ -47,7 +47,7 @@
 --
 -- * __Components__: A 'Component' can be considered an instance of a @miso@ application. A 'Component'
 --   contains user-defined state, logic for updating this state, and a function
---   for creating UI templates from this user-defined state. 'Component' can nest other 'Component' because @miso@
+--   for creating UI templates from this user-defined state. 'Component' can nest other 'Component' because it
 --   is defined recursively.
 --
 -- * __Custom renderers__: The underlying DOM operations are able to be abstracted.
@@ -301,6 +301,122 @@
 --
 -- As a convention, the @*with@ variant of 'VNode' lifecycle hooks (e.g. 'Miso.Event.onCreatedWith') provide the target 'DOMRef' in the callback function (shown above).
 --
+-- = 'VNode' (Element nodes)
+--
+-- A 'VNode' represents a [DOM element node](https://developer.mozilla.org/en-US/docs/Web/API/Element) — the most common kind of virtual DOM node.
+-- It carries a 'Namespace', a tag name, a list of 'Attribute' values, and a list of child 'View' nodes:
+--
+-- @
+-- 'VNode' 'HTML' "div" [ 'id_' "container" ] [ "Hello, world!" ]
+-- @
+--
+-- In practice you will rarely construct 'VNode' directly. Instead use the element smart constructors
+-- from "Miso.Html.Element", which fix the namespace and tag for you:
+--
+-- @
+-- 'div_'    [ 'id_' "container" ] [ "Hello, world!" ]
+-- 'button_' [ 'onClick' DoSomething ] [ "Click me" ]
+-- 'h1_'     [ 'className' "title" ] [ 'text' (ms pageTitle) ]
+-- @
+--
+-- For elements not covered by "Miso.Html.Element", use 'node' (or its synonym 'vnode') directly:
+--
+-- @
+-- 'node' 'HTML' "details" [] [ 'node' 'HTML' "summary" [] [ "More info" ] ]
+-- @
+--
+-- SVG and MathML elements use the 'SVG' and 'MATHML' namespaces respectively,
+-- and are covered by the smart constructors in "Miso.Svg.Element" and "Miso.Mathml.Element".
+--
+-- Unlike 'VComp' and 'VFrag', 'VNode' has a one-to-one correspondence with a physical DOM element:
+-- each 'VNode' in the virtual DOM maps to exactly one element in the browser.
+--
+-- The smart constructors for 'VNode' are:
+--
+-- * 'node'  — raw constructor, takes 'Namespace', tag, attributes, children
+-- * 'vnode' — synonym for 'node'
+-- * All combinators in "Miso.Html.Element", "Miso.Svg.Element", "Miso.Mathml.Element"
+--
+-- = 'VText' (Text nodes)
+--
+-- A 'VText' node represents a [DOM text node](https://developer.mozilla.org/en-US/docs/Web/API/Text).
+-- Unlike 'VComp' and 'VFrag', 'VText' has a one-to-one correspondence with a physical DOM node:
+-- each 'VText' in the virtual DOM maps to exactly one @Text@ node in the browser.
+--
+-- The simplest way to produce a 'VText' is via the 'IsString' instance on @'View' model action@.
+-- String literals inside a child list are automatically promoted to 'VText' nodes without
+-- any extra imports:
+--
+-- @
+-- 'div_' [] [ "Hello, world!" ]
+-- @
+--
+-- For dynamic content, use the 'text' smart constructor with a 'MisoString':
+--
+-- @
+-- 'div_' [] [ 'text' (ms userName) ]
+-- @
+--
+-- == HTML Encoding
+--
+-- When compiling with the @ssr@ flag (server-side rendering), 'text' automatically
+-- HTML-encodes its argument — @\<@, @\>@, @&@, @\"@, and @\'@ are replaced with their
+-- respective HTML entities. This prevents accidental XSS when rendering user-supplied
+-- strings on the server.
+--
+-- @
+-- -- SSR output: &lt;b&gt;bold&lt;\/b&gt;
+-- 'text' "\<b\>bold\<\/b\>"
+-- @
+--
+-- To embed pre-rendered or trusted content without escaping, use 'textRaw'. It is a
+-- no-op on the client and bypasses encoding on the server:
+--
+-- @
+-- 'textRaw' "\<b\>bold\<\/b\>"   -- server and client: \<b\>bold\<\/b\>
+-- @
+--
+-- == Concatenating Multiple Strings
+--
+-- 'text_' accepts a list of 'MisoString' values and joins them with a single space,
+-- which is useful when building text from multiple pieces without manual concatenation:
+--
+-- @
+-- -- Renders: Hello world
+-- 'div_' [] [ 'text_' [ "Hello", "world" ] ]
+-- @
+--
+-- == Keyed Text Nodes
+--
+-- A 'VText' may optionally carry a 'Key'. Keyed text nodes participate in the same
+-- reconciliation algorithm as keyed 'VNode' and 'VFrag' nodes. Providing a stable key
+-- lets the differ identify the node across renders, preventing unnecessary DOM text node
+-- replacement when sibling order changes.
+--
+-- @
+-- 'ul_' [] (map renderItem items)
+--
+-- renderItem :: Item -> 'View' model Action
+-- renderItem item = 'li_' [] [ 'textKey' (itemId item) (itemLabel item) ]
+-- @
+--
+-- 'keyed' can also attach a key to any existing 'View', including a 'VText' produced
+-- by a string literal or 'text':
+--
+-- @
+-- 'keyed' "greeting" ("Hello!" :: 'View' model action)
+-- @
+--
+-- The smart constructors for 'VText' are:
+--
+-- * 'text'     — single string, HTML-encoded on the server
+-- * 'vtext'    — synonym for 'text'
+-- * 'textRaw'  — single string, never HTML-encoded
+-- * 'text_'    — list of strings joined with a space
+-- * 'textKey'  — single keyed string
+-- * 'textKey_' — list of keyed strings joined with a space
+-- * 'keyed'    — attach a key to any 'View', including 'VText'
+--
 -- = 'VFrag' (Fragment nodes)
 --
 -- Similar to the [React Fragment](https://react.dev/reference/react/Fragment) API (@\<Fragment\>@ or @\<\>\<\/\>@ syntax), and to @DocumentFragment@ in the browser DOM API. @miso@ provides a 'VFrag' constructor for grouping together sibling nodes without introducing an extra wrapper element in the DOM.
@@ -383,7 +499,7 @@
 --
 -- * Defining event handlers
 --
--- Users can define their own event handlers using the 'Miso.Event.on' combinator. By default this will define an event in the 'Miso.Event.Types.BUBBLE' phase. See 'Miso.Event.onCapture' for handling events during the 'Miso.Event.Types.CAPTURE' phase. See the the module "Miso.Html.Event" for many predefined events.
+-- Users can define their own event handlers using the 'Miso.Event.on' combinator. By default this will define an event in the 'Miso.Event.Types.BUBBLE' phase. See 'Miso.Event.onCapture' for handling events during the 'Miso.Event.Types.CAPTURE' phase. See the module "Miso.Html.Event" for many predefined events.
 --
 -- @
 -- 'onChangeWith' :: ('MisoString' -> 'DOMRef' -> action) -> 'Attribute' action
@@ -413,12 +529,55 @@
 --
 -- = Attributes / Properties
 --
--- The 'Attribute' type allows us to define web handlers that map browser events to
--- Haskell data types (e.g. 'Miso.Html.Event.onClick'), along with specifying properties on DOM elements
--- (like 'Miso.Html.Property.className' and 'Miso.Html.Property.id_'). See "Miso.Property" and "Miso.Html.Property" for more information.
+-- The 'Attribute' type carries everything that can be attached to a DOM element:
 --
 -- @
--- 'div_' [ 'id_' "some-id", 'className' "some-class" ] [ ]
+-- data 'Attribute' action
+--   = 'Property' MisoString Value        -- ^ DOM property (key/value)
+--   | 'ClassList' [MisoString]           -- ^ CSS class list
+--   | 'On' (Sink action -> ...)          -- ^ Event handler
+--   | 'Styles' (Map MisoString MisoString) -- ^ Inline style map
+-- @
+--
+-- In practice you never construct these directly. Use the smart constructors from
+-- "Miso.Html.Property", "Miso.Html.Event", "Miso.Property", and "Miso.CSS":
+--
+-- @
+-- 'div_'
+--   [ 'id_' "container"          -- textProp "id"
+--   , 'className' "card active"  -- textProp "class"
+--   , 'classList' ["card", "active"] -- ClassList (alternative)
+--   , 'disabled_' True           -- boolProp "disabled"
+--   , 'onClick' MyAction         -- On event handler
+--   , 'style_' [ 'CSS.display' "flex" ]  -- Styles map
+--   ]
+--   []
+-- @
+--
+-- == Custom properties
+--
+-- Use 'prop' (or the typed variants 'textProp', 'boolProp', 'intProp', 'doubleProp',
+-- 'objectProp') from "Miso.Property" to set arbitrary DOM properties:
+--
+-- @
+-- 'prop' "data-index" (42 :: Int)      -- sets element.data-index = 42
+-- 'textProp' "placeholder" "Search…"  -- sets element.placeholder
+-- 'boolProp' "checked" True            -- sets element.checked = true
+-- @
+--
+-- Note that DOM /properties/ and HTML /attributes/ are distinct. Miso sets
+-- properties on the DOM node object (e.g. @node.checked@) rather than the
+-- HTML attribute (e.g. @setAttribute("checked", ...)@). This matches what
+-- the browser actually exposes in JavaScript and avoids common pitfalls with
+-- boolean attributes.
+--
+-- == Keys
+--
+-- 'key_' (and its alias 'keyProp') attaches a reconciliation key to any element.
+-- See the @'Key'@ section for details.
+--
+-- @
+-- 'li_' [ 'key_' (itemId item) ] [ 'text' (itemLabel item) ]
 -- @
 --
 -- = 'Effect'
@@ -473,6 +632,12 @@
 -- 'ComponentInfo' provides the current 'ComponentId' the @parent@ 'ComponentId', and the 'DOMRef' ('_componentDOMRef') that the 'Component' is mounted on.
 --
 -- = 'Component' communication
+--
+-- Miso provides three mechanisms for 'Component' to exchange data:
+--
+-- * __Props__ — synchronous, parent-to-child read-only data passed at mount time (see below).
+-- * __Async mailbox__ — message-passing via 'mail' / 'broadcast' / 'checkMail'; any 'Component' can send a t'Miso.JSON.Value' to any other by 'ComponentId'.
+-- * __PubSub__ ("Miso.PubSub") — publish\/subscribe for fan-out messaging across unrelated 'Component'.
 --
 -- = Props
 --
@@ -709,15 +874,149 @@
 --
 -- = (2D/3D) Canvas support
 --
---  Miso has full 2D and 3D canvas support. See the "Miso.Canvas" module, the [miso-canvas](https://github.com/haskell-miso/miso-canvas2d) example, along with the [three-miso](https://github.com/haskell-miso/three-miso) package.
+-- Miso has full 2D and 3D canvas support via "Miso.Canvas". See also the
+-- [miso-canvas](https://github.com/haskell-miso/miso-canvas2d) example and the
+-- [three-miso](https://github.com/haskell-miso/three-miso) package for Three.js integration.
+--
+-- == The 'Canvas' monad
+--
+-- Drawing commands run in the 'Canvas' monad, which is a 'ReaderT' over a
+-- @CanvasContext2D@ (the raw JavaScript @CanvasRenderingContext2D@):
+--
+-- @
+-- type 'Canvas' a = 'ReaderT' 'CanvasContext2D' IO a
+-- @
+--
+-- == Embedding a canvas in the view
+--
+-- Use the 'canvas' smart constructor.
+-- It takes an /init/ callback (runs once on mount, returns state) and a
+-- /draw/ callback (runs on every render with the current state):
+--
+-- @
+-- 'canvas'
+--   [ HP.'width_' "800", HP.'height_' "480" ]
+--   (\\_ -> pure ())                   -- init: no per-canvas state
+--   (\\() -> drawScene myModel)        -- draw: closure over current model
+-- @
+--
+-- 'canvas_' is the variant that threads no init state at all (always passes @()@).
+--
+-- == Drawing commands
+--
+-- Common 2D primitives:
+--
+-- @
+-- drawScene :: Model -> 'Canvas' ()
+-- drawScene model = do
+--   'clearRect' (0, 0, 800, 480)
+--   'fillStyle' ('RGB' 30 144 255)
+--   'beginPath' ()
+--   'arc' (400, 240, 50, 0, 2 * pi)
+--   'fill' ()
+--   'font' "24px sans-serif"
+--   'fillText' ("Score: " \<\> ms (score model), 10, 30)
+-- @
+--
+-- Available primitives include: 'clearRect', 'fillRect', 'strokeRect',
+-- 'beginPath', 'closePath', 'moveTo', 'lineTo', 'arc', 'arcTo',
+-- 'fill', 'stroke', 'fillText', 'drawImage', 'drawImage''.
+--
+-- Style setters: 'fillStyle', 'strokeStyle', 'lineWidth', 'font'.
+-- 'fillStyle' and 'strokeStyle' accept a 'StyleArg' — use 'color' from "Miso.Canvas"
+-- (not "Miso.CSS") to construct one from a t'Miso.CSS.Color.Color' value.
+-- See the __Canonical Import Pattern__ section for how to avoid the name collision
+-- between 'Miso.Canvas.color' and 'Miso.CSS.color'.
 --
 -- = 'Control.Monad.State.State' management
 --
---  A simple 'Miso.Lens.Lens' implementation is included with miso, this was done for convenience, to minimize dependencies, reduce payload size, and provide a simpler interface. See "Miso.Lens". This is a simple lens formulation that exposes many common 'MonadState' lenses (e.g. @'+='@) that work in the 'Effect' monad. "Miso.Lens" is not required for use, any lens library will also work with miso.
+-- Miso bundles a lightweight lens library in "Miso.Lens" to minimise dependencies
+-- and payload size. Any lens library (optics, lens) also works — "Miso.Lens" is not required.
+--
+-- == Basic lens operations
+--
+-- @
+-- 'Miso.Lens.view' l      -- read a field   (MonadReader)
+-- 'set'  l v    -- write a field
+-- 'over' l f    -- modify a field
+-- r '^.' l      -- infix read
+-- r '&' l '.~' v  -- infix write
+-- @
+--
+-- == 'MonadState' operators (for use inside 'Effect')
+--
+-- @
+-- l '+=' n   -- increment a numeric field
+-- l '-=' n   -- decrement
+-- l '*=' n   -- multiply
+-- @
+--
+-- == 'this' — the identity lens
+--
+-- When the model /is/ the field (e.g. the model is a plain @Int@), use 'this':
+--
+-- @
+-- update = \\case
+--   Increment -> 'this' '+=' 1
+--   Decrement -> 'this' '-=' 1
+-- @
+--
+-- == Generating lenses
+--
+-- Three approaches, pick one:
+--
+-- * __Template Haskell__ ("Miso.Lens.TH"): 'makeLenses' / 'makeClassy' splice lenses for each record field.
+-- * __Generics__ ("Miso.Lens.Generic"): 'field' \/ 'HasLens' derive lenses without TH.
+-- * __Hand-written__: construct a 'Lens' directly using the @Lens s a@ synonym.
+--
+-- @
+-- {-# LANGUAGE TemplateHaskell #-}
+-- import Miso.Lens.TH (makeLenses)
+--
+-- data Model = Model { _count :: Int, _name :: MisoString }
+-- makeLenses ''Model
+--
+-- update = \\case
+--   Increment -> count '+=' 1
+--   Rename n  -> name '.~' n
+-- @
 --
 -- = HTML
 --
--- Miso's virtual DOM DSL ('Miso.Types.View') type can be repurposed to render HTML. See the "Miso.Html.Render" module for more information. This uses the 'Miso.Html.Render.ToHtml' class.
+-- Miso's 'View' type doubles as an HTML serialiser via the 'ToHtml' class in
+-- "Miso.Html.Render". This is used for server-side rendering (SSR): build a
+-- 'View' with the normal DSL and render it to a lazy 'Data.ByteString.Lazy.ByteString'
+-- on the server.
+--
+-- @
+-- class 'ToHtml' a where
+--   'toHtml' :: a -> 'Data.ByteString.Lazy.ByteString'
+-- @
+--
+-- Instances are provided for @'View' m a@ and @['View' m a]@:
+--
+-- @
+-- import Miso.Html.Render (toHtml)
+--
+-- pageHtml :: 'Data.ByteString.Lazy.ByteString'
+-- pageHtml = 'toHtml' $ 'div_' [ 'id_' "root" ] [ "Hello, world!" ]
+-- @
+--
+-- This is typically wired into a Servant (or WAI) handler on the server:
+--
+-- @
+-- import Servant
+-- import Miso.Html.Render (toHtml)
+--
+-- type API = Get '[HTML] 'Data.ByteString.Lazy.ByteString'
+--
+-- server :: Server API
+-- server = pure (toHtml myView)
+-- @
+--
+-- On the client, pass the matching 'Component' to 'miso' (instead of 'startApp')
+-- so it hydrates the server-rendered markup rather than redrawing from scratch.
+-- See the __Prerendering__ section for the full flow.
 --
 -- = JavaScript EDSL
 --
@@ -752,29 +1051,261 @@
 --
 -- = Routing
 --
--- miso exposes its own internal router. See "Miso.Router" for more information. The router is inspired by both the [servant](https://hackage.haskell.org/package/servant) and the [web-routes](https://hackage.haskell.org/package/web-routes) package. The router has its own 'Sub' called 'Miso.Router.routerSub' meant for easy integration with the History API.
+-- Miso includes a client-side router in "Miso.Router" inspired by
+-- [servant](https://hackage.haskell.org/package/servant) and
+-- [web-routes](https://hackage.haskell.org/package/web-routes).
+-- Routes are defined as Servant-style types and matched against the browser URI.
+--
+-- == Defining routes
+--
+-- Routes are Servant-style type-level expressions. A @Route@ sum type
+-- mirrors the type, with one constructor per branch:
+--
+-- > {-# LANGUAGE DataKinds #-}
+-- >
+-- > import Servant.API
+-- > import Miso.Router
+-- >
+-- > -- type Routes = Home :<|> ("about" :> About) :<|> ("user" :> Capture "id" Int :> UserPage)
+-- >
+-- > data Route = Home | About | UserPage Int
+--
+-- == Subscribing to URI changes
+--
+-- 'routerSub' fires your action whenever the browser URI changes, delivering
+-- either the matched route or a 'RoutingError':
+--
+-- @
+-- 'subs' = [ 'routerSub' HandleRoute ]
+--
+-- update = \\case
+--   HandleRoute (Right route) -> 'modify' (\\m -> m { currentRoute = route })
+--   HandleRoute (Left _)      -> 'modify' (\\m -> m { currentRoute = NotFound })
+-- @
+--
+-- 'uriSub' is the lower-level variant that delivers the raw 'URI' instead of
+-- a parsed route.
+--
+-- == Navigating programmatically
+--
+-- @
+-- 'pushURI'   uri    -- push a URI onto the History stack
+-- 'pushRoute' route  -- like pushURI but takes a typed route (via 'Router' class)
+-- @
+--
+-- == Parsing a URI manually
+--
+-- @
+-- 'runRouter' "\/user\/42" myParser  -- Right (UserPage 42) or Left RoutingError
+-- 'parseURI'  "\/about"              -- Right URI or Left error
+-- @
 --
 -- = 'MisoString'
 --
--- miso includes its own string type named t'MisoString'. This is the preferred string type to use
--- in order to maximize application performance. Since strings are ubiquitous in applications we
--- want to minimize the copying of these strings between the JS and Haskell heaps. t'MisoString' accomplishes this.
--- t'MisoString' is a synonym for t'JSString' when using the JS / WASM backends. When using vanilla GHC
--- it is t'Data.Text'. See "Miso.String" for more information.
+-- t'MisoString' is miso's canonical string type, chosen to minimise copying between
+-- the Haskell and JavaScript heaps:
 --
--- For string conversions see the 'ms', 'fromMisoString' functions and 'ToMisoString' / 'FromMisoString' classes.
+-- * __JS / WASM backends__: t'MisoString' is @JSString@, a direct reference to a
+--   JavaScript string — no marshalling cost when passing to the DOM or FFI.
+-- * __Server / vanilla GHC__ (@ssr@ flag): t'MisoString' is t'Data.Text'.
 --
--- t'MisoString' is also used in the "Miso.Util.Lexer" and "Miso.Util.Parser" modules.
+-- Use t'MisoString' anywhere you would otherwise reach for 'String' or 'Text' in a
+-- miso application. See "Miso.String" for the full API.
+--
+-- == Converting to 'MisoString'
+--
+-- The 'ms' function (shorthand for 'toMisoString') converts any type with a
+-- 'ToMisoString' instance:
+--
+-- @
+-- ms "hello"          -- String    -> MisoString
+-- ms (42 :: Int)      -- Int       -> MisoString
+-- ms (3.14 :: Double) -- Double    -> MisoString
+-- ms myText           -- Data.Text -> MisoString
+-- @
+--
+-- 'ToMisoString' instances are provided for 'String', t'Data.Text.Text',
+-- t'Data.Text.Lazy.Text', t'Data.ByteString.ByteString', 'Int', 'Word',
+-- 'Double', 'Float', and 'Char'.
+--
+-- == Converting from 'MisoString'
+--
+-- 'fromMisoString' parses a t'MisoString' back into another type (throws on failure).
+-- Use 'fromMisoStringEither' for a safe variant:
+--
+-- @
+-- fromMisoString "42"     :: Int     -- 42
+-- fromMisoString "3.14"   :: Double  -- 3.14
+-- fromMisoStringEither s  :: Either String Int
+-- @
+--
+-- 'FromMisoString' instances are provided for 'String', t'Data.Text.Text',
+-- t'Data.Text.Lazy.Text', t'Data.ByteString.ByteString', 'Int', 'Word',
+-- 'Double', and 'Float'.
+--
+-- == Multiline literals
+--
+-- "Miso.String.QQ" provides a QuasiQuoter for multiline t'MisoString' literals:
+--
+-- @
+-- {-# LANGUAGE QuasiQuotes #-}
+--
+-- import Miso.String.QQ (misoString)
+--
+-- snippet :: MisoString
+-- snippet = [misoString|
+--   line one
+--   line two
+-- |]
+-- @
+--
+-- t'MisoString' is also the element type used throughout "Miso.Util.Lexer" and
+-- "Miso.Util.Parser".
 --
 -- = JSON
 --
--- "Miso.JSON" is a [microaeson](https://hackage.haskell.org/package/microaeson)
--- implementation that uses t'MisoString'. This is done for performance reasons and to minimize the dependency burden. "Miso.JSON" is used
--- in "Miso.Event.Decoder", "Miso.Fetch", "Miso.WebSocket" modules respectively.
+-- "Miso.JSON" is a [microaeson](https://hackage.haskell.org/package/microaeson)-inspired
+-- JSON library specialised to t'MisoString'. On the JS\/WASM backends it delegates
+-- encoding and decoding to the JavaScript runtime (@JSON.stringify@ \/ @JSON.parse@)
+-- for performance. On the server (@ssr@ flag) it uses a pure Haskell implementation.
+-- "Miso.JSON" is used internally by "Miso.Event.Decoder", "Miso.Fetch", and "Miso.WebSocket".
+--
+-- == 'Value'
+--
+-- The JSON 'Value' type mirrors the JSON specification:
+--
+-- @
+-- data 'Value'
+--   = 'Number' 'Double'
+--   | 'Bool'   'Bool'
+--   | 'String' 'MisoString'
+--   | 'Array'  ['Value']
+--   | 'Object' ('Map' 'MisoString' 'Value')
+--   | 'Null'
+-- @
+--
+-- == Encoding
+--
+-- Encode any 'ToJSON' instance to a t'MisoString':
+--
+-- @
+-- 'encode' value        -- uses JS runtime on client, pure on server
+-- 'encodePure' value    -- always uses pure Haskell implementation
+-- @
+--
+-- == Decoding
+--
+-- @
+-- 'decode' s            :: Maybe a      -- returns Nothing on failure
+-- 'eitherDecode' s      :: Either MisoString a
+-- @
+--
+-- == 'ToJSON' \/ 'FromJSON'
+--
+-- Derive instances via @GHC.Generics@:
+--
+-- @
+-- {-# LANGUAGE DeriveGeneric #-}
+--
+-- import GHC.Generics
+-- import Miso.JSON
+--
+-- data User = User { name :: MisoString, age :: Int }
+--   deriving (Generic)
+--
+-- instance ToJSON   User
+-- instance FromJSON User
+-- @
+--
+-- Use 'genericToJSON' \/ 'genericParseJSON' with 'Options' to customise field and
+-- constructor names. 'camelTo2' is provided for converting @camelCase@ to
+-- @snake_case@ (or any separator):
+--
+-- @
+-- instance ToJSON User where
+--   toJSON = 'genericToJSON' 'defaultOptions' { 'fieldLabelModifier' = 'camelTo2' \'_\' }
+-- @
+--
+-- == Building and Parsing Objects
+--
+-- @
+-- -- Build
+-- 'object' [ "name" '.=' ms "Alice", "age" '.=' (30 :: Int) ]
+--
+-- -- Parse (inside a 'withObject' callback or event decoder)
+-- 'withObject' "User" $ \\o -> User
+--   \<$\> o '.:' "name"     -- required field
+--   \<*\> o '.:' "age"
+--
+-- o '.:?' "nickname"    -- optional field → Maybe a
+-- o '.:!' "nickname"    -- optional field, explicit null → Maybe a
+-- p '.!=' "anon"        -- provide a default for a Maybe parser
+-- @
+--
+-- == Pretty-Printing
+--
+-- @
+-- 'encodePretty'  value          -- indented with 'defConfig' (2-space indent)
+-- 'encodePretty'' config value   -- indented with custom 'Config'
+-- @
+--
+-- == @miso-aeson@
+--
+-- If you prefer to use the [aeson](https://hackage.haskell.org/package/aeson) library directly,
+-- the [miso-aeson](https://github.com/haskell-miso/miso-aeson) package provides a compatibility
+-- shim that bridges @aeson@\'s 'Data.Aeson.ToJSON' \/ 'Data.Aeson.FromJSON' instances with miso\'s
+-- event decoder and fetch API, so existing @aeson@-derived instances can be used without rewriting them.
 --
 -- = Styles
 --
--- Miso prescribes no exact CSS style usage. It is up to the user's discretion on how best to handle styles in their application. Inline styles, external stylesheets and the "Miso.CSS" DSL can all be used. See also [miso-ui](https://ui.haskell-miso.org) for an example of what is possible.
+-- Miso does not prescribe a single CSS strategy. Three approaches work out of the box:
+--
+-- == 1. Structured DSL ("Miso.CSS")
+--
+-- 'style_' takes a list of @'Style'@ values (which are @(MisoString, MisoString)@ pairs).
+-- Miso manages individual properties on the DOM node, merging and diffing them efficiently:
+--
+-- @
+-- import qualified Miso.CSS as CSS
+-- import           Miso.CSS.Color (RGB(..))
+--
+-- 'div_'
+--   [ CSS.'style_'
+--       [ CSS.'display' "flex"
+--       , CSS.'flexDirection' "column"
+--       , CSS.'backgroundColor' (RGB 30 30 30)
+--       , CSS.'color' (RGB 255 255 255)
+--       ]
+--   ]
+--   []
+-- @
+--
+-- Custom properties can be constructed with the '=:' operator (re-exported from "Miso.Util"):
+--
+-- @
+-- "user-select" '=:' "none"
+-- @
+--
+-- == 2. Inline string ('CSS.styleInline_')
+--
+-- For simple or dynamic style strings, 'styleInline_' sets the element's @style@
+-- attribute as a raw string:
+--
+-- @
+-- CSS.'styleInline_' "display:flex; gap:8px; padding:16px"
+-- @
+--
+-- == 3. External stylesheets
+--
+-- Link external CSS files from the @\<head\>@ via the 'styles' field on 'Component'
+-- (see the __Development__ section), or include them in your HTML template directly.
+-- This is the most common approach for production apps using Tailwind, Bootstrap, etc.
+--
+-- See [miso-ui](https://ui.haskell-miso.org) for a larger example.
+--
+-- __Name collision note__: if you use both "Miso.Canvas" and "Miso.CSS" in the same
+-- module, always qualify "Miso.CSS" — both export a 'color' function with different types.
+-- See the __Canonical Import Pattern__ section.
 --
 -- = Development
 --
@@ -787,8 +1318,8 @@
 --  where
 --    app = counter
 -- #ifdef INTERACTIVE
---      { 'scripts' = [ 'Src' "https://ajax.googleapis.com/ajax/libs/jquery/3.7.1/jquery.min.js" (False :: CacheBust) ]
---      , 'styles' = [ 'Href' "https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" (False :: CacheBust)  ]
+--      { 'scripts' = [ 'Src' "https://ajax.googleapis.com/ajax/libs/jquery/3.7.1/jquery.min.js" ('False' :: 'CacheBust') ]
+--      , 'styles' = [ 'Href' "https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" ('False' :: 'CacheBust')  ]
 --      }
 -- #endif
 -- @
@@ -797,9 +1328,8 @@
 --
 -- = Debugging
 --
--- Sometimes things can go wrong. Common errors like using `onClick` but not listening for the the 'click' event are common.
--- These are errors that cannot be caught statically. These can be detected by enabling 'DebugAll'. Currently, debugging event delegation
--- and page hydration is supported.
+-- Sometimes things can go wrong. Common errors like using `onClick` but not listening for the 'click' event are common.
+-- These are errors that cannot be caught statically (unless we use a dependently-typed language like [Idris](https://idris-lang.org)). These can be detected by enabling 'DebugAll'. Currently, debugging event delegation and page hydration is supported.
 --
 -- * 'DebugHydrate'
 -- * 'DebugEvents'
@@ -810,8 +1340,29 @@
 --
 -- = Internals
 --
--- Internally miso uses a global event queue and a scheduler to process all events raised by 'Component' throughout the lifetime of
--- an application. Events are processed in FIFO order, batched by the 'Component' that raised them.
+-- Internally miso uses a global event queue and a scheduler to process all
+-- events raised by 'Component' throughout the lifetime of an application.
+-- Events are processed in FIFO order, batched by the 'Component' that raised them.
+--
+-- * __Event queue__: All actions dispatched via a 'Sink' (from event handlers,
+--   subscriptions, or 'io' callbacks) are enqueued and drained by the scheduler.
+--
+-- * __Scheduler__: The scheduler pulls actions off the queue one batch at a time,
+--   runs the 'update' function for each, collects the resulting 'IO' work, and
+--   executes it. Rendering (VDOM diff + patch) is triggered after each batch.
+--
+-- * __'Waiter'__: A 'Miso.Concurrent.Waiter' is a synchronization primitive used
+--   internally to coordinate the event loop — it blocks the scheduler thread until
+--   new work arrives, avoiding busy-waiting.
+--
+-- * __Event delegation__: Rather than attaching listeners to individual DOM nodes,
+--   miso attaches a single capture and a single bubble listener to @\<body\>@.
+--   Incoming events are routed through the virtual DOM tree to the matching handler.
+--   This minimises listener churn when the VDOM is patched.
+--
+-- * __VDOM diffing__: The diff algorithm in "Miso.Diff" compares old and new
+--   'View' trees and emits the minimal set of DOM mutations. Keyed children (see
+--   the @'Key'@ section) allow O(n) list reconciliation instead of O(n²).
 --
 -- = Prerendering
 --

--- a/src/Miso.hs
+++ b/src/Miso.hs
@@ -1190,18 +1190,18 @@
 -- for performance. On the server (@ssr@ flag) it uses a pure Haskell implementation.
 -- "Miso.JSON" is used internally by "Miso.Event.Decoder", "Miso.Fetch", and "Miso.WebSocket".
 --
--- == 'Value'
+-- == 'Miso.JSON.Value'
 --
--- The JSON 'Value' type mirrors the JSON specification:
+-- The JSON t'Miso.JSON.Value' type mirrors the JSON specification:
 --
 -- @
--- data 'Value'
---   = 'Number' 'Double'
---   | 'Bool'   'Bool'
---   | 'String' 'MisoString'
---   | 'Array'  ['Value']
---   | 'Object' ('Map' 'MisoString' 'Value')
---   | 'Null'
+-- data Value
+--   = Number Double
+--   | Bool   Bool
+--   | String MisoString
+--   | Array  [Value]
+--   | Object (Map MisoString Value)
+--   | Null
 -- @
 --
 -- == Encoding
@@ -1323,10 +1323,6 @@
 --
 -- See [miso-ui](https://ui.haskell-miso.org) for a larger example.
 --
--- __Name collision note__: if you use both "Miso.Canvas" and "Miso.CSS" in the same
--- module, always qualify "Miso.CSS" — both export a 'color' function with different types.
--- See the __Canonical Import Pattern__ section.
---
 -- = Development
 --
 -- When developing miso applications interactively it is possible to append 'styles' and 'scripts' to the @\<head\>@ portion of
@@ -1382,7 +1378,7 @@
 --
 -- * __VDOM diffing__: The diff algorithm in "Miso.Diff" compares old and new
 --   'View' trees and emits the minimal set of DOM mutations. Keyed children (see
---   the @'Key'@ section) allow O(n) list reconciliation instead of O(n²).
+--   the 'Key' section) significantly speed up child list reconciliation.
 --
 -- = Prerendering
 --

--- a/src/Miso.hs
+++ b/src/Miso.hs
@@ -1028,16 +1028,18 @@
 -- pageHtml = 'toHtml' $ 'div_' [ 'id_' "root" ] [ "Hello, world!" ]
 -- @
 --
--- This is typically wired into a Servant (or WAI) handler on the server:
+-- This is typically wired into a Servant handler on the server using the
+-- [servant-miso-html](https://github.com/haskell-miso/servant-miso-html) package,
+-- which provides an @HTML@ content-type that serialises 'View' and 'Component'
+-- values directly — no manual 'ByteString' conversion needed:
 --
 -- @
--- import Servant
--- import Miso.Html.Render (toHtml)
+-- import Servant.Miso.Html (HTML)
 --
--- type API = Get '[HTML] 'Data.ByteString.Lazy.ByteString'
---
--- server :: Server API
--- server = pure (toHtml myView)
+-- type Home    = \"home\"    :\> Get '[HTML] (Component model action)
+-- type About   = \"about\"   :\> Get '[HTML] (View model action)
+-- type Contact = \"contact\" :\> Get '[HTML] [View model action]
+-- type API = Home :\<|\> About :\<|\> Contact
 -- @
 --
 -- On the client, pass the matching 'Component' to 'miso' (instead of 'startApp')

--- a/src/Miso.hs
+++ b/src/Miso.hs
@@ -1152,8 +1152,6 @@
 -- > import Servant.API
 -- > import Miso.Router
 -- >
--- > -- type Routes = Home :<|> ("about" :> About) :<|> ("user" :> Capture "id" Int :> UserPage)
--- >
 -- > data Route = Home | About | UserPage Int
 --
 -- == Subscribing to URI changes

--- a/src/Miso.hs
+++ b/src/Miso.hs
@@ -1137,51 +1137,84 @@
 --
 -- = Routing
 --
--- Miso includes a client-side router in "Miso.Router" inspired by
--- [servant](https://hackage.haskell.org/package/servant) and
--- [web-routes](https://hackage.haskell.org/package/web-routes).
--- Routes are defined as Servant-style types and matched against the browser URI.
+-- "Miso.Router" provides a reversible, type-safe client-side router. A @Route@
+-- type encodes URL structure; the 'Router' class converts between routes and
+-- 'URI' values in both directions. Use it with 'Miso.Subscription.History.routerSub'
+-- or 'Miso.Subscription.History.uriSub' to react to browser navigation.
 --
--- == Defining routes
+-- == Defining a 'Router' with Generics
 --
--- Routes are Servant-style type-level expressions. A @Route@ sum type
--- mirrors the type, with one constructor per branch:
+-- Derive 'Router' via @GHC.Generics@ — constructor names become path segments
+-- (camel-case uses only the first hump). Use t'Capture', t'Path', t'QueryParam',
+-- and t'QueryFlag' as constructor fields to describe the URL shape:
 --
--- > {-# LANGUAGE DataKinds #-}
--- >
--- > import Servant.API
--- > import Miso.Router
--- >
--- > data Route = Home | About | UserPage Int
+-- @
+-- {-# LANGUAGE DeriveGeneric  #-}
+-- {-# LANGUAGE DeriveAnyClass #-}
+--
+-- import GHC.Generics
+-- import Miso.Router
+--
+-- data Route
+--   = Index                                                      -- matches "/"
+--   | About                                                      -- matches "/about"
+--   | Widget (Capture "id" Int) (QueryParam "tab" MisoString)   -- matches "/widget/42?tab=info"
+--   deriving stock    (Show, Eq, Generic)
+--   deriving anyclass Router
+-- @
+--
+-- The router is /reversible/ — 'prettyRoute' re-serialises any route back to a URL:
+--
+-- @
+-- 'prettyRoute' (Widget (Capture 42) (QueryParam (Just "info")))
+-- -- "\/widget\/42?tab=info"
+-- @
+--
+-- == Defining a 'Router' manually
+--
+-- For full control, implement 'routeParser' and 'fromRoute' directly:
+--
+-- @
+-- data Route = Widget Int
+--
+-- instance Router Route where
+--   routeParser = routes [ Widget \<$\> ('path' "widget" *\> 'capture') ]
+--   fromRoute (Widget n) = [ 'toPath' "widget", 'toCapture' n ]
+-- @
 --
 -- == Subscribing to URI changes
 --
--- 'routerSub' fires your action whenever the browser URI changes, delivering
--- either the matched route or a 'RoutingError':
+-- 'Miso.Subscription.History.routerSub' listens to @popstate@ events and delivers
+-- the parsed route (or a 'RoutingError') to your @update@ function:
 --
 -- @
--- 'subs' = [ 'routerSub' HandleRoute ]
+-- app = ('vcomp' m u v) { 'subs' = [ 'routerSub' HandleRoute ] }
 --
 -- update = \\case
---   HandleRoute (Right route) -> 'modify' (\\m -> m { currentRoute = route })
---   HandleRoute (Left _)      -> 'modify' (\\m -> m { currentRoute = NotFound })
+--   HandleRoute (Right Index)       -> 'modify' (\\m -> m { page = HomePage })
+--   HandleRoute (Right About)       -> 'modify' (\\m -> m { page = AboutPage })
+--   HandleRoute (Left _)            -> 'modify' (\\m -> m { page = NotFound })
 -- @
 --
--- 'uriSub' is the lower-level variant that delivers the raw 'URI' instead of
--- a parsed route.
+-- 'Miso.Subscription.History.uriSub' is the lower-level variant — it delivers
+-- the raw 'URI' without parsing, useful when you want to handle routing yourself.
 --
 -- == Navigating programmatically
 --
 -- @
--- 'pushURI'   uri    -- push a URI onto the History stack
--- 'pushRoute' route  -- like pushURI but takes a typed route (via 'Router' class)
+-- 'pushURI'    uri    -- push a raw 'URI' onto the History stack
+-- 'pushRoute'  route  -- push a typed route (serialised via 'Router')
+-- 'replaceURI' uri    -- replace the current history entry
+-- 'back'              -- go back one entry
+-- 'forward'           -- go forward one entry
 -- @
 --
--- == Parsing a URI manually
+-- == Type-safe links in views
+--
+-- 'Miso.Router.href_' produces a type-safe @href@ attribute from any route:
 --
 -- @
--- 'runRouter' "\/user\/42" myParser  -- Right (UserPage 42) or Left RoutingError
--- 'parseURI'  "\/about"              -- Right URI or Left error
+-- 'button_' [ 'Miso.Router.href_' (Widget (Capture 10) (QueryParam Nothing)) ] [ "Go to widget 10" ]
 -- @
 --
 -- = 'MisoString'

--- a/src/Miso.hs
+++ b/src/Miso.hs
@@ -878,53 +878,54 @@
 -- [miso-canvas](https://github.com/haskell-miso/miso-canvas2d) example and the
 -- [three-miso](https://github.com/haskell-miso/three-miso) package for Three.js integration.
 --
--- == The 'Canvas' monad
+-- == The 'Miso.Canvas.Canvas' monad
 --
--- Drawing commands run in the 'Canvas' monad, which is a 'ReaderT' over a
+-- Drawing commands run in the 'Miso.Canvas.Canvas' monad, which is a 'ReaderT' over a
 -- @CanvasContext2D@ (the raw JavaScript @CanvasRenderingContext2D@):
 --
 -- @
--- type 'Canvas' a = 'ReaderT' 'CanvasContext2D' IO a
+-- type Canvas a = ReaderT CanvasContext2D IO a
 -- @
 --
 -- == Embedding a canvas in the view
 --
--- Use the 'canvas' smart constructor.
+-- Use the 'Miso.Canvas.canvas' smart constructor.
 -- It takes an /init/ callback (runs once on mount, returns state) and a
 -- /draw/ callback (runs on every render with the current state):
 --
 -- @
--- 'canvas'
+-- 'Miso.Canvas.canvas'
 --   [ HP.'width_' "800", HP.'height_' "480" ]
 --   (\\_ -> pure ())                   -- init: no per-canvas state
 --   (\\() -> drawScene myModel)        -- draw: closure over current model
 -- @
 --
--- 'canvas_' is the variant that threads no init state at all (always passes @()@).
+-- 'Miso.Canvas.canvas_' is the variant that threads no init state at all (always passes @()@).
 --
 -- == Drawing commands
 --
 -- Common 2D primitives:
 --
 -- @
--- drawScene :: Model -> 'Canvas' ()
+-- drawScene :: Model -> 'Miso.Canvas.Canvas' ()
 -- drawScene model = do
---   'clearRect' (0, 0, 800, 480)
---   'fillStyle' ('RGB' 30 144 255)
---   'beginPath' ()
---   'arc' (400, 240, 50, 0, 2 * pi)
---   'fill' ()
---   'font' "24px sans-serif"
---   'fillText' ("Score: " \<\> ms (score model), 10, 30)
+--   'Miso.Canvas.clearRect' (0, 0, 800, 480)
+--   'Miso.Canvas.fillStyle' ('Miso.CSS.Color.RGB' 30 144 255)
+--   'Miso.Canvas.beginPath' ()
+--   'Miso.Canvas.arc' (400, 240, 50, 0, 2 * pi)
+--   'Miso.Canvas.fill' ()
+--   'Miso.Canvas.font' "24px sans-serif"
+--   'Miso.Canvas.fillText' ("Score: " \<\> ms (score model), 10, 30)
 -- @
 --
--- Available primitives include: 'clearRect', 'fillRect', 'strokeRect',
--- 'beginPath', 'closePath', 'moveTo', 'lineTo', 'arc', 'arcTo',
--- 'fill', 'stroke', 'fillText', 'drawImage', 'drawImage''.
+-- Available primitives include: 'Miso.Canvas.clearRect', 'Miso.Canvas.fillRect', 'Miso.Canvas.strokeRect',
+-- 'Miso.Canvas.beginPath', 'Miso.Canvas.closePath', 'Miso.Canvas.moveTo', 'Miso.Canvas.lineTo',
+-- 'Miso.Canvas.arc', 'Miso.Canvas.arcTo', 'Miso.Canvas.fill', 'Miso.Canvas.stroke',
+-- 'Miso.Canvas.fillText', 'Miso.Canvas.drawImage', 'Miso.Canvas.drawImage''.
 --
--- Style setters: 'fillStyle', 'strokeStyle', 'lineWidth', 'font'.
--- 'fillStyle' and 'strokeStyle' accept a 'StyleArg' — use 'color' from "Miso.Canvas"
--- (not "Miso.CSS") to construct one from a t'Miso.CSS.Color.Color' value.
+-- Style setters: 'Miso.Canvas.fillStyle', 'Miso.Canvas.strokeStyle', 'Miso.Canvas.lineWidth', 'Miso.Canvas.font'.
+-- 'Miso.Canvas.fillStyle' and 'Miso.Canvas.strokeStyle' accept a 'Miso.Canvas.StyleArg' — use
+-- 'Miso.Canvas.color' (not 'Miso.CSS.color') to construct one from a t'Miso.CSS.Color.Color' value.
 -- See the __Canonical Import Pattern__ section for how to avoid the name collision
 -- between 'Miso.Canvas.color' and 'Miso.CSS.color'.
 --
@@ -936,11 +937,11 @@
 -- == Basic lens operations
 --
 -- @
--- 'Miso.Lens.view' l      -- read a field   (MonadReader)
--- 'set'  l v    -- write a field
--- 'over' l f    -- modify a field
--- r '^.' l      -- infix read
--- r '&' l '.~' v  -- infix write
+-- 'Miso.Lens.view' l   -- read a field (MonadReader)
+-- 'set'  l v           -- write a field
+-- 'over' l f           -- modify a field
+-- r '^.' l             -- infix read
+-- r '&' l '.~' v       -- infix write
 -- @
 --
 -- == 'MonadState' operators (for use inside 'Effect')

--- a/src/Miso.hs
+++ b/src/Miso.hs
@@ -785,23 +785,47 @@
 --
 -- == Asynchronous communication
 --
--- 'Component' are able to communicate asynchronously via a message-passing system.
--- The miso runtime exposes a few primitives to allow t'Component' communication.
+-- Every 'Component' has a 'mailbox' — a slot that receives t'Miso.JSON.Value' messages
+-- sent by other components. Messages are dispatched asynchronously via the event queue.
 --
--- * 'broadcast'
--- * 'mail'
--- * 'mailParent'
--- * 'mailChildren'
--- * 'mailAncestors'
+-- === Sending
 --
--- All t'Component' have a 'mailbox' that can receive messages (as t'Miso.JSON.Value') from other t'Component'.
--- This is meant to be used with the 'checkMail' function. The 'mail' function allows a 'Component' to send a specific message (as 'Value') to another t'Component' via its t'ComponentId'.
--- The 'ComponentId' can be found in the 'Effect' monad. Using 'ask' will return a t'ComponentInfo'. The 'Component' receiving
--- the message will find it in its 'mailbox'.
+-- * 'mail' @componentId msg@ — send to a specific 'ComponentId' (obtained via 'ask' inside 'Effect')
+-- * 'mailParent' @msg@ — send to the direct parent
+-- * 'mailChildren' @msg@ — send to all immediate children
+-- * 'mailAncestors' @msg@ — walk up the hierarchy, delivering to every ancestor
+-- * 'broadcast' @msg@ — deliver to every mounted 'Component' except the sender
 --
--- * "Miso.PubSub"
+-- === Receiving with 'checkMail'
 --
--- miso has support for the publisher / subscriber concurrency pattern. See the "Miso.PubSub" module for more information.
+-- Wire up the 'mailbox' field on 'Component' using 'checkMail', which handles
+-- JSON parsing and routes to success\/error actions:
+--
+-- @
+-- data Action
+--   = ReceivedMsg MyMsg
+--   | MailError   MisoString
+--
+-- myComp :: 'Component' parent props model Action
+-- myComp = ('vcomp' m u v)
+--   { 'mailbox' = 'checkMail' ReceivedMsg MailError }
+-- @
+--
+-- === Looking up a 'ComponentId'
+--
+-- Inside 'Effect', use 'ask' to obtain a t'ComponentInfo':
+--
+-- @
+-- update = \\case
+--   SendMsg targetId -> do
+--     'io_' ('mail' targetId ("hello" :: 'MisoString'))
+--   GetMyId -> do
+--     info <- 'ask'
+--     let myId = '_componentInfoId' info
+--     ...
+-- @
+--
+-- * "Miso.PubSub" — publish\/subscribe pattern for fan-out messaging across unrelated components.
 --
 -- == Synchronous communication
 --
@@ -1048,34 +1072,68 @@
 --
 -- = JavaScript EDSL
 --
--- Miso provides a Javascript DSL (inspired by [jsaddle](https://hackage.haskell.org/package/jsaddle)) via "Miso.DSL".
--- See the 'Miso.DSL.ToJSVal' / 'Miso.DSL.FromJSVal' typeclasses when marshaling to and from Haskell to JavaScript. See also the 'Miso.DSL.jsg'
--- function for accessing JavaScript objects that exist in the global scope.
+-- "Miso.DSL" provides a JavaScript DSL inspired by [jsaddle](https://hackage.haskell.org/package/jsaddle)
+-- for interacting with the browser from Haskell.
+--
+-- == Key operators
+--
+-- * '(Miso.DSL.!)' — property access: @obj '!' "key"@ reads @obj.key@
+-- * '(Miso.DSL.#)' — method call: @obj '#' "method" args@ calls @obj.method(args)@
+-- * 'Miso.DSL.jsg' — access a global JS variable by name
+-- * 'Miso.DSL.jsgf' — call a global JS function by name with arguments
 --
 -- @
--- document :: 'JSVal' <- 'jsg' "document" :: IO 'JSVal'
--- len :: 'Int' <- 'fromJSValUnchecked' =<< (document ! "body" ! "children" ! "length")
+-- -- Read document.body.children.length
+-- document <- 'Miso.DSL.jsg' "document"
+-- len :: 'Int' <- 'Miso.DSL.fromJSValUnchecked' =<< (document 'Miso.DSL.!' "body" 'Miso.DSL.!' "children" 'Miso.DSL.!' "length")
+--
+-- -- Call console.log("hello")
+-- console <- 'Miso.DSL.jsg' "console"
+-- console 'Miso.DSL.#' "log" $ ["hello" :: 'MisoString']
 -- @
+--
+-- == Marshalling
+--
+-- 'Miso.DSL.ToJSVal' converts Haskell values to 'Miso.DSL.JSVal' for passing into JavaScript.
+-- 'Miso.DSL.FromJSVal' converts 'Miso.DSL.JSVal' back to Haskell.
+-- 'Miso.DSL.fromJSValUnchecked' throws on failure; use 'Miso.DSL.fromJSVal' for a safe @Maybe@ variant.
 --
 -- = QuasiQuotation (@inline-js@)
 --
--- Along with "Miso.DSL", a JavaScript QuasiQuoter is now included (See "Miso.FFI.QQ"). This makes it easy to
--- integrate miso with any third-party JavaScript library. The bindings in scope can be used inside the QuasiQuoter, which
--- will utilize their 'Miso.DSL.ToJSVal' instances. When returning values from the QuasiQuoter, the 'Miso.DSL.FromJSVal' instance will
--- be used Haskell.
+-- "Miso.FFI.QQ" provides the 'Miso.FFI.QQ.js' QuasiQuoter for embedding inline JavaScript
+-- directly in Haskell source. Any Haskell binding in scope can be interpolated into
+-- the JavaScript body with @${varName}@ syntax — miso uses the binding's 'Miso.DSL.ToJSVal'
+-- instance to marshal it across the boundary at runtime.
 --
 -- @
---
 -- {-# LANGUAGE QuasiQuotes #-}
 --
--- import Miso.FFI.QQ ('js')
+-- import Miso.FFI.QQ ('Miso.FFI.QQ.js')
 --
+-- -- Fire-and-forget: pass a value to a JS library
 -- update :: Action -> 'Effect' parent props model Action
 -- update = \\case
---   Log msg -> io_ [js| console.log(${msg}) |]
+--   Log msg -> 'io_' ['Miso.FFI.QQ.js'| console.log(${msg}) |]
 --
 -- data Action = Log MisoString
 -- @
+--
+-- == Returning values from JavaScript
+--
+-- The return type is inferred from the call site via 'Miso.DSL.FromJSVal'.
+-- Use an explicit type annotation or a @do@-binding to drive inference:
+--
+-- @
+-- fac :: Int -> IO Int
+-- fac n = ['Miso.FFI.QQ.js'|
+--   let x = 1;
+--   for (let i = 1; i <= ${n}; i++) { x *= i; }
+--   return x;
+-- |]
+-- @
+--
+-- Haskell variables referenced inside the quoter must be in scope at the splice
+-- site; the compiler will report an error if a @${name}@ has no corresponding binding.
 --
 -- = Routing
 --
@@ -1418,10 +1476,34 @@
 --
 -- == Dynamic prerendering
 --
--- More advanced usage of prerendering entails sharing the @model@ between the server and client. In such scenarios the 'hydateModel' function should be specified inside the t'Component'.
--- The SSR flag (`-fssr`) must be specified when using this feature.
+-- Dynamic prerendering shares @model@ state between the server and client so the
+-- client can hydrate from a meaningful initial state rather than a blank model.
+-- The @-fssr@ Cabal flag must be enabled when compiling the server.
 --
--- 'hydrateModel' is used to load initial data into a Component's 'model' that is necessary for hydration.
+-- The 'hydrateModel' field on 'Component' accepts an optional @IO model@ action
+-- that is run once during hydration to load the initial model (e.g. by reading
+-- JSON embedded in the page). It is ignored on subsequent remounts.
+--
+-- @
+-- -- Server: embed the model as JSON in the HTML response
+-- serverView :: model -> 'View' model action
+-- serverView m =
+--   'div_' []
+--     [ 'script_' [ 'id_' "initial-model" ] [ 'textRaw' ('encode' m) ]
+--     , appView m
+--     ]
+--
+-- -- Client: read it back during hydration
+-- myComp :: 'App' model Action
+-- myComp = ('vcomp' defaultModel updateFn viewFn)
+--   { 'hydrateModel' = Just $ do
+--       json <- 'Miso.FFI.getElementById' "initial-model" >>= 'Miso.FFI.getBody'
+--       pure $ 'fromMisoString' json
+--   }
+-- @
+--
+-- When 'hydrateModel' is @Nothing@, hydration uses the static 'model' field — this
+-- is equivalent to static prerendering.
 --
 -----------------------------------------------------------------------------
 module Miso


### PR DESCRIPTION
Add dedicated VNode section and expand thin sections with API descriptions, examples, and cross-references:

- VNode: element nodes, node/vnode smart constructors, namespace variants
- MisoString: ms/toMisoString, FromMisoString, misoString QQ
- JSON: Value ADT, encode/decode, ToJSON/FromJSON generics, object building/parsing operators, pretty-printing, miso-aeson note
- Attributes/Properties: Attribute constructors, prop/boolProp/textProp, DOM properties vs HTML attributes distinction, key_
- Canvas: Canvas monad, canvas/canvas_ pattern, drawing primitives, fillStyle/strokeStyle cross-reference to CSS.Color
- State management: view/set/over, +=/-=/*=, this, makeLenses/HasLens
- HTML: ToHtml/toHtml, SSR ByteString rendering, Servant handler wiring
- Routing: routerSub/uriSub, pushURI/pushRoute, runRouter/parseURI
- Styles: structured DSL, styleInline_, external stylesheets; Canvas name collision cross-reference
- Internals: event queue, scheduler, Waiter, event delegation, VDOM diff
- Component communication: intro listing props/mailbox/PubSub mechanisms