### PR TITLE
Add `mailDescendants`.

### DIFF
--- a/src/Miso.hs
+++ b/src/Miso.hs
@@ -628,6 +628,7 @@
 -- * 'mailParent'
 -- * 'mailChildren'
 -- * 'mailAncestors'
+-- * 'mailDescendants'
 --
 -- All t'Component' have a 'mailbox' that can receive messages (as t'Miso.JSON.Value') from other t'Component'.
 -- This is meant to be used with the 'checkMail' function. The 'mail' function allows a 'Component' to send a specific message (as 'Value') to another t'Component' via its t'ComponentId'.
@@ -878,6 +879,7 @@ module Miso
   , parent
   , mailParent
   , mailChildren
+  , mailDescendants
   , mailAncestors
   , broadcast
     -- ** Subscriptions

--- a/src/Miso/Runtime.hs
+++ b/src/Miso/Runtime.hs
@@ -52,6 +52,7 @@ module Miso.Runtime
   , mailParent
   , mailChildren
   , mailAncestors
+  , mailDescendants
   -- ** WebSocket
   , websocketConnect
   , websocketConnectJSON
@@ -1407,6 +1408,32 @@ mailChildren msg = do
   io_ $ do
     ComponentState {..} <- (IM.! _componentInfoId) <$> readIORef components
     forM_ (IS.toList _componentChildren) (flip mail msg)
+-----------------------------------------------------------------------------
+-- | Send any @ToJSON message => message@ to all descendants t'Miso.Types.Component' mailbox
+--
+-- Unlike 'mailChildren', this is relevant for all descendants 'Component'.
+--
+-- @
+-- mailDescendants ("test message" :: MisoString) :: Effect parent props model action
+-- @
+--
+-- @since 1.12.0.0
+mailDescendants
+  :: ToJSON message
+  => message
+  -- ^ Message to send
+  -> Effect parent props model action
+mailDescendants msg = do
+  ComponentInfo {..} <- ask
+  io_ $ do
+    cs <- (IM.! _componentInfoId) <$> readIORef components
+    forM_ (IS.toList (_componentChildren cs)) $ \child -> do
+      visit =<< (IM.! child) <$> readIORef components
+  where
+    visit ComponentState {..} = do
+      mail _componentId msg
+      forM_ (IS.toList _componentChildren) $ \child -> do
+        visit =<< (IM.! child) <$> readIORef components
 ----------------------------------------------------------------------------
 -- | Helper function for processing @Mail@ from 'mail'.
 --


### PR DESCRIPTION
Like `mailAncestors`, which messages to all `Component` ancestor, `mailDescendants` messages to all `Component` descendant.

`mailChildren`, unlike `mailDescendants`, only messages to immediate descendants.

- [x] Add `'mailDescendants'` to `src/Miso.hs` docs
- [x] Export `'mailDescendants'`
- [x] Export `'mailDescendants'` top-level from `src/Miso.hs`
- [x] Provide implementation of `mailDescendants` in `src/Miso/Runtime.hs`