### PR TITLE
Store `schedulerThread` in `StablePtr`.

### DIFF
--- a/src/Miso/Reload.hs
+++ b/src/Miso/Reload.hs
@@ -105,7 +105,7 @@ reload events vcomp = do
   when (exists == 1) $ do
     (_, oldSchedulerRef) <- deRefStablePtr =<< x_get
     killThread =<< readIORef oldSchedulerRef
-  x_clear
+    x_clear
   clearPage
   void (initComponent events Draw False vcomp)
   x_store =<< newStablePtr (components, schedulerThread)

--- a/src/Miso/Reload.hs
+++ b/src/Miso/Reload.hs
@@ -48,17 +48,15 @@ module Miso.Reload
   , live
   ) where
 -----------------------------------------------------------------------------
+import           Control.Concurrent
 import           Control.Monad
 -----------------------------------------------------------------------------
-#ifdef WASM
-import           Miso.DSL.TH.File (evalFile)
-#endif
 import           Miso.DSL ((!), jsg, setField)
 import qualified Miso.FFI.Internal as FFI
 import           Miso.Types (Component(..), Events, App)
 import           Miso.String (MisoString)
 import           Miso.Runtime (componentModel, initComponent, topLevelComponentId, Hydrate(..))
-import           Miso.Runtime.Internal (components)
+import           Miso.Runtime.Internal (components, schedulerThread)
 -----------------------------------------------------------------------------
 import           Miso.Lens
 -----------------------------------------------------------------------------
@@ -102,7 +100,15 @@ reload
   => Events
   -> App model action
   -> IO ()
-reload events vcomp = clearPage >> initComponent events Draw False vcomp
+reload events vcomp = do
+  exists <- x_exists
+  when (exists == 1) $ do
+    (_, oldSchedulerRef) <- deRefStablePtr =<< x_get
+    killThread =<< readIORef oldSchedulerRef
+  x_clear
+  clearPage
+  void (initComponent events Draw False vcomp)
+  x_store =<< newStablePtr (components, schedulerThread)
 -----------------------------------------------------------------------------
 -- | Live reloading. Persists all t'Component' `model` between successive GHCi reloads.
 --
@@ -131,12 +137,14 @@ live events vcomp = do
   exists <- x_exists
   if exists == 1
     then do
-      -- clearPage (perform this with the context)
-      clearPage
+      -- clearBody (only clear the body)
+      clearBody
 
       -- Deref old state, update new state, set pointer in C heap.
-      _oldState <- readIORef =<< deRefStablePtr =<< x_get
+      (oldComponentsRef, oldSchedulerRef) <- deRefStablePtr =<< x_get
+      killThread =<< readIORef oldSchedulerRef
 
+      _oldState <- readIORef oldComponentsRef
       let oldModel = (_oldState IM.! topLevelComponentId) ^. componentModel
           initialVComp = vcomp { model = oldModel }
 
@@ -150,18 +158,20 @@ live events vcomp = do
       -- Don't forget to flush (native mobile needs this too)
       FFI.flush
 
-      -- Clear and set static ptr to use new state
+      -- Clear and set static ptr to use new state (new CAF state)
       x_clear
-      x_store =<< newStablePtr components
+      x_store =<< newStablePtr (components, schedulerThread)
     else do
       -- This means it is initial load, just store the pointer.
-      x_store =<< newStablePtr components
       void (initComponent events Draw False vcomp)
+      x_store =<< newStablePtr (components, schedulerThread)
 -----------------------------------------------------------------------------
-clearPage :: IO ()
-clearPage = do
+clearPage, clearBody, clearHead :: IO ()
+clearPage = clearBody >> clearHead
+clearBody = do
   body_ <- jsg "document" ! ("body" :: MisoString)
   setField body_ "innerHTML" ("" :: MisoString)
+clearHead = do
   head_ <- jsg "document" ! ("head" :: MisoString)
   setField head_ "innerHTML" ("" :: MisoString)
 -----------------------------------------------------------------------------

--- a/src/Miso/Runtime.hs
+++ b/src/Miso/Runtime.hs
@@ -81,6 +81,7 @@ module Miso.Runtime
   , arrayBuffer
   -- ** Internal Component state
   , components
+  , schedulerThread
   , componentIds
   , rootComponentId
   , componentId
@@ -157,11 +158,13 @@ initialize
   -- ^ Is the root node being rendered?
   -> props
   -- ^ Initial props for this component
+  -> Maybe Key
+  -- ^ Optional key for stable hot-reload model recovery
   -> Component parent props model action
   -> IO DOMRef
   -- ^ Callback function is used for obtaining the t'Miso.Types.Component' 'DOMRef'.
   -> IO (ComponentState parent props model action)
-initialize events _componentParentId hydrate isRoot initialProps comp@Component {..} getComponentMountPoint = do
+initialize events _componentParentId hydrate isRoot initialProps maybeKey comp@Component {..} getComponentMountPoint = do
   _componentId <- freshComponentId
   let
     _componentProps = initialProps
@@ -173,12 +176,16 @@ initialize events _componentParentId hydrate isRoot initialProps comp@Component 
     case (hydrate, hydrateModel) of
       (Hydrate, Just m) -> m
       (Draw, _) -> do
-        IM.lookup _componentId <$> readIORef components >>= \case
+        vcomps <- readIORef components
+        case IM.lookup _componentId vcomps of
+          Just cs -> pure (cs ^. componentModel)
           Nothing ->
-            pure model
-          Just cs ->
-            -- hot reload scenario, let it flow
-            pure (cs ^. componentModel)
+            case maybeKey of
+              Nothing -> pure model
+              Just k  -> pure $ fromMaybe model $ listToMaybe
+                [ cs ^. componentModel
+                | cs <- IM.elems vcomps
+                , _componentKey cs == Just k ]
       _ -> pure model
   _componentScripts <-
     IM.lookup _componentId <$> readIORef components >>= \case
@@ -226,6 +233,7 @@ initialize events _componentParentId hydrate isRoot initialProps comp@Component 
 
   let vcomponent = ComponentState
         { _componentEvents = events
+        , _componentKey = maybeKey
         , _componentMailbox = mailbox
         , _componentBindings = bindings
         , _componentTopics = mempty
@@ -662,6 +670,9 @@ globalQueue = unsafePerformIO (newIORef emptyQueue)
 componentId :: Lens (ComponentState parent props model action) ComponentId
 componentId = lens _componentId $ \record field -> record { _componentId = field }
 -----------------------------------------------------------------------------
+componentKey :: Lens (ComponentState parent props model action) (Maybe Key)
+componentKey = lens _componentKey $ \record field -> record { _componentKey = field }
+-----------------------------------------------------------------------------
 parentId :: Lens (ComponentState parent props model action) ComponentId
 parentId = lens _componentParentId $ \record field -> record { _componentParentId = field }
 -----------------------------------------------------------------------------
@@ -698,6 +709,8 @@ data ComponentState parent props model action
   = ComponentState
   { _componentId :: ComponentId
   -- ^ The ID of the current t'Miso.Types.Component'
+  , _componentKey :: Maybe Key
+  -- ^ Optional key for stable hot-reload model recovery
   , _componentParentId :: ComponentId
   -- ^ The ID of the t'Miso.Types.Component''s parent
   , _componentProps :: props
@@ -998,7 +1011,6 @@ cleanup :: Bool -> DOMRef -> IO ()
 cleanup live domRef = do
   vcomps <- readIORef components
   when (IM.size vcomps > 0) $ do
-    killThread =<< readIORef schedulerThread
     if live
       then do
         -- In hot reload we want to reset subs and connections, and free lifecycle hooks
@@ -1112,7 +1124,7 @@ buildVTree events_ parentId_ vcompId hydrate snk logLevel_ = \case
 
     mountCallback <- do
       syncCallback1' $ \parent_ -> do
-        ComponentState {..} <- initialize events_ vcompId hydrate False newProps app (pure parent_)
+        ComponentState {..} <- initialize events_ vcompId hydrate False newProps maybeKey app (pure parent_)
         modifyComponent vcompId (children %= IS.insert _componentId)
         vtree <- toJSVal =<< readIORef _componentVTree
         FFI.set "parent" vcomp_ (Object vtree)
@@ -1251,8 +1263,8 @@ setAttrs vnode_@(Object jval) attrs snk logLevel events =
 -- | Registers components in the global state
 registerComponent :: MonadIO m => ComponentState parent props model action -> m ()
 registerComponent componentState = liftIO $
-  atomicModifyIORef' components $ \cs ->
-    (IM.insert (_componentId componentState) componentState cs, ())
+  atomicModifyIORef' components $ \vcomps' ->
+    (IM.insert (_componentId componentState) componentState vcomps', ())
 -----------------------------------------------------------------------------
 -- | Renders styles
 --
@@ -2040,7 +2052,7 @@ initComponent events hydrate live vcomp_@Component {..} = do
   withJS $ do
     root <- Diff.mountElement (getMountPoint mountPoint)
     cleanup live root
-    void $ initialize events rootComponentId hydrate True () vcomp_ (pure root)
+    void $ initialize events rootComponentId hydrate True () Nothing vcomp_ (pure root)
     atomicWriteIORef schedulerThread =<< forkIO scheduler
 ----------------------------------------------------------------------------
 -- | Global variable to hold the scheduler thread

--- a/src/Miso/Runtime.hs
+++ b/src/Miso/Runtime.hs
@@ -177,15 +177,13 @@ initialize events _componentParentId hydrate isRoot initialProps maybeKey comp@C
       (Hydrate, Just m) -> m
       (Draw, _) -> do
         vcomps <- readIORef components
-        case IM.lookup _componentId vcomps of
-          Just cs -> pure (cs ^. componentModel)
-          Nothing ->
-            case maybeKey of
-              Nothing -> pure model
-              Just k  -> pure $ fromMaybe model $ listToMaybe
-                [ cs ^. componentModel
-                | cs <- IM.elems vcomps
-                , _componentKey cs == Just k ]
+        case maybeKey of
+          Just k  -> pure $ fromMaybe model $ listToMaybe
+            [ cs ^. componentModel
+            | cs <- IM.elems vcomps
+            , cs ^. componentKey == Just k
+            ]
+          Nothing -> pure model
       _ -> pure model
   _componentScripts <-
     IM.lookup _componentId <$> readIORef components >>= \case

--- a/src/Miso/Runtime.hs
+++ b/src/Miso/Runtime.hs
@@ -1011,6 +1011,7 @@ cleanup :: Bool -> DOMRef -> IO ()
 cleanup live domRef = do
   vcomps <- readIORef components
   when (IM.size vcomps > 0) $ do
+    killThread =<< readIORef schedulerThread
     if live
       then do
         -- In hot reload we want to reset subs and connections, and free lifecycle hooks

--- a/src/Miso/Runtime/Internal.hs
+++ b/src/Miso/Runtime/Internal.hs
@@ -25,7 +25,8 @@ module Miso.Runtime.Internal
   , componentIds
   , rootComponentId
   , ComponentState(..)
+  , schedulerThread
   ) where
 ----------------------------------------------------------------------------
-import Miso.Runtime (components, ComponentState(..), componentIds, rootComponentId)
+import Miso.Runtime (components, ComponentState(..), componentIds, rootComponentId, schedulerThread)
 ----------------------------------------------------------------------------


### PR DESCRIPTION
When using `live` and `reload` functions, the scheduler `ThreadId` needs to persist between `:r` invocations (via `StablePtr`). Otherwise, the CAF gets recreated and the previous scheduler thread (along with its closure) leaks into the heap (due to the `forever` call). This causes accumulated heap growth during a hot reload session. By storing the `ThreadId` in the `StablePtr` this allows us to kill the previous scheduler `ThreadId` cleanly.

Likewise the `ComponentState`, in order to be reified reliably, needs to be fetched by unique `Key` (not `ComponentId`, which is not stable between user changes to application state). Onus falls on the user to `Key` their `Component` uniquely during a hot-reload session (with the exception of the top level `ComponentId` which is always 1).

This means `live` users should always `Key` `Component` uniquely. The only `Component` that is allowed to be left unkeyed during hot-reload (w/ `live`) is the top-level root `Component`, of id `1`.

- [x] Add `ThreadId` to `StablePtr` in `live` / `reload` (along with `components :: IORef (CompenentState parent props model action)`)
- [x] Don't `clearPage` during `live`, just `clearBody`. Scripts / styles only need to be loaded once.
- [x] Drop `killThread =<< readIORef schedulerThread`
- [x] Add `_componentKey` to `ComponentState`.