### PR TITLE
docs: Fix deadlinks in CSS DSL

### DIFF
--- a/src/Miso/CSS.hs
+++ b/src/Miso/CSS.hs
@@ -86,7 +86,6 @@ module Miso.CSS
   , clipPath
   , color
   , columnGap
-  , cssVariable
   , cursor
   , direction
   , display
@@ -836,13 +835,6 @@ color x = "color" =: renderColor x
 --
 columnGap :: MisoString -> Style
 columnGap x = "column-gap" =: x
------------------------------------------------------------------------------
--- | Set a [CSS custom property](https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties).
---
--- > cssVariable "brand-color" (renderColor red)
---
-cssVariable :: MisoString -> MisoString -> Style
-cssVariable name val = ("--" <> name) =: val
 -----------------------------------------------------------------------------
 -- | https://developer.mozilla.org/en-US/docs/Web/CSS/direction
 --

--- a/src/Miso/CSS.hs
+++ b/src/Miso/CSS.hs
@@ -551,7 +551,7 @@ animationDirection x = "animation-direction" =: x
 animationDuration :: MisoString -> Style
 animationDuration x = "animation-duration" =: x
 -----------------------------------------------------------------------------
--- | https://animation-mozilla.org/en-US/docs/Web/CSS/align-content/animation-fill-mode
+-- | https://developer.mozilla.org/en-US/docs/Web/CSS/animation-fill-mode
 --
 animationFillMode :: MisoString -> Style
 animationFillMode x = "animation-fill-mode" =: x
@@ -837,10 +837,12 @@ color x = "color" =: renderColor x
 columnGap :: MisoString -> Style
 columnGap x = "column-gap" =: x
 -----------------------------------------------------------------------------
--- | https://developer.mozilla.org/en-US/docs/Web/CSS/css-variable
+-- | Set a [CSS custom property](https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties).
 --
-cssVariable :: MisoString -> Style
-cssVariable x = "css-variable" =: x
+-- > cssVariable "brand-color" (renderColor red)
+--
+cssVariable :: MisoString -> MisoString -> Style
+cssVariable name val = ("--" <> name) =: val
 -----------------------------------------------------------------------------
 -- | https://developer.mozilla.org/en-US/docs/Web/CSS/direction
 --

--- a/src/Miso/CSS/Color.hs
+++ b/src/Miso/CSS/Color.hs
@@ -332,8 +332,8 @@ hsla = HSLA
 -----------------------------------------------------------------------------
 -- | Smart constructor for a 'Hex' 'Color'
 --
--- >>> renderColor (hsla 0 0 0 1.0)
--- "hsl(0,0,0,1.0)"
+-- >>> renderColor (hex "ccc")
+-- "#ccc"
 --
 hex :: MisoString -> Color
 hex = Hex


### PR DESCRIPTION
- Remove `cssVariable`
- Fix `animationFillMode` docstring URL (animation-mozilla.org -> developer.mozilla.org)
- Fix `hex` docstring example (was showing `hsla` instead of `hex`)