### PR TITLE
Add `rAFSubElapsed`

### DIFF
--- a/src/Miso/Subscription/RAF.hs
+++ b/src/Miso/Subscription/RAF.hs
@@ -67,25 +67,18 @@ rAFSubElapsed :: Double -> action -> Sub action
 rAFSubElapsed interval action sink = createSub acquire release sink
   where
     acquire = do
-      cbRef   <- newIORef (error "rAFSubElapsed: uninitialized, impossible")
-      lastRef <- newIORef (0.0 :: Double)
-      elapRef <- newIORef (0.0 :: Double)
-      callback <- syncCallback1 $ \jsval -> do
-        t    <- fromJSValUnchecked jsval
-        prev <- readIORef lastRef
-        writeIORef lastRef t
-        let dt = if prev == 0 then 0 else min interval (t - prev)
-        elap <- readIORef elapRef
-        let newElap = elap + dt
-        if newElap >= interval
-          then do
-            writeIORef elapRef (newElap - interval)
-            sink action
-          else writeIORef elapRef newElap
-        void (requestAnimationFrame =<< readIORef cbRef)
-      writeIORef cbRef callback
-      void (requestAnimationFrame callback)
-      pure callback
-
-    release callback = freeFunction (Function callback)
+      cbRef <- newIORef (error "rAFSubElapsed: uninitialized, impossible")
+      let go lastT elap = do
+            cb <- syncCallback1 $ \jsval -> do
+              t <- fromJSValUnchecked jsval
+              let dt      = if lastT == 0 then 0 else min interval (t - lastT)
+                  newElap = elap + dt
+              if newElap >= interval
+                then sink action *> go t (newElap - interval)
+                else go t newElap
+            writeIORef cbRef cb
+            void (requestAnimationFrame cb)
+      go 0 0
+      pure cbRef
+    release cbRef = freeFunction . Function =<< readIORef cbRef
 ----------------------------------------------------------------------------

--- a/src/Miso/Subscription/RAF.hs
+++ b/src/Miso/Subscription/RAF.hs
@@ -20,7 +20,10 @@
 -- @
 --
 ----------------------------------------------------------------------------
-module Miso.Subscription.RAF where
+module Miso.Subscription.RAF
+  ( rAFSub
+  , rAFSubElapsed
+  ) where
 ----------------------------------------------------------------------------
 import           Control.Monad (void)
 import           Data.IORef
@@ -29,7 +32,7 @@ import           Miso.DSL
 import           Miso.Effect (Sub)
 import           Miso.Subscription.Util (createSub)
 ----------------------------------------------------------------------------
--- | A 'Sub' for 60FPS animations when using 'requestForAnimationFrame'.
+-- | A 'Sub' for 60FPS animations when using 'requestAnimationFrame'.
 --
 -- The 'Double' returned is a [DOMHighResTimeStamp](https://developer.mozilla.org/en-US/docs/Web/API/DOMHighResTimeStamp) expressed in milliseconds.
 --
@@ -44,6 +47,43 @@ rAFSub toAction sink = createSub acquire release sink
           void (requestAnimationFrame =<< readIORef ref)
 
       writeIORef ref callback
+      void (requestAnimationFrame callback)
+      pure callback
+
+    release callback = freeFunction (Function callback)
+----------------------------------------------------------------------------
+-- | Like 'rAFSub' but fires @action@ at most once per @interval@ milliseconds.
+--
+-- Elapsed time is accumulated in 'IORef's inside the subscription so the
+-- model is not touched between ticks — Miso only re-renders when a tick
+-- actually fires, rather than on every animation frame.
+--
+-- @
+-- app = defaultApp model update view
+--   { subs = [ rAFSubElapsed 175 Tick ] }
+-- @
+--
+rAFSubElapsed :: Double -> action -> Sub action
+rAFSubElapsed interval action sink = createSub acquire release sink
+  where
+    acquire = do
+      cbRef   <- newIORef (error "rAFSubElapsed: uninitialized, impossible")
+      lastRef <- newIORef (0.0 :: Double)
+      elapRef <- newIORef (0.0 :: Double)
+      callback <- syncCallback1 $ \jsval -> do
+        t    <- fromJSValUnchecked jsval
+        prev <- readIORef lastRef
+        writeIORef lastRef t
+        let dt = if prev == 0 then 0 else min interval (t - prev)
+        elap <- readIORef elapRef
+        let newElap = elap + dt
+        if newElap >= interval
+          then do
+            writeIORef elapRef (newElap - interval)
+            sink action
+          else writeIORef elapRef newElap
+        void (requestAnimationFrame =<< readIORef cbRef)
+      writeIORef cbRef callback
       void (requestAnimationFrame callback)
       pure callback
 


### PR DESCRIPTION
RAF-synced `Sub` that fires an action on a fixed interval.

Accumulates elapsed time in `IORef`s so the model is untouched between ticks; `Miso` only re-renders when the interval elapses rather than every frame.