### PR TITLE
Remove `MVar` rendezvous from `_componentDraw`

### DIFF
--- a/src/Miso/Runtime.hs
+++ b/src/Miso/Runtime.hs
@@ -191,6 +191,8 @@ initialize events _componentParentId hydrate isRoot initialProps maybeKey comp@C
 
   let _componentMailbox = S.empty
 
+  cbRef <- newIORef (error "componentDraw: impossible")
+
   let _componentDraw = \newModel -> do
         currentProps <- (^. componentProps) . (IM.! _componentId) <$> readIORef components
         newVTree <-
@@ -198,8 +200,7 @@ initialize events _componentParentId hydrate isRoot initialProps maybeKey comp@C
             _componentSink logLevel (view currentProps newModel)
         oldVTree <- readIORef _componentVTree
         atomicWriteIORef _componentVTree newVTree
-        cbRef <- newIORef (error "componentDraw: impossible")
-        cb <- asyncCallback1 $ \_ -> do
+        cb <- syncCallback1 $ \_ -> do
           Diff.diff (Just oldVTree) (Just newVTree) _componentDOMRef
           FFI.updateRef oldVTree newVTree
           FFI.flush

--- a/src/Miso/Runtime.hs
+++ b/src/Miso/Runtime.hs
@@ -200,7 +200,7 @@ initialize events _componentParentId hydrate isRoot initialProps maybeKey comp@C
             _componentSink logLevel (view currentProps newModel)
         oldVTree <- readIORef _componentVTree
         atomicWriteIORef _componentVTree newVTree
-        cb <- syncCallback1 $ \_ -> do
+        cb <- asyncCallback1 $ \_ -> do
           Diff.diff (Just oldVTree) (Just newVTree) _componentDOMRef
           FFI.updateRef oldVTree newVTree
           FFI.flush

--- a/src/Miso/Runtime.hs
+++ b/src/Miso/Runtime.hs
@@ -189,12 +189,7 @@ initialize events _componentParentId hydrate isRoot initialProps maybeKey comp@C
   _componentVTree <- newIORef (VTree (Object jsNull))
   _componentSubThreads <- newIORef M.empty
 
-  frame <- newEmptyMVar :: IO (MVar Double)
   let _componentMailbox = S.empty
-
-  rAFCallback <-
-    asyncCallback1 $ \jsval -> do
-      putMVar frame =<< fromJSValUnchecked jsval
 
   let _componentDraw = \newModel -> do
         currentProps <- (^. componentProps) . (IM.! _componentId) <$> readIORef components
@@ -202,12 +197,15 @@ initialize events _componentParentId hydrate isRoot initialProps maybeKey comp@C
           buildVTree events _componentParentId _componentId Draw
             _componentSink logLevel (view currentProps newModel)
         oldVTree <- readIORef _componentVTree
-        _frame <- requestAnimationFrame rAFCallback
-        _timestamp :: Double <- takeMVar frame
-        Diff.diff (Just oldVTree) (Just newVTree) _componentDOMRef
-        FFI.updateRef oldVTree newVTree
         atomicWriteIORef _componentVTree newVTree
-        FFI.flush
+        cbRef <- newIORef (error "componentDraw: impossible")
+        cb <- asyncCallback1 $ \_ -> do
+          Diff.diff (Just oldVTree) (Just newVTree) _componentDOMRef
+          FFI.updateRef oldVTree newVTree
+          FFI.flush
+          freeFunction . Function =<< readIORef cbRef
+        atomicWriteIORef cbRef cb
+        void (requestAnimationFrame cb)
 
   let _componentApplyActions = \(actions :: [action]) model_ comps currentProps -> do
         let info = ComponentInfo _componentId _componentParentId _componentDOMRef currentProps


### PR DESCRIPTION
The frame `MVar` + `asyncCallback1` pair was used to block the scheduler thread until `requestAnimationFrame` fired before running `Diff.diff`. The action `queue` already serializes draws so concurrent diffs are impossible. 

- [x] Replace the `MVar` rendezvous with a per-draw `asyncCallback1` that captures `(oldVTree, newVTree)` in its closure, runs the `diff` at the rAF boundary, and frees itself after firing. `_componentVTree` is updated synchronously so rapid back-to-back draws each see the correct prior state.