### PR TITLE
Improve CSS DSL: new properties, type fixes, better APIs

### DIFF
--- a/src/Miso/CSS.hs
+++ b/src/Miso/CSS.hs
@@ -9,7 +9,28 @@
 -- Stability   :  experimental
 -- Portability :  non-portable
 --
--- Module for constructing CSS styles and stylesheets in miso
+-- CSS DSL for constructing inline styles and t'StyleSheet' values in miso.
+--
+-- __Inline styles__ attach to a single DOM node via 'style_':
+--
+-- @
+-- div_ [ style_ [ backgroundColor blue, padding (px 8) ] ] []
+-- @
+--
+-- __Stylesheets__ are built with 'sheet_', 'selector_', 'keyframes_', and 'media_',
+-- then injected into the document via 'Miso.style_':
+--
+-- @
+-- sheet_
+--   [ selector_ ".card" [ backgroundColor white, borderRadius (px 4) ]
+--   , keyframes_ "fade-in"
+--       [ from_ [ opacity 0 ]
+--       , to_   [ opacity 1 ]
+--       ]
+--   , media_ (screen_ \`and_\` minWidth_ (px 768))
+--       [ rule_ ".card" [ padding (px 16) ] ]
+--   ]
+-- @
 --
 -----------------------------------------------------------------------------
 module Miso.CSS
@@ -441,30 +462,22 @@ pct x = MS.ms x <> "%"
 ppx :: Double -> MisoString
 ppx x = MS.ms x <> "ppx"
 -----------------------------------------------------------------------------
--- | Used when constructing a t'StyleSheet'
+-- | A CSS selector rule for use inside 'sheet_'.
 --
--- @
--- sheet_
---   [ selector_ ".name"
---     [ backgroundColor red
---     , alignContent "top"
---     ]
---   ]
--- @
+-- > selector_ ".card" [ backgroundColor white, borderRadius (px 4) ]
 --
 selector_ :: MisoString -> [Style] -> Styles
 selector_ k v = Styles (k,v)
 -----------------------------------------------------------------------------
--- | Smart constructor for t'StyleSheet'
+-- | Build a t'StyleSheet' from a list of t'Styles' rules.
+-- Pass the result to 'Miso.style_' to inject it into the document.
 sheet_ :: [Styles] -> StyleSheet
 sheet_ = StyleSheet
 -----------------------------------------------------------------------------
--- | @style_@ is an attribute that will set the @style@
--- attribute of the associated DOM node to @attrs@.
+-- | @style_@ is an attribute that sets the @style@ attribute of a DOM node.
+-- Properties absent from the list are removed.
 --
--- @style@ attributes not contained in @attrs@ will be deleted.
---
--- > div_ [ style_ [ backgroundColor "red" ] [ ]
+-- > div_ [ style_ [ backgroundColor red, padding (px 8) ] ] []
 --
 -- <https://developer.mozilla.org/en-US/docs/Web/CSS>
 --

--- a/src/Miso/CSS.hs
+++ b/src/Miso/CSS.hs
@@ -528,7 +528,7 @@ renderStyleSheet styleSheet = MS.intercalate "\n"
 -- @
 -- keyframes_ "slide-in"
 --   [ from_ [ transforms [ translateX (pct 0) ] ]
---   , at (pct 50) [ opacity "0.5" ]
+--   , at (pct 50) [ opacity 0.5 ]
 --   , to_   [ transforms [ translateX (pct 100) ], backgroundColor red ]
 --   ]
 -- @
@@ -546,7 +546,7 @@ to_ styles = KeyframeStop ("to", styles)
 -----------------------------------------------------------------------------
 -- | A keyframe stop at a given position, typically built with 'pct'.
 --
--- > at (pct 50) [ opacity "0.5" ]
+-- > at (pct 50) [ opacity 0.5 ]
 --
 at :: MisoString -> [Style] -> KeyframeStop
 at stop styles = KeyframeStop (stop, styles)
@@ -665,7 +665,7 @@ animationDirection x = "animation-direction" =: x
 animationDuration :: MisoString -> Style
 animationDuration x = "animation-duration" =: x
 -----------------------------------------------------------------------------
--- | https://animation-mozilla.org/en-US/docs/Web/CSS/align-content/animation-fill-mode
+-- | https://developer.mozilla.org/en-US/docs/Web/CSS/animation-fill-mode
 --
 animationFillMode :: MisoString -> Style
 animationFillMode x = "animation-fill-mode" =: x
@@ -981,7 +981,9 @@ direction x = "direction" =: x
 display :: MisoString -> Style
 display x = "display" =: x
 -----------------------------------------------------------------------------
--- | https://developer.mozilla.org/en-US/docs/Web/CSS/fill
+-- | SVG [fill](https://developer.mozilla.org/en-US/docs/Web/CSS/fill) color.
+--
+-- > fill red
 --
 fill :: Color -> Style
 fill x = "fill" =: renderColor x
@@ -1491,7 +1493,9 @@ rowGap x = "row-gap" =: x
 scrollBehavior :: MisoString -> Style
 scrollBehavior x = "scroll-behavior" =: x
 -----------------------------------------------------------------------------
--- | https://developer.mozilla.org/en-US/docs/Web/CSS/stroke
+-- | SVG [stroke](https://developer.mozilla.org/en-US/docs/Web/CSS/stroke) color.
+--
+-- > stroke black
 --
 stroke :: Color -> Style
 stroke x = "stroke" =: renderColor x

--- a/src/Miso/CSS.hs
+++ b/src/Miso/CSS.hs
@@ -202,9 +202,12 @@ module Miso.CSS
   , rotate3d
   , scale
   , scaleXY
+  , scale3d
   , scaleX
   , scaleY
   , scaleZ
+  , perspectiveFn
+  , matrix3d
   , skew
   , skewX
   , skewY
@@ -1448,6 +1451,11 @@ scale n = TransformFn $ "scale(" <> MS.ms n <> ")"
 scaleXY :: Double -> Double -> TransformFn
 scaleXY x y = TransformFn $ "scale(" <> MS.ms x <> "," <> MS.ms y <> ")"
 -----------------------------------------------------------------------------
+-- | https://developer.mozilla.org/en-US/docs/Web/CSS/transform-function/scale3d
+--
+scale3d :: Double -> Double -> Double -> TransformFn
+scale3d x y z = TransformFn $ "scale3d(" <> MS.intercalate "," [MS.ms x, MS.ms y, MS.ms z] <> ")"
+-----------------------------------------------------------------------------
 -- | https://developer.mozilla.org/en-US/docs/Web/CSS/transform-function/scaleX
 --
 scaleX :: Double -> TransformFn
@@ -1462,6 +1470,36 @@ scaleY n = TransformFn $ "scaleY(" <> MS.ms n <> ")"
 --
 scaleZ :: Double -> TransformFn
 scaleZ n = TransformFn $ "scaleZ(" <> MS.ms n <> ")"
+-----------------------------------------------------------------------------
+-- | https://developer.mozilla.org/en-US/docs/Web/CSS/transform-function/perspective
+-- The @perspective()@ transform function, distinct from the @perspective@ CSS property.
+--
+-- >>> renderTransformFn (perspectiveFn (px 500))
+-- "perspective(500px)"
+--
+perspectiveFn :: MisoString -> TransformFn
+perspectiveFn d = TransformFn $ "perspective(" <> d <> ")"
+-----------------------------------------------------------------------------
+-- | https://developer.mozilla.org/en-US/docs/Web/CSS/transform-function/matrix3d
+-- 4x4 homogeneous matrix in column-major order; each tuple is one column.
+--
+-- > matrix3d (1,0,0,0) (0,1,0,0) (0,0,1,0) (10,20,0,1)
+--
+matrix3d
+  :: (Double, Double, Double, Double)
+  -> (Double, Double, Double, Double)
+  -> (Double, Double, Double, Double)
+  -> (Double, Double, Double, Double)
+  -> TransformFn
+matrix3d (a1,b1,c1,d1) (a2,b2,c2,d2) (a3,b3,c3,d3) (a4,b4,c4,d4) =
+  TransformFn $ "matrix3d(" <> values <> ")"
+  where
+    values = MS.intercalate ","
+      [ MS.ms a1, MS.ms b1, MS.ms c1, MS.ms d1
+      , MS.ms a2, MS.ms b2, MS.ms c2, MS.ms d2
+      , MS.ms a3, MS.ms b3, MS.ms c3, MS.ms d3
+      , MS.ms a4, MS.ms b4, MS.ms c4, MS.ms d4
+      ]
 -----------------------------------------------------------------------------
 -- | https://developer.mozilla.org/en-US/docs/Web/CSS/transform-function/skew
 --

--- a/src/Miso/CSS.hs
+++ b/src/Miso/CSS.hs
@@ -187,7 +187,27 @@ module Miso.CSS
   , textStrokeWidth
   , top
   , transform
+  , transforms
   , transformOrigin
+    -- *** Transform functions
+  , translate
+  , translateX
+  , translateY
+  , translateZ
+  , translate3d
+  , rotate
+  , rotateX
+  , rotateY
+  , rotateZ
+  , rotate3d
+  , scale
+  , scaleXY
+  , scaleX
+  , scaleY
+  , scaleZ
+  , skew
+  , skewX
+  , skewY
   , transitionDelay
   , transitionDuration
   , transition
@@ -1342,10 +1362,121 @@ top x = "top" =: x
 transform :: MisoString -> Style
 transform x = "transform" =: x
 -----------------------------------------------------------------------------
+-- | Apply a list of t'TransformFn' values as a @transform@ style.
+--
+-- @
+-- transforms [ translate (px 10) (pct 50), rotate (deg 45), scaleX 1.5 ]
+-- @
+--
+transforms :: [TransformFn] -> Style
+transforms fns = "transform" =: MS.intercalate " " (map renderTransformFn fns)
+-----------------------------------------------------------------------------
 -- | https://developer.mozilla.org/en-US/docs/Web/CSS/transform-origin
 --
 transformOrigin :: MisoString -> Style
 transformOrigin x = "transform-origin" =: x
+-----------------------------------------------------------------------------
+-- | https://developer.mozilla.org/en-US/docs/Web/CSS/transform-function/translate
+--
+-- >>> renderTransformFn (translate (px 10) (pct 50))
+-- "translate(10px,50.0%)"
+--
+translate :: MisoString -> MisoString -> TransformFn
+translate x y = TransformFn $ "translate(" <> x <> "," <> y <> ")"
+-----------------------------------------------------------------------------
+-- | https://developer.mozilla.org/en-US/docs/Web/CSS/transform-function/translateX
+--
+translateX :: MisoString -> TransformFn
+translateX x = TransformFn $ "translateX(" <> x <> ")"
+-----------------------------------------------------------------------------
+-- | https://developer.mozilla.org/en-US/docs/Web/CSS/transform-function/translateY
+--
+translateY :: MisoString -> TransformFn
+translateY y = TransformFn $ "translateY(" <> y <> ")"
+-----------------------------------------------------------------------------
+-- | https://developer.mozilla.org/en-US/docs/Web/CSS/transform-function/translateZ
+--
+translateZ :: MisoString -> TransformFn
+translateZ z = TransformFn $ "translateZ(" <> z <> ")"
+-----------------------------------------------------------------------------
+-- | https://developer.mozilla.org/en-US/docs/Web/CSS/transform-function/translate3d
+--
+translate3d :: MisoString -> MisoString -> MisoString -> TransformFn
+translate3d x y z = TransformFn $ "translate3d(" <> MS.intercalate "," [x, y, z] <> ")"
+-----------------------------------------------------------------------------
+-- | https://developer.mozilla.org/en-US/docs/Web/CSS/transform-function/rotate
+--
+-- >>> renderTransformFn (rotate (deg 45))
+-- "rotate(45.0deg)"
+--
+rotate :: MisoString -> TransformFn
+rotate a = TransformFn $ "rotate(" <> a <> ")"
+-----------------------------------------------------------------------------
+-- | https://developer.mozilla.org/en-US/docs/Web/CSS/transform-function/rotateX
+--
+rotateX :: MisoString -> TransformFn
+rotateX a = TransformFn $ "rotateX(" <> a <> ")"
+-----------------------------------------------------------------------------
+-- | https://developer.mozilla.org/en-US/docs/Web/CSS/transform-function/rotateY
+--
+rotateY :: MisoString -> TransformFn
+rotateY a = TransformFn $ "rotateY(" <> a <> ")"
+-----------------------------------------------------------------------------
+-- | https://developer.mozilla.org/en-US/docs/Web/CSS/transform-function/rotateZ
+--
+rotateZ :: MisoString -> TransformFn
+rotateZ a = TransformFn $ "rotateZ(" <> a <> ")"
+-----------------------------------------------------------------------------
+-- | https://developer.mozilla.org/en-US/docs/Web/CSS/transform-function/rotate3d
+-- x, y, z are unitless direction vector components; angle uses a unit constructor like 'deg'.
+--
+rotate3d :: Double -> Double -> Double -> MisoString -> TransformFn
+rotate3d x y z a = TransformFn $ "rotate3d(" <> MS.intercalate "," [MS.ms x, MS.ms y, MS.ms z, a] <> ")"
+-----------------------------------------------------------------------------
+-- | https://developer.mozilla.org/en-US/docs/Web/CSS/transform-function/scale
+-- Uniform scale on both axes.
+--
+-- >>> renderTransformFn (scale 1.5)
+-- "scale(1.5)"
+--
+scale :: Double -> TransformFn
+scale n = TransformFn $ "scale(" <> MS.ms n <> ")"
+-----------------------------------------------------------------------------
+-- | https://developer.mozilla.org/en-US/docs/Web/CSS/transform-function/scale
+-- Non-uniform scale: separate X and Y factors.
+--
+scaleXY :: Double -> Double -> TransformFn
+scaleXY x y = TransformFn $ "scale(" <> MS.ms x <> "," <> MS.ms y <> ")"
+-----------------------------------------------------------------------------
+-- | https://developer.mozilla.org/en-US/docs/Web/CSS/transform-function/scaleX
+--
+scaleX :: Double -> TransformFn
+scaleX n = TransformFn $ "scaleX(" <> MS.ms n <> ")"
+-----------------------------------------------------------------------------
+-- | https://developer.mozilla.org/en-US/docs/Web/CSS/transform-function/scaleY
+--
+scaleY :: Double -> TransformFn
+scaleY n = TransformFn $ "scaleY(" <> MS.ms n <> ")"
+-----------------------------------------------------------------------------
+-- | https://developer.mozilla.org/en-US/docs/Web/CSS/transform-function/scaleZ
+--
+scaleZ :: Double -> TransformFn
+scaleZ n = TransformFn $ "scaleZ(" <> MS.ms n <> ")"
+-----------------------------------------------------------------------------
+-- | https://developer.mozilla.org/en-US/docs/Web/CSS/transform-function/skew
+--
+skew :: MisoString -> MisoString -> TransformFn
+skew x y = TransformFn $ "skew(" <> x <> "," <> y <> ")"
+-----------------------------------------------------------------------------
+-- | https://developer.mozilla.org/en-US/docs/Web/CSS/transform-function/skewX
+--
+skewX :: MisoString -> TransformFn
+skewX a = TransformFn $ "skewX(" <> a <> ")"
+-----------------------------------------------------------------------------
+-- | https://developer.mozilla.org/en-US/docs/Web/CSS/transform-function/skewY
+--
+skewY :: MisoString -> TransformFn
+skewY a = TransformFn $ "skewY(" <> a <> ")"
 -----------------------------------------------------------------------------
 -- | https://developer.mozilla.org/en-US/docs/Web/CSS/transition-delay
 --

--- a/src/Miso/CSS.hs
+++ b/src/Miso/CSS.hs
@@ -254,6 +254,21 @@ module Miso.CSS
   -- *** Media Queries
   , media_
   , rule_
+    -- *** Media query combinators
+  , screen_
+  , print_
+  , all_
+  , and_
+  , or_
+  , not_
+  , minWidth_
+  , maxWidth_
+  , minHeight_
+  , maxHeight_
+  , orientation_
+  , prefersColorScheme_
+  , prefersReducedMotion_
+  , hover_
   ) where
 -----------------------------------------------------------------------------
 import qualified Data.Map as M
@@ -540,14 +555,14 @@ at stop styles = KeyframeStop (stop, styles)
 -- | https://developer.mozilla.org/en-US/docs/Web/CSS/@media
 --
 -- @
--- media_ "screen and (min-width: 480px)"
+-- media_ (screen_ \`and_\` minWidth_ (px 480))
 --   [ rule_ "header" [ height "auto" ]
 --   , rule_ "ul"     [ display "block" ]
 --   ]
 -- @
 --
-media_ :: MisoString -> [MediaRule] -> Styles
-media_ name rules = Media name (map getMediaRule rules)
+media_ :: MediaQuery -> [MediaRule] -> Styles
+media_ (MediaQuery q) rules = Media q (map getMediaRule rules)
 -----------------------------------------------------------------------------
 -- | A selector rule inside a 'media_' block.
 --
@@ -555,6 +570,71 @@ media_ name rules = Media name (map getMediaRule rules)
 --
 rule_ :: MisoString -> [Style] -> MediaRule
 rule_ sel styles = MediaRule (sel, styles)
+-----------------------------------------------------------------------------
+-- | The @screen@ media type.
+screen_ :: MediaQuery
+screen_ = MediaQuery "screen"
+-----------------------------------------------------------------------------
+-- | The @print@ media type.
+print_ :: MediaQuery
+print_ = MediaQuery "print"
+-----------------------------------------------------------------------------
+-- | The @all@ media type (matches all devices).
+all_ :: MediaQuery
+all_ = MediaQuery "all"
+-----------------------------------------------------------------------------
+-- | Logical @and@ for media queries.
+--
+-- > screen_ \`and_\` minWidth_ (px 480)
+--
+and_ :: MediaQuery -> MediaQuery -> MediaQuery
+and_ (MediaQuery a) (MediaQuery b) = MediaQuery (a <> " and " <> b)
+-----------------------------------------------------------------------------
+-- | Logical @or@ for media queries (comma-separated).
+--
+-- > screen_ \`or_\` print_
+--
+or_ :: MediaQuery -> MediaQuery -> MediaQuery
+or_ (MediaQuery a) (MediaQuery b) = MediaQuery (a <> ", " <> b)
+-----------------------------------------------------------------------------
+-- | Logical @not@ for media queries.
+--
+-- > not_ print_
+--
+not_ :: MediaQuery -> MediaQuery
+not_ (MediaQuery q) = MediaQuery ("not " <> q)
+-----------------------------------------------------------------------------
+-- | @min-width@ media feature. Use unit constructors like 'px' or 'em'.
+minWidth_ :: MisoString -> MediaQuery
+minWidth_ x = MediaQuery ("(min-width: " <> x <> ")")
+-----------------------------------------------------------------------------
+-- | @max-width@ media feature.
+maxWidth_ :: MisoString -> MediaQuery
+maxWidth_ x = MediaQuery ("(max-width: " <> x <> ")")
+-----------------------------------------------------------------------------
+-- | @min-height@ media feature.
+minHeight_ :: MisoString -> MediaQuery
+minHeight_ x = MediaQuery ("(min-height: " <> x <> ")")
+-----------------------------------------------------------------------------
+-- | @max-height@ media feature.
+maxHeight_ :: MisoString -> MediaQuery
+maxHeight_ x = MediaQuery ("(max-height: " <> x <> ")")
+-----------------------------------------------------------------------------
+-- | @orientation@ media feature. Use @\"portrait\"@ or @\"landscape\"@.
+orientation_ :: MisoString -> MediaQuery
+orientation_ x = MediaQuery ("(orientation: " <> x <> ")")
+-----------------------------------------------------------------------------
+-- | @prefers-color-scheme@ media feature. Use @\"light\"@ or @\"dark\"@.
+prefersColorScheme_ :: MisoString -> MediaQuery
+prefersColorScheme_ x = MediaQuery ("(prefers-color-scheme: " <> x <> ")")
+-----------------------------------------------------------------------------
+-- | @prefers-reduced-motion@ media feature. Use @\"reduce\"@ or @\"no-preference\"@.
+prefersReducedMotion_ :: MisoString -> MediaQuery
+prefersReducedMotion_ x = MediaQuery ("(prefers-reduced-motion: " <> x <> ")")
+-----------------------------------------------------------------------------
+-- | @hover@ media feature. Use @\"hover\"@ or @\"none\"@.
+hover_ :: MisoString -> MediaQuery
+hover_ x = MediaQuery ("(hover: " <> x <> ")")
 -----------------------------------------------------------------------------
 -- | https://developer.mozilla.org/en-US/docs/Web/CSS/align-content
 --

--- a/src/Miso/CSS.hs
+++ b/src/Miso/CSS.hs
@@ -90,7 +90,6 @@ module Miso.CSS
   , caretColor
   , color
   , columnGap
-  , cssVariable
   , cursor
   , direction
   , display
@@ -972,11 +971,6 @@ color x = "color" =: renderColor x
 columnGap :: MisoString -> Style
 columnGap x = "column-gap" =: x
 -----------------------------------------------------------------------------
--- | https://developer.mozilla.org/en-US/docs/Web/CSS/css-variable
---
-cssVariable :: MisoString -> Style
-cssVariable x = "css-variable" =: x
------------------------------------------------------------------------------
 -- | https://developer.mozilla.org/en-US/docs/Web/CSS/direction
 --
 direction :: MisoString -> Style
@@ -989,8 +983,8 @@ display x = "display" =: x
 -----------------------------------------------------------------------------
 -- | https://developer.mozilla.org/en-US/docs/Web/CSS/fill
 --
-fill :: MisoString -> Style
-fill x = "fill" =: x
+fill :: Color -> Style
+fill x = "fill" =: renderColor x
 -----------------------------------------------------------------------------
 -- | https://developer.mozilla.org/en-US/docs/Web/CSS/filter
 --
@@ -1499,8 +1493,8 @@ scrollBehavior x = "scroll-behavior" =: x
 -----------------------------------------------------------------------------
 -- | https://developer.mozilla.org/en-US/docs/Web/CSS/stroke
 --
-stroke :: MisoString -> Style
-stroke x = "stroke" =: x
+stroke :: Color -> Style
+stroke x = "stroke" =: renderColor x
 -----------------------------------------------------------------------------
 -- | https://developer.mozilla.org/en-US/docs/Web/CSS/stroke-width
 --

--- a/src/Miso/CSS.hs
+++ b/src/Miso/CSS.hs
@@ -84,6 +84,10 @@ module Miso.CSS
   , boxShadow
   , boxSizing
   , clipPath
+  , accentColor
+  , appearance
+  , backdropFilter
+  , caretColor
   , color
   , columnGap
   , cssVariable
@@ -101,15 +105,19 @@ module Miso.CSS
   , flexWrap
   , fontFamily
   , fontSize
+  , fontStretch
   , fontStyle
+  , fontVariant
   , fontWeight
   , gap
   , gridAutoColumns
   , gridAutoFlow
   , gridAutoRows
+  , gridColumn
   , gridColumnEnd
   , gridColumnSpan
   , gridColumnStart
+  , gridRow
   , gridRowEnd
   , gridRowSpan
   , gridRowStart
@@ -144,11 +152,20 @@ module Miso.CSS
   , maxWidth
   , minHeight
   , minWidth
+  , mixBlendMode
+  , objectFit
+  , objectPosition
   , opacity
   , order
+  , outline
+  , outlineColor
+  , outlineOffset
+  , outlineStyle
+  , outlineWidth
   , overflow
   , overflowX
   , overflowY
+  , overscrollBehavior
   , paddingBottom
   , paddingInlineEnd
   , paddingInlineStart
@@ -157,6 +174,7 @@ module Miso.CSS
   , paddingRight
   , paddingTop
   , perspective
+  , pointerEvents
   , position
   , relativeAlignBottom
   , relativeAlignInlineEnd
@@ -173,8 +191,10 @@ module Miso.CSS
   , relativeLeftOf
   , relativeRightOf
   , relativeTopOf
+  , resize
   , right
   , rowGap
+  , scrollBehavior
   , stroke
   , strokeWidth
   , textAlign
@@ -185,6 +205,7 @@ module Miso.CSS
   , textStrokeColor
   , textStroke
   , textStrokeWidth
+  , textTransform
   , top
   , transform
   , transformOrigin
@@ -193,10 +214,12 @@ module Miso.CSS
   , transition
   , transitionProperty
   , transitionTimingFunction
+  , userSelect
   , verticalAlign
   , visibility
   , whiteSpace
   , width
+  , willChange
   , wordBreak
   , xAutoFontSize
   , xAutoFontSizePresetSizes
@@ -225,8 +248,12 @@ module Miso.CSS
   , matrix
   -- *** Animation
   , keyframes_
+  , from_
+  , to_
+  , at
   -- *** Media Queries
   , media_
+  , rule_
   ) where
 -----------------------------------------------------------------------------
 import qualified Data.Map as M
@@ -361,11 +388,11 @@ s x = MS.ms x <> "s"
 ms :: Double -> MisoString
 ms x = MS.ms x <> "ms"
 -----------------------------------------------------------------------------
--- | CSS function for specifying a [URL](https://developer.mozilla.org/en-US/docs/Web/API/StyleSheet)
+-- | CSS function for specifying a [URL](https://developer.mozilla.org/en-US/docs/Web/CSS/url)
 --
 -- @
 -- >>> url "dog.png"
--- "url(\"dog.png\")"
+-- "url(dog.png)"
 -- @
 --
 url :: MisoString -> MisoString
@@ -485,41 +512,49 @@ renderStyleSheet styleSheet = MS.intercalate "\n"
 -- | https://developer.mozilla.org/en-US/docs/Web/CSS/@keyframes
 --
 -- @
--- testKeyFrame :: Styles
--- testKeyFrame = keyframes "slide-in"
---   [ "from" =:
---       [ transform "translateX(0%)"
---       ]
---   , "to" =:
---       [ transform "translateX(100%)"
---       , backgroundColor red
---       , backgroundSize "10px"
---       , backgroundRepeat "true"
---       ]
---   , pct 10 =:
---     [ "foo" =: "bar"
---     ]
---  ]
+-- keyframes_ "slide-in"
+--   [ from_ [ transforms [ translateX (pct 0) ] ]
+--   , at (pct 50) [ opacity "0.5" ]
+--   , to_   [ transforms [ translateX (pct 100) ], backgroundColor red ]
+--   ]
 -- @
 --
-keyframes_ :: MisoString -> [(MisoString, [Style])] -> Styles
-keyframes_ = KeyFrame
+keyframes_ :: MisoString -> [KeyframeStop] -> Styles
+keyframes_ name stops = KeyFrame name (map getKeyframeStop stops)
+-----------------------------------------------------------------------------
+-- | The @from@ stop in a t'KeyframeStop' (equivalent to @0%@).
+from_ :: [Style] -> KeyframeStop
+from_ styles = KeyframeStop ("from", styles)
+-----------------------------------------------------------------------------
+-- | The @to@ stop in a t'KeyframeStop' (equivalent to @100%@).
+to_ :: [Style] -> KeyframeStop
+to_ styles = KeyframeStop ("to", styles)
+-----------------------------------------------------------------------------
+-- | A keyframe stop at a given position, typically built with 'pct'.
+--
+-- > at (pct 50) [ opacity "0.5" ]
+--
+at :: MisoString -> [Style] -> KeyframeStop
+at stop styles = KeyframeStop (stop, styles)
 -----------------------------------------------------------------------------
 -- | https://developer.mozilla.org/en-US/docs/Web/CSS/@media
 --
 -- @
 -- media_ "screen and (min-width: 480px)"
---   [ "header" =:
---       [ height "auto"
---       ]
---   , "ul" =:
---       [ display "block"
---       ]
+--   [ rule_ "header" [ height "auto" ]
+--   , rule_ "ul"     [ display "block" ]
 --   ]
 -- @
 --
-media_ :: MisoString -> [(MisoString, [Style])] -> Styles
-media_ = Media
+media_ :: MisoString -> [MediaRule] -> Styles
+media_ name rules = Media name (map getMediaRule rules)
+-----------------------------------------------------------------------------
+-- | A selector rule inside a 'media_' block.
+--
+-- > rule_ "header" [ height "auto" ]
+--
+rule_ :: MisoString -> [Style] -> MediaRule
+rule_ sel styles = MediaRule (sel, styles)
 -----------------------------------------------------------------------------
 -- | https://developer.mozilla.org/en-US/docs/Web/CSS/align-content
 --
@@ -827,6 +862,26 @@ boxSizing x = "box-sizing" =: x
 clipPath :: MisoString -> Style
 clipPath x = "clip-path" =: x
 -----------------------------------------------------------------------------
+-- | https://developer.mozilla.org/en-US/docs/Web/CSS/accent-color
+--
+accentColor :: Color -> Style
+accentColor x = "accent-color" =: renderColor x
+-----------------------------------------------------------------------------
+-- | https://developer.mozilla.org/en-US/docs/Web/CSS/appearance
+--
+appearance :: MisoString -> Style
+appearance x = "appearance" =: x
+-----------------------------------------------------------------------------
+-- | https://developer.mozilla.org/en-US/docs/Web/CSS/backdrop-filter
+--
+backdropFilter :: MisoString -> Style
+backdropFilter x = "backdrop-filter" =: x
+-----------------------------------------------------------------------------
+-- | https://developer.mozilla.org/en-US/docs/Web/CSS/caret-color
+--
+caretColor :: Color -> Style
+caretColor x = "caret-color" =: renderColor x
+-----------------------------------------------------------------------------
 -- | https://developer.mozilla.org/en-US/docs/Web/CSS/color
 --
 color :: Color -> Style
@@ -879,8 +934,8 @@ flexFlow x = "flex-flow" =: x
 -----------------------------------------------------------------------------
 -- | https://developer.mozilla.org/en-US/docs/Web/CSS/flex-grow
 --
-flexGrow :: MisoString -> Style
-flexGrow x = "flex-grow" =: x
+flexGrow :: Double -> Style
+flexGrow x = "flex-grow" =: MS.ms x
 -----------------------------------------------------------------------------
 -- | https://developer.mozilla.org/en-US/docs/Web/CSS/flex
 --
@@ -889,8 +944,8 @@ flex x = "flex" =: x
 -----------------------------------------------------------------------------
 -- | https://developer.mozilla.org/en-US/docs/Web/CSS/flex-shrink
 --
-flexShrink :: MisoString -> Style
-flexShrink x = "flex-shrink" =: x
+flexShrink :: Double -> Style
+flexShrink x = "flex-shrink" =: MS.ms x
 -----------------------------------------------------------------------------
 -- | https://developer.mozilla.org/en-US/docs/Web/CSS/flex-wrap
 --
@@ -907,10 +962,20 @@ fontFamily x = "font-family" =: x
 fontSize :: MisoString -> Style
 fontSize x = "font-size" =: x
 -----------------------------------------------------------------------------
+-- | https://developer.mozilla.org/en-US/docs/Web/CSS/font-stretch
+--
+fontStretch :: MisoString -> Style
+fontStretch x = "font-stretch" =: x
+-----------------------------------------------------------------------------
 -- | https://developer.mozilla.org/en-US/docs/Web/CSS/font-style
 --
 fontStyle :: MisoString -> Style
 fontStyle x = "font-style" =: x
+-----------------------------------------------------------------------------
+-- | https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant
+--
+fontVariant :: MisoString -> Style
+fontVariant x = "font-variant" =: x
 -----------------------------------------------------------------------------
 -- | https://developer.mozilla.org/en-US/docs/Web/CSS/font-weight
 --
@@ -942,6 +1007,11 @@ gridAutoFlow x = "grid-auto-flow" =: x
 gridAutoRows :: MisoString -> Style
 gridAutoRows x = "grid-auto-rows" =: x
 -----------------------------------------------------------------------------
+-- | https://developer.mozilla.org/en-US/docs/Web/CSS/grid-column
+--
+gridColumn :: MisoString -> Style
+gridColumn x = "grid-column" =: x
+-----------------------------------------------------------------------------
 -- | https://developer.mozilla.org/en-US/docs/Web/CSS/grid-column-end
 --
 gridColumnEnd :: MisoString -> Style
@@ -956,6 +1026,11 @@ gridColumnSpan x = "grid-column-span" =: x
 --
 gridColumnStart :: MisoString -> Style
 gridColumnStart x = "grid-column-start" =: x
+-----------------------------------------------------------------------------
+-- | https://developer.mozilla.org/en-US/docs/Web/CSS/grid-row
+--
+gridRow :: MisoString -> Style
+gridRow x = "grid-row" =: x
 -----------------------------------------------------------------------------
 -- | https://developer.mozilla.org/en-US/docs/Web/CSS/grid-row-end
 --
@@ -1127,15 +1202,55 @@ minHeight x = "min-height" =: x
 minWidth :: MisoString -> Style
 minWidth x = "min-width" =: x
 -----------------------------------------------------------------------------
+-- | https://developer.mozilla.org/en-US/docs/Web/CSS/mix-blend-mode
+--
+mixBlendMode :: MisoString -> Style
+mixBlendMode x = "mix-blend-mode" =: x
+-----------------------------------------------------------------------------
+-- | https://developer.mozilla.org/en-US/docs/Web/CSS/object-fit
+--
+objectFit :: MisoString -> Style
+objectFit x = "object-fit" =: x
+-----------------------------------------------------------------------------
+-- | https://developer.mozilla.org/en-US/docs/Web/CSS/object-position
+--
+objectPosition :: MisoString -> Style
+objectPosition x = "object-position" =: x
+-----------------------------------------------------------------------------
 -- | https://developer.mozilla.org/en-US/docs/Web/CSS/opacity
 --
-opacity :: MisoString -> Style
-opacity x = "opacity" =: x
+opacity :: Double -> Style
+opacity x = "opacity" =: MS.ms x
 -----------------------------------------------------------------------------
 -- | https://developer.mozilla.org/en-US/docs/Web/CSS/order
 --
-order :: MisoString -> Style
-order x = "order" =: x
+order :: Int -> Style
+order x = "order" =: MS.ms x
+-----------------------------------------------------------------------------
+-- | https://developer.mozilla.org/en-US/docs/Web/CSS/outline
+--
+outline :: MisoString -> Style
+outline x = "outline" =: x
+-----------------------------------------------------------------------------
+-- | https://developer.mozilla.org/en-US/docs/Web/CSS/outline-color
+--
+outlineColor :: Color -> Style
+outlineColor x = "outline-color" =: renderColor x
+-----------------------------------------------------------------------------
+-- | https://developer.mozilla.org/en-US/docs/Web/CSS/outline-offset
+--
+outlineOffset :: MisoString -> Style
+outlineOffset x = "outline-offset" =: x
+-----------------------------------------------------------------------------
+-- | https://developer.mozilla.org/en-US/docs/Web/CSS/outline-style
+--
+outlineStyle :: MisoString -> Style
+outlineStyle x = "outline-style" =: x
+-----------------------------------------------------------------------------
+-- | https://developer.mozilla.org/en-US/docs/Web/CSS/outline-width
+--
+outlineWidth :: MisoString -> Style
+outlineWidth x = "outline-width" =: x
 -----------------------------------------------------------------------------
 -- | https://developer.mozilla.org/en-US/docs/Web/CSS/overflow
 --
@@ -1151,6 +1266,11 @@ overflowX x = "overflow-x" =: x
 --
 overflowY :: MisoString -> Style
 overflowY x = "overflow-y" =: x
+-----------------------------------------------------------------------------
+-- | https://developer.mozilla.org/en-US/docs/Web/CSS/overscroll-behavior
+--
+overscrollBehavior :: MisoString -> Style
+overscrollBehavior x = "overscroll-behavior" =: x
 -----------------------------------------------------------------------------
 -- | https://developer.mozilla.org/en-US/docs/Web/CSS/padding-bottom
 --
@@ -1191,6 +1311,11 @@ paddingTop x = "padding-top" =: x
 --
 perspective :: MisoString -> Style
 perspective x = "perspective" =: x
+-----------------------------------------------------------------------------
+-- | https://developer.mozilla.org/en-US/docs/Web/CSS/pointer-events
+--
+pointerEvents :: MisoString -> Style
+pointerEvents x = "pointer-events" =: x
 -----------------------------------------------------------------------------
 -- | https://developer.mozilla.org/en-US/docs/Web/CSS/position
 --
@@ -1272,6 +1397,11 @@ relativeRightOf x = "relative-right-of" =: x
 relativeTopOf :: MisoString -> Style
 relativeTopOf x = "relative-top-of" =: x
 -----------------------------------------------------------------------------
+-- | https://developer.mozilla.org/en-US/docs/Web/CSS/resize
+--
+resize :: MisoString -> Style
+resize x = "resize" =: x
+-----------------------------------------------------------------------------
 -- | https://developer.mozilla.org/en-US/docs/Web/CSS/right
 --
 right :: MisoString -> Style
@@ -1281,6 +1411,11 @@ right x = "right" =: x
 --
 rowGap :: MisoString -> Style
 rowGap x = "row-gap" =: x
+-----------------------------------------------------------------------------
+-- | https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-behavior
+--
+scrollBehavior :: MisoString -> Style
+scrollBehavior x = "scroll-behavior" =: x
 -----------------------------------------------------------------------------
 -- | https://developer.mozilla.org/en-US/docs/Web/CSS/stroke
 --
@@ -1332,6 +1467,11 @@ textStroke x = "text-stroke" =: x
 textStrokeWidth :: MisoString -> Style
 textStrokeWidth x = "text-stroke-width" =: x
 -----------------------------------------------------------------------------
+-- | https://developer.mozilla.org/en-US/docs/Web/CSS/text-transform
+--
+textTransform :: MisoString -> Style
+textTransform x = "text-transform" =: x
+-----------------------------------------------------------------------------
 -- | https://developer.mozilla.org/en-US/docs/Web/CSS/top
 --
 top :: MisoString -> Style
@@ -1372,6 +1512,11 @@ transitionProperty x = "transition-property" =: x
 transitionTimingFunction :: MisoString -> Style
 transitionTimingFunction x = "transition-timing-function" =: x
 -----------------------------------------------------------------------------
+-- | https://developer.mozilla.org/en-US/docs/Web/CSS/user-select
+--
+userSelect :: MisoString -> Style
+userSelect x = "user-select" =: x
+-----------------------------------------------------------------------------
 -- | https://developer.mozilla.org/en-US/docs/Web/CSS/vertical-align
 --
 verticalAlign :: MisoString -> Style
@@ -1391,6 +1536,11 @@ whiteSpace x = "white-space" =: x
 --
 width :: MisoString -> Style
 width x = "width" =: x
+-----------------------------------------------------------------------------
+-- | https://developer.mozilla.org/en-US/docs/Web/CSS/will-change
+--
+willChange :: MisoString -> Style
+willChange x = "will-change" =: x
 -----------------------------------------------------------------------------
 -- | https://developer.mozilla.org/en-US/docs/Web/CSS/word-break
 --
@@ -1419,6 +1569,6 @@ xHandleSize x = "-x-handle-size" =: x
 -----------------------------------------------------------------------------
 -- | https://developer.mozilla.org/en-US/docs/Web/CSS/z-index
 --
-zIndex :: MisoString -> Style
-zIndex x = "z-index" =: x
+zIndex :: Int -> Style
+zIndex x = "z-index" =: MS.ms x
 -----------------------------------------------------------------------------

--- a/src/Miso/CSS/Types.hs
+++ b/src/Miso/CSS/Types.hs
@@ -15,6 +15,7 @@ module Miso.CSS.Types
     Style
   , Styles (..)
   , StyleSheet (..)
+  , TransformFn (..)
   ) where
 -----------------------------------------------------------------------------
 import Miso.String (MisoString)
@@ -64,6 +65,16 @@ newtype StyleSheet = StyleSheet { getStyleSheet :: [Styles] }
 -- | Type for a CSS 'Style'
 --
 type Style = (MisoString, MisoString)
+-----------------------------------------------------------------------------
+-- | An individual CSS [transform function](https://developer.mozilla.org/en-US/docs/Web/CSS/transform-function).
+-- Construct values with 'translate', 'rotate', 'scale', etc., then combine with 'transforms'.
+--
+-- @
+-- transforms [ translate (px 10) (pct 50), rotate (deg 45), scaleX 1.5 ]
+-- @
+--
+newtype TransformFn = TransformFn { renderTransformFn :: MisoString }
+  deriving (Eq, Show)
 -----------------------------------------------------------------------------
 -- | Type for a @Map@ of CSS 'Style'. Used with @StyleSheet@.
 -- It maps CSS properties to their values.

--- a/src/Miso/CSS/Types.hs
+++ b/src/Miso/CSS/Types.hs
@@ -15,6 +15,8 @@ module Miso.CSS.Types
     Style
   , Styles (..)
   , StyleSheet (..)
+  , KeyframeStop (..)
+  , MediaRule (..)
   ) where
 -----------------------------------------------------------------------------
 import Miso.String (MisoString)
@@ -34,26 +36,16 @@ import Miso.String (MisoString)
 --        , alignContent "center"
 --        ]
 --    , keyframes_ "slide-in"
---      [ "from" =:
---        [ transform "translateX(0%)"
---        ]
---      , "to" =:
---        [ transform "translateX(100%)"
---        , backgroundColor red
+--      [ from_ [ transforms [ translateX (pct 0) ] ]
+--      , at (pct 50)
+--        [ backgroundColor red
 --        , backgroundSize "10px"
---        , backgroundRepeat "true"
 --        ]
---      , pct 10 =:
---        [ "foo" =: "bar"
---        ]
+--      , to_ [ transforms [ translateX (pct 100) ] ]
 --      ]
 --    , media_ "screen and (min-width: 480px)"
---      [ "header" =:
---        [ height "auto"
---        ]
---      , "ul" =:
---        [ display "block"
---        ]
+--      [ rule_ "header" [ height "auto" ]
+--      , rule_ "ul"     [ display "block" ]
 --      ]
 --    ]
 -- @
@@ -71,5 +63,13 @@ data Styles
   = Styles (MisoString, [Style])
   | KeyFrame MisoString [(MisoString, [Style])]
   | Media MisoString [(MisoString, [Style])]
+  deriving (Eq, Show)
+-----------------------------------------------------------------------------
+-- | A single stop in a '@keyframes' rule. Construct with 'from_', 'to_', or 'at'.
+newtype KeyframeStop = KeyframeStop { getKeyframeStop :: (MisoString, [Style]) }
+  deriving (Eq, Show)
+-----------------------------------------------------------------------------
+-- | A selector rule inside a '@media' block. Construct with 'rule_'.
+newtype MediaRule = MediaRule { getMediaRule :: (MisoString, [Style]) }
   deriving (Eq, Show)
 -----------------------------------------------------------------------------

--- a/src/Miso/CSS/Types.hs
+++ b/src/Miso/CSS/Types.hs
@@ -17,6 +17,7 @@ module Miso.CSS.Types
   , StyleSheet (..)
   , KeyframeStop (..)
   , MediaRule (..)
+  , MediaQuery (..)
   ) where
 -----------------------------------------------------------------------------
 import Miso.String (MisoString)
@@ -43,7 +44,7 @@ import Miso.String (MisoString)
 --        ]
 --      , to_ [ transforms [ translateX (pct 100) ] ]
 --      ]
---    , media_ "screen and (min-width: 480px)"
+--    , media_ (screen_ `and_` minWidth_ (px 480))
 --      [ rule_ "header" [ height "auto" ]
 --      , rule_ "ul"     [ display "block" ]
 --      ]
@@ -71,5 +72,11 @@ newtype KeyframeStop = KeyframeStop { getKeyframeStop :: (MisoString, [Style]) }
 -----------------------------------------------------------------------------
 -- | A selector rule inside a '@media' block. Construct with 'rule_'.
 newtype MediaRule = MediaRule { getMediaRule :: (MisoString, [Style]) }
+  deriving (Eq, Show)
+-----------------------------------------------------------------------------
+-- | A CSS [media query](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_media_queries).
+-- Construct with 'screen_', 'print_', 'all_', 'minWidth_', etc.,
+-- and compose with 'and_', 'or_', 'not_'.
+newtype MediaQuery = MediaQuery { renderMediaQuery :: MisoString }
   deriving (Eq, Show)
 -----------------------------------------------------------------------------

--- a/src/Miso/Subscription/RAF.hs
+++ b/src/Miso/Subscription/RAF.hs
@@ -20,7 +20,10 @@
 -- @
 --
 ----------------------------------------------------------------------------
-module Miso.Subscription.RAF where
+module Miso.Subscription.RAF
+  ( rAFSub
+  , rAFSubElapsed
+  ) where
 ----------------------------------------------------------------------------
 import           Control.Monad (void)
 import           Data.IORef
@@ -29,7 +32,7 @@ import           Miso.DSL
 import           Miso.Effect (Sub)
 import           Miso.Subscription.Util (createSub)
 ----------------------------------------------------------------------------
--- | A 'Sub' for 60FPS animations when using 'requestForAnimationFrame'.
+-- | A 'Sub' for 60FPS animations when using 'requestAnimationFrame'.
 --
 -- The 'Double' returned is a [DOMHighResTimeStamp](https://developer.mozilla.org/en-US/docs/Web/API/DOMHighResTimeStamp) expressed in milliseconds.
 --
@@ -44,6 +47,43 @@ rAFSub toAction sink = createSub acquire release sink
           void (requestAnimationFrame =<< readIORef ref)
 
       writeIORef ref callback
+      void (requestAnimationFrame callback)
+      pure callback
+
+    release callback = freeFunction (Function callback)
+----------------------------------------------------------------------------
+-- | Like 'rAFSub' but fires @action@ at most once per @interval@ milliseconds.
+--
+-- Elapsed time is accumulated in 'IORef's inside the subscription so the
+-- model is not touched between ticks — Miso only re-renders when a tick
+-- actually fires, rather than on every animation frame.
+--
+-- @
+-- app = defaultApp model update view
+--   { subs = [ rAFSubElapsed 175 Tick ] }
+-- @
+--
+rAFSubElapsed :: Double -> action -> Sub action
+rAFSubElapsed interval action sink = createSub acquire release sink
+  where
+    acquire = do
+      cbRef   <- newIORef (error "rAFSubElapsed: uninitialized, impossible")
+      lastRef <- newIORef (0.0 :: Double)
+      elapRef <- newIORef (0.0 :: Double)
+      callback <- syncCallback1 $ \jsval -> do
+        t    <- fromJSValUnchecked jsval
+        prev <- readIORef lastRef
+        writeIORef lastRef t
+        let dt = if prev == 0 then 0 else min interval (t - prev)
+        elap <- readIORef elapRef
+        let newElap = elap + dt
+        if newElap >= interval
+          then do
+            writeIORef elapRef (newElap - interval)
+            sink action
+          else writeIORef elapRef newElap
+        void (requestAnimationFrame =<< readIORef cbRef)
+      writeIORef cbRef callback
       void (requestAnimationFrame callback)
       pure callback
 


### PR DESCRIPTION
- Fix types: opacity (Double), zIndex (Int), flexGrow/flexShrink (Double), order (Int)
- Add MediaRule newtype + rule_ combinator for typed media_ blocks
- Add KeyframeStop newtype + from_, to_, at combinators for typed keyframes_
- Fix url docstring (output has no quotes)
- Add missing properties: accentColor, appearance, backdropFilter, caretColor, fontStretch, fontVariant, gridColumn, gridRow, mixBlendMode, objectFit, objectPosition, outline, outlineColor, outlineOffset, outlineStyle, outlineWidth, overscrollBehavior, pointerEvents, resize, scrollBehavior, textTransform, userSelect, willChange