### PR TITLE
fix: Make `MisoString` `take` and `length` functions consistent with `Data.Text`

### DIFF
--- a/ffi/wasm/Data/JSString.hs
+++ b/ffi/wasm/Data/JSString.hs
@@ -445,7 +445,7 @@ unfoldrN n f seed = go seed mempty
 foreign import javascript unsafe
   """
   if ($1 < 1) return "";
-  return $2.slice(0, $1);
+  return Array.from($2).slice(0, $1).join('');
   """ take :: Int -> JSString -> JSString
 -----------------------------------------------------------------------------
 foreign import javascript unsafe
@@ -791,7 +791,7 @@ foldl' f x ys =
 -----------------------------------------------------------------------------
 foreign import javascript unsafe
   """
-  return $1.length
+  return Array.from($1).length;
   """ length :: JSString -> Int
 -----------------------------------------------------------------------------
 foreign import javascript unsafe


### PR DESCRIPTION
- the problem is that if we use javascript's length and split functions they count the number of utf-16 codepoints in the string, not the number of characters. for example the length of a string with a single emoji would be two in js, but 1 in haskell.
- this only affects the WASM backend
- the javascript backend uses ghcjs-base which should have the correct implementation