### PR TITLE
Add await to miso DSL

### DIFF
--- a/ffi/ghc/Miso/DSL/FFI.hs
+++ b/ffi/ghc/Miso/DSL/FFI.hs
@@ -138,6 +138,9 @@ fromJSValUnchecked_Double = undefined
 fromJSVal_JSString :: JSVal -> IO (Maybe Text)
 fromJSVal_JSString = undefined
 -----------------------------------------------------------------------------
+await :: JSVal -> IO JSVal
+await = undefined
+-----------------------------------------------------------------------------
 -- | A asynchronous callback
 asyncCallback :: IO () -> IO JSVal
 asyncCallback = undefined

--- a/ffi/ghc/Miso/DSL/FFI.hs
+++ b/ffi/ghc/Miso/DSL/FFI.hs
@@ -7,6 +7,8 @@ import           Text.Read (readMaybe)
 -- | A type that represents any JS value
 data JSVal = JSVal
 -----------------------------------------------------------------------------
+data JSException
+-----------------------------------------------------------------------------
 instance Eq JSVal where
   JSVal == JSVal = True
 -----------------------------------------------------------------------------

--- a/ffi/js/Miso/DSL/FFI.hs
+++ b/ffi/js/Miso/DSL/FFI.hs
@@ -78,6 +78,7 @@ module Miso.DSL.FFI
   , toString_Float
   , toString_Word
   , toString_Int
+  , JSException
   ) where
 -----------------------------------------------------------------------------
 import           Data.JSString

--- a/ffi/js/Miso/DSL/FFI.hs
+++ b/ffi/js/Miso/DSL/FFI.hs
@@ -1,6 +1,7 @@
 -----------------------------------------------------------------------------
 {-# LANGUAGE CPP               #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE InterruptibleFFI  #-}
 -----------------------------------------------------------------------------
 {-# OPTIONS_GHC -fno-warn-orphans  #-}
 -----------------------------------------------------------------------------
@@ -36,6 +37,8 @@ module Miso.DSL.FFI
   , fromJSVal_Maybe
   , fromJSValUnchecked_Maybe
   -- * Callback FFI
+  , awaitPromise_ffi
+  , await
   , asyncCallback
   , asyncCallback1
   , asyncCallback2
@@ -79,6 +82,7 @@ module Miso.DSL.FFI
 -----------------------------------------------------------------------------
 import           Data.JSString
 import           Data.Text
+import           Control.Exception (throwIO)
 -----------------------------------------------------------------------------
 import qualified GHCJS.Marshal as Marshal
 import           GHCJS.Types
@@ -319,6 +323,26 @@ fromJSVal_Float = Marshal.fromJSVal
 fromJSValUnchecked_Float :: JSVal -> IO Float
 fromJSValUnchecked_Float = Marshal.fromJSValUnchecked
 {-# INLINE fromJSValUnchecked_Float #-}
+-----------------------------------------------------------------------------
+-- | Suspends the current Haskell thread and yields to the JS event loop
+-- until the given JavaScript Promise resolves or rejects.
+foreign import javascript interruptible
+#if GHCJS_NEW
+  "((promise, $c) => { promise.then(s => $c(null, s), e => $c(e, null)); })"
+#else
+  "$1.then(function(s) { $c(null, s); }, function(e) { $c(e, null); });"
+#endif
+  awaitPromise_ffi :: JSVal -> IO (JSVal, JSVal)
+
+-- | Awaits a JS Promise. If the promise rejects, it throws a 'JSException',
+-- mirroring the exact behavior of the GHC WASM backend's 'safe' imports.
+await :: JSVal -> IO JSVal
+await promise = do
+  (err, val) <- awaitPromise_ffi promise
+  -- If the error argument is null/undefined, the promise resolved successfully
+  if isNull_ffi err || isUndefined_ffi err
+    then pure val
+    else throwIO =<< mkJSException err
 -----------------------------------------------------------------------------
 asyncCallback :: IO () -> IO JSVal
 asyncCallback x = jsval <$> Callback.asyncCallback x

--- a/ffi/wasm/Miso/DSL/FFI.hs
+++ b/ffi/wasm/Miso/DSL/FFI.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE TemplateHaskell          #-}
 {-# LANGUAGE MultilineStrings         #-}
 {-# LANGUAGE ForeignFunctionInterface #-}
+{-# LANGUAGE InterruptibleFFI  #-}
 -----------------------------------------------------------------------------
 {-# OPTIONS_GHC -fno-warn-orphans  #-}
 -----------------------------------------------------------------------------
@@ -39,6 +40,7 @@ module Miso.DSL.FFI
   , fromJSVal_Maybe
   , fromJSValUnchecked_Maybe
   -- * Callback FFI
+  , await
   , asyncCallback
   , asyncCallback1
   , asyncCallback2
@@ -250,6 +252,9 @@ foreign import javascript unsafe
   """ jsNull :: JSVal
 -----------------------------------------------------------------------------
 foreign import javascript unsafe "return globalThis" global :: JSVal
+-----------------------------------------------------------------------------
+foreign import javascript interruptible "return await $1;"
+  await :: JSVal -> IO JSVal
 -----------------------------------------------------------------------------
 foreign import javascript "wrapper"
   asyncCallback

--- a/ffi/wasm/Miso/DSL/FFI.hs
+++ b/ffi/wasm/Miso/DSL/FFI.hs
@@ -76,6 +76,7 @@ module Miso.DSL.FFI
   , parseDouble
   , parseWord
   , parseFloat
+  , JSException
   ) where
 -----------------------------------------------------------------------------
 import           Data.Text (Text)

--- a/src/Miso/DSL.hs
+++ b/src/Miso/DSL.hs
@@ -164,6 +164,7 @@ module Miso.DSL
   , asyncCallback2
   , asyncCallback3
   , apply
+  , JSException
   ) where
 -----------------------------------------------------------------------------
 import           Control.Applicative

--- a/src/Miso/DSL.hs
+++ b/src/Miso/DSL.hs
@@ -158,6 +158,7 @@ module Miso.DSL
   , syncCallback1'
   , syncCallback2'
   , syncCallback3'
+  , await
   , asyncCallback
   , asyncCallback1
   , asyncCallback2

--- a/tests/app/Main.hs
+++ b/tests/app/Main.hs
@@ -17,6 +17,7 @@ module Main where
 -----------------------------------------------------------------------------
 import           Control.Concurrent (newEmptyMVar, putMVar, takeMVar)
 import           Control.Monad.Reader
+import           Control.Exception (try, evaluate)
 import qualified Data.Map.Strict as M
 import           Data.Map.Strict (Map)
 import qualified Data.IntMap.Strict as IM
@@ -1642,3 +1643,25 @@ main = withJS $ do
           component (0 :: Int) noop $ \_ _ ->
             div_ [] (replicate 999 (mount_ testComponent))
         mountedComponents >>= (`shouldBe` 1000)
+
+    describe "Miso.DSL `await` tests" $ do
+      it "Successful Promise resolution should result in a value" $ do
+        -- Create a Promise and immediately resolve it with `42`
+        val <- liftIO $ do
+          promise <- jsg ("Promise" :: MisoString)
+          p <- promise # ("resolve" :: MisoString) $ (42 :: Int)
+          result <- await p
+          fromJSValUnchecked result
+
+        val `shouldBe` (42 :: Int)
+
+      it "A rejected Promise will throw an error we can catch" $ do
+        result <- liftIO $ do
+          promise <- jsg ("Promise" :: MisoString)
+          p <- promise # ("reject" :: MisoString) $ ("TEST_ERROR" :: MisoString)
+
+          -- await p returns a thunk, without evaluate here the exception would
+          -- only be thrown when the result is evaluated, so we force its evaluation here
+          try @JSException (await p >>= evaluate)
+
+        Data.Either.isLeft result `shouldBe` True


### PR DESCRIPTION
- Tested WASM and JS backends (but not legacy ghcjs)