### PR TITLE
fix: Derive `Exception` for `JSException`.

### DIFF
--- a/ffi/ghc/Miso/DSL/FFI.hs
+++ b/ffi/ghc/Miso/DSL/FFI.hs
@@ -1,13 +1,19 @@
 -----------------------------------------------------------------------------
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE DeriveAnyClass     #-}
+-----------------------------------------------------------------------------
 module Miso.DSL.FFI where
 -----------------------------------------------------------------------------
+import           Control.Exception (Exception)
 import           Data.Text (Text, pack, unpack)
 import           Text.Read (readMaybe)
 -----------------------------------------------------------------------------
 -- | A type that represents any JS value
 data JSVal = JSVal
 -----------------------------------------------------------------------------
-data JSException
+data JSException = JSException
+  deriving stock Show
+  deriving anyclass Exception
 -----------------------------------------------------------------------------
 instance Eq JSVal where
   JSVal == JSVal = True


### PR DESCRIPTION
When haddocking the mock vanilla GHC FFI backend, the `JSException` type requires deriving `Exception`.

```haskell
data JSException = JSException
  deriving stock Show
  deriving anyclass Exception
```