### PR TITLE
ci: Build `exe:component-tests` in CI.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -150,3 +150,6 @@ jobs:
 
      - name: (WASM) Miso integration tests
        run: nix-build -A playwright-wasm && ./result/bin/playwright
+
+     - name: (x86) Miso GHC (GHC 9.12.2) test suite
+       run: nix develop --command bash -c 'cabal build exe:component-tests'


### PR DESCRIPTION
While not actually executed using the vanilla GHC backend, this is required for haddocking.

Per https://github.com/dmjio/miso/pull/1564 a compile error was introduced that went uncaught in the test suite. Adding a `cabal build` of `exe:component-tests` should catch this in the future going forward.