### PR TITLE
feat: Add read-only `context` access within `Effect`

### DIFF
--- a/src/Miso.hs
+++ b/src/Miso.hs
@@ -123,11 +123,12 @@
 --       Add -> 'Miso.Lens.this' 'Miso.Lens.+=' 1
 --       Subtract -> 'Miso.Lens.this' 'Miso.Lens.-=' 1
 --
---           * - The type of the global @context@
---           |     * - The type of the @props@ inherited from the parent 'Component'
---           |     |     * - The type of the current 'Component' 'model'
---           |     |     |             * - The type of the action that updates 'Component' 'model'
---           |     |     |             |
+--          * - The type of the global @context@
+--          |     * - The type of the @props@ inherited from the parent 'Component'
+--          |     |      * - The type of the current 'Component' 'model'
+--          |     |      |              * - The global @context@ threaded into the 'View' (@'View' context action@)
+--          |     |      |              |  * - The type of the action that updates 'Component' 'model'
+--          |     |      |              |  |
 --     v :: () -> () -> 'Int' -> 'View' () Action
 --     v _context _props x = 'vfrag'
 --       [ H.'Miso.Html.Element.button_' [ HE.'Miso.Html.Event.onClick' Add, HP.'Miso.Html.Property.id_' "add" ] [ "+" ]
@@ -231,10 +232,22 @@
 -- view ctx _props _model = ...
 -- @
 --
+-- __Reading__ (in 'Miso.Types.update'):
+--
+-- The current @context@ is also readable inside the 'Effect' monad, just like
+-- @props@: use 'Miso.Effect.getContext' (or 'Miso.Lens.view' with the
+-- 'Miso.Effect.context' lens):
+--
+-- @
+-- update Toggle = do
+--   ctx <- 'Miso.Effect.getContext'
+--   …
+-- @
+--
 -- __Updating__ (from 'Miso.Types.update'):
 --
--- @context@ is __write-only__ inside 'update'; mutate it with
--- 'Miso.Effect.modifyContext' (or 'Miso.Effect.putContext' to replace it):
+-- Mutate the @context@ with 'Miso.Effect.modifyContext' (or
+-- 'Miso.Effect.putContext' to replace it):
 --
 -- @
 -- update Toggle = 'Miso.Effect.modifyContext' (\\theme -> if theme == Light then Dark else Light)

--- a/src/Miso/Effect.hs
+++ b/src/Miso/Effect.hs
@@ -138,6 +138,10 @@ module Miso.Effect
   , componentInfoProps
   , props
   , getProps
+  -- *** Context
+  , componentInfoContext
+  , context
+  , getContext
   ) where
 -----------------------------------------------------------------------------
 import           Control.Monad (void)
@@ -157,6 +161,9 @@ mkComponentInfo
   -> DOMRef
   -- ^ 'DOMRef'
   -> props
+  -- ^ props
+  -> context
+  -- ^ context
   -> ComponentInfo context props
 mkComponentInfo = ComponentInfo
 -----------------------------------------------------------------------------
@@ -175,6 +182,8 @@ data ComponentInfo context props
   -- ^ The DOM node this component is mounted on
   , _componentInfoProps :: props
   -- ^ The current @props@ value passed into this component
+  , _componentInfoContext :: context
+  -- ^ The current @context@ value passed into this component
   }
 -----------------------------------------------------------------------------
 -- | Lens for accessing the t'ComponentId' from t'ComponentInfo'.
@@ -230,6 +239,41 @@ componentInfoDOMRef = lens _componentInfoDOMRef $ \r x -> r { _componentInfoDOMR
 componentInfoProps :: Lens (ComponentInfo context props) props
 componentInfoProps = lens _componentInfoProps $ \r x -> r { _componentInfoProps = x }
 -----------------------------------------------------------------------------
+-- | Lens for accessing the underlying t'Miso.Types.Component' @context@.
+--
+-- @
+--   update = \case
+--     SomeAction -> do
+--       ctx <- view componentInfoContext
+--       someAction ctx
+-- @
+--
+-- @since 1.13.0.0
+componentInfoContext :: Lens (ComponentInfo context props) context
+componentInfoContext = lens _componentInfoContext $ \r x -> r { _componentInfoContext = x }
+-----------------------------------------------------------------------------
+-- | Lens for accessing the underlying t'Miso.Types.Component' @context@.
+--
+-- This is a shorter convenience lens that is a synonynm for 'componentInfoContext'.
+-- See 'getContext' for usage in the 'Effect' monad.
+--
+-- @
+--   update = \case
+--     SomeAction ->
+--       someAction =<< view context
+-- @
+--
+-- __Note:__ this lens is __read-only__ within 'Effect'. It targets the
+-- 'ComponentInfo' reader environment, so setting through it (e.g. with
+-- 'Miso.Lens.set' \/ 'Miso.Lens..=') has no observable effect. To change the
+-- global @context@ from 'Miso.Types.update', use 'Miso.Effect.modifyContext',
+-- 'Miso.Effect.putContext', or 'Miso.Effect.modifyContext_' (the 'State'-monad
+-- variant, which supports lens operators like @'Miso.Lens..='@) instead.
+--
+-- @since 1.13.0.0
+context :: Lens (ComponentInfo context props) context
+context = componentInfoContext
+-----------------------------------------------------------------------------
 -- | Lens for accessing the underlying t'Miso.Types.Component' @props@.
 --
 -- This is a shorter convenience lens that is a synonynm for 'componentInfoProps'.
@@ -255,6 +299,19 @@ props = componentInfoProps
 --
 getProps :: MonadReader (ComponentInfo context props) m => m props
 getProps = Miso.Lens.view props
+-----------------------------------------------------------------------------
+-- | Read-only @context@ retrieval from within the 'Effect' monad.
+--
+-- @
+--   update = \case
+--     SomeAction -> do
+--       ctx <- getContext
+--       someAction ctx
+-- @
+--
+-- @since 1.13.0.0
+getContext :: MonadReader (ComponentInfo context props) m => m context
+getContext = Miso.Lens.view context
 -----------------------------------------------------------------------------
 -- | 'ComponentId' of the current t'Miso.Types.Component'
 type ComponentId = Int
@@ -520,7 +577,7 @@ withSink f = tell [ async f ]
 -- 'update' Toggle = 'modifyContext' (\\theme -> if theme == Light then Dark else Light)
 -- @
 --
--- @since 1.9.0.0
+-- @since 1.13.0.0
 modifyContext
   :: (context -> context)
   -- ^ Transformation to apply to the global @context@
@@ -532,7 +589,7 @@ modifyContext f = tell [ ContextModify f ]
 -- A convenience wrapper around 'modifyContext'. See 'modifyContext' for details
 -- of when re-renders are triggered.
 --
--- @since 1.9.0.0
+-- @since 1.13.0.0
 putContext
   :: context
   -- ^ New global @context@ value
@@ -551,7 +608,7 @@ putContext = modifyContext . const
 -- 'update' Toggle = 'modifyContext_' $ theme '.=' Dark
 -- @
 --
--- @since 1.9.0.0
+-- @since 1.13.0.0
 modifyContext_
   :: State context ()
   -- ^ 'State' computation describing the @context@ mutation

--- a/src/Miso/Runtime.hs
+++ b/src/Miso/Runtime.hs
@@ -220,8 +220,8 @@ initialize events _componentParentId hydrate isRoot initialProps maybeKey comp@C
         atomicWriteIORef _componentVTree newVTree
         FFI.flush
 
-  let _componentApplyActions = \(actions :: Seq action) model_ currentProps -> do
-        let info = ComponentInfo _componentId _componentParentId _componentDOMRef currentProps
+  let _componentApplyActions = \(actions :: Seq action) model_ currentProps ctx -> do
+        let info = ComponentInfo _componentId _componentParentId _componentDOMRef currentProps ctx
         foldl'
           (\(m, ss) a ->
               case runEffect (update a) info m of
@@ -314,7 +314,7 @@ scheduler Proxy =
       vcomps <- readIORef components
       let ComponentState {..} = vcomps IM.! vcompId
           (updatedModel, schedules) =
-            _componentApplyActions events _componentModel _componentProps
+            _componentApplyActions events _componentModel _componentProps currentContext
       forM_ schedules $ \case
         Schedule Async action ->
           evalScheduled Async (action _componentSink)
@@ -595,6 +595,7 @@ data ComponentState context props model action
       :: Seq action
       -> model
       -> props
+      -> context
       -> (model, [Schedule context action])
   -- ^ t'Miso.Types.Component' actions application. Given the pending actions,
   --   current @model@ and @props@, returns the updated @model@ and the
@@ -882,7 +883,7 @@ drain ComponentState {..} = do
     S.Empty -> pure ()
     actions -> do
        currentContext <- readIORef @context globalContext
-       case _componentApplyActions actions _componentModel _componentProps of
+       case _componentApplyActions actions _componentModel _componentProps currentContext of
          (_, schedules) -> do
            forM_ schedules $ \case
              -- dmj: process all actions synchronously during unmount


### PR DESCRIPTION
Thread the current global `context` value into `ComponentInfo` (the reader environment of `Effect`) so it can be read from `update`, mirroring `props`.

- Add `_componentInfoContext` field, `componentInfoContext`/`context` lenses, and `getContext` reader to `Miso.Effect`.
- Plumb the context through `_componentApplyActions` in `Miso.Runtime`.
- Document read-only context access in `Miso` and note that writes still go through `modifyContext`/`putContext`/`modifyContext_`.
- Tag context API `@since 1.13.0.0`.