### PR TITLE
[native] isolate bundle provenance and add a conformance fixture

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -131,6 +131,7 @@ jobs:
          nix-build -A sample-app-native-bundle
          mkdir -p bundle-artifact
          cp result/main.lynx.bundle bundle-artifact/main.lynx.bundle
+         cp result/main.lynx.bundle.sha256 bundle-artifact/main.lynx.bundle.sha256
 
      - name: Upload Lynx bundle
        uses: actions/upload-artifact@v4
@@ -268,6 +269,7 @@ jobs:
        run: |
          mkdir -p sample-app-native/android/app/src/main/assets
          cp bundle-artifact/main.lynx.bundle sample-app-native/android/app/src/main/assets/main.lynx.bundle
+         cp bundle-artifact/main.lynx.bundle.sha256 sample-app-native/android/app/src/main/assets/main.lynx.bundle.sha256
 
      - name: (Android) assemble debug APK
        working-directory: sample-app-native/android

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -137,7 +137,9 @@ jobs:
        uses: actions/upload-artifact@v4
        with:
          name: lynx-bundle
-         path: bundle-artifact/main.lynx.bundle
+         path: |
+           bundle-artifact/main.lynx.bundle
+           bundle-artifact/main.lynx.bundle.sha256
          if-no-files-found: error
 
   build-macos:

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ haddocks/
 /sample-app/public/
 
 .gradle
+sample-app-native/android/app/src/main/assets/main.lynx.bundle
+sample-app-native/android/app/src/main/assets/main.lynx.bundle.sha256

--- a/default.nix
+++ b/default.nix
@@ -31,6 +31,16 @@ rec {
       styles = ./sample-app-native/styles.css;
     };
 
+  # Core-elements-only dual-thread conformance fixture. It is a separate
+  # executable so gallery feature coverage remains intact.
+  sample-app-native-conformance-bundle =
+    pkgs.mkLynxBundle {
+      name = "sample-app-native-conformance-bundle";
+      jsDrv = pkgs.pkgsCross.ghcjs.haskell.packages.ghcNative.sample-app-native;
+      exeName = "app-native-conformance";
+      styles = ./sample-app-native/conformance.css;
+    };
+
   # Android host APK (Kotlin + Lynx SDK), built reproducibly via nixpkgs
   # androidenv + the gradle mitm-cache dep fetcher. Embeds the freshly built
   # sample-app-native-bundle in assets. See nix/android.nix.

--- a/flake.nix
+++ b/flake.nix
@@ -91,6 +91,15 @@
             styles = ./sample-app-native/styles.css;
           };
 
+          # Core-elements-only dual-thread fixture for deterministic runtime
+          # conformance. This is intentionally separate from the gallery.
+          sample-app-native-conformance-bundle = pkgs.mkLynxBundle {
+            name = "sample-app-native-conformance-bundle";
+            jsDrv = pkgs.pkgsCross.ghcjs.haskell.packages.ghcNative.sample-app-native;
+            exeName = "app-native-conformance";
+            styles = ./sample-app-native/conformance.css;
+          };
+
           # Util
           inherit (pkgs.haskell.packages.ghc9122)
             miso-from-html;

--- a/nix/android.nix
+++ b/nix/android.nix
@@ -37,6 +37,7 @@ let
     chmod -R u+w $out
     mkdir -p $out/app/src/main/assets
     cp ${bundle}/main.lynx.bundle $out/app/src/main/assets/main.lynx.bundle
+    cp ${bundle}/main.lynx.bundle.sha256 $out/app/src/main/assets/main.lynx.bundle.sha256
     # SDK location comes from ANDROID_HOME, not a checked-in local.properties.
     rm -f $out/local.properties
   '';

--- a/nix/lib/mk-lynx-bundle.nix
+++ b/nix/lib/mk-lynx-bundle.nix
@@ -91,5 +91,7 @@ pkgs.stdenv.mkDerivation {
   installPhase = ''
     mkdir -p $out
     cp -r dist/. $out/
+    cd $out
+    ${pkgs.coreutils}/bin/sha256sum main.lynx.bundle > main.lynx.bundle.sha256
   '';
 }

--- a/nix/source.nix
+++ b/nix/source.nix
@@ -2,12 +2,23 @@
 with lib;
 with (builtins.fromJSON (builtins.readFile ../flake.lock));
 let
-  make-src-filter = src: with lib;
+  make-src-filter =
+    { src
+    , excludedNames ? []
+    }: with lib;
     cleanSourceWith {
       inherit src;
       filter =
-        name: type: let baseName = baseNameOf (toString name); in
-         ((type == "regular" && hasSuffix ".hs" baseName) ||
+        name: type:
+        let
+          baseName = baseNameOf (toString name);
+          excluded =
+            [ ".git" ".github" ".gradle" ".stack-work" "coverage"
+              "dist" "dist-newstyle" "node_modules" "result"
+            ] ++ excludedNames;
+        in
+         (!elem baseName excluded && (
+         (type == "regular" && hasSuffix ".hs" baseName) ||
          (hasSuffix ".yaml" baseName) ||
          (hasSuffix ".cabal" baseName) ||
          (hasSuffix ".css" baseName) ||
@@ -17,8 +28,7 @@ let
          (hasSuffix ".js" baseName) ||
          (baseName == "README.md") ||
          (baseName == "LICENSE") ||
-         (type == "directory" && baseName != "tests") ||
-         (type == "directory" && baseName != "dist"));
+         (type == "directory")));
     };
 
   # fetch from flake
@@ -31,10 +41,18 @@ let
 in
 {
   # local sources
-  miso             = make-src-filter ../.;
-  miso-tests       = make-src-filter ../tests;
-  sample-app       = make-src-filter ../sample-app;
-  sample-app-native = make-src-filter ../sample-app-native;
+  # Keep package sources independent: changing a sample or native host must not
+  # invalidate the Miso library derivation.
+  miso = make-src-filter {
+    src = ../.;
+    excludedNames = [ "sample-app" "sample-app-native" "tests" ];
+  };
+  miso-tests = make-src-filter { src = ../tests; };
+  sample-app = make-src-filter { src = ../sample-app; };
+  sample-app-native = make-src-filter {
+    src = ../sample-app-native;
+    excludedNames = [ "android" "ios" "build" "styles.css" ];
+  };
 
   # non-flakified sources
   miso-from-html = fetchFromGitHub {

--- a/nix/source.nix
+++ b/nix/source.nix
@@ -51,7 +51,7 @@ in
   sample-app = make-src-filter { src = ../sample-app; };
   sample-app-native = make-src-filter {
     src = ../sample-app-native;
-    excludedNames = [ "android" "ios" "build" "styles.css" ];
+    excludedNames = [ "android" "ios" "build" "styles.css" "conformance.css" ];
   };
 
   # non-flakified sources

--- a/sample-app-native/Conformance.hs
+++ b/sample-app-native/Conformance.hs
@@ -1,0 +1,298 @@
+-----------------------------------------------------------------------------
+{-# LANGUAGE DeriveAnyClass     #-}
+{-# LANGUAGE DeriveGeneric      #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE LambdaCase         #-}
+{-# LANGUAGE OverloadedStrings  #-}
+{-# LANGUAGE RecordWildCards    #-}
+{-# LANGUAGE StaticPointers     #-}
+-----------------------------------------------------------------------------
+-- | Deterministic dual-thread conformance fixture using only Lynx core
+-- @<view>@ and @<text>@ elements. Optional gallery behaviors must not be able
+-- to truncate the tree before IFR, BTS, MTS, churn, or lifecycle probes run.
+module Main where
+-----------------------------------------------------------------------------
+import           GHC.Generics (Generic)
+import           Miso hiding (text_)
+import qualified Miso.CSS as CSS
+import           Miso.Html.Property (id_)
+import           Miso.JSON (FromJSON, ToJSON)
+import           Miso.Native
+import qualified Miso.Native.Element.View.Event as VE
+import           Miso.Native.MainThread (setStyleProperty)
+-----------------------------------------------------------------------------
+data Action
+  = IncrementBTS
+  | ToggleDynamic
+  | PaintMTS DOMRef
+  | ReadMTS DOMRef Int
+  deriving stock (Generic)
+  deriving anyclass (ToJSON, FromJSON)
+
+data Model = Model
+  { probeCount     :: Int
+  , dynamicVisible :: Bool
+  , lastEvent      :: MisoString
+  } deriving stock (Eq, Generic)
+    deriving anyclass (ToJSON, FromJSON)
+-----------------------------------------------------------------------------
+main :: IO ()
+main =
+  nativeWithContext nativeEvents ()
+    (static (mountStatic_ probeComponent))
+
+probeComponent :: Component () () Model Action
+probeComponent = component initialModel updateModel viewModel
+  where
+    initialModel = Model
+      { probeCount = 0
+      , dynamicVisible = True
+      , lastEvent = "boot"
+      }
+
+updateModel :: Action -> Effect () () Model Action
+updateModel = \case
+  IncrementBTS ->
+    modify $ \m -> m
+      { probeCount = probeCount m + 1
+      , lastEvent = "bts: increment"
+      }
+  ToggleDynamic ->
+    modify $ \m -> m
+      { dynamicVisible = not (dynamicVisible m)
+      , lastEvent = "bts: toggle dynamic"
+      }
+  PaintMTS domRef ->
+    io_ (setStyleProperty domRef "background-color" "#f59e0b")
+  ReadMTS domRef n ->
+    io_ (setStyleProperty domRef "opacity" (opacityForCount n))
+
+viewModel :: () -> () -> Model -> View () Model Action
+viewModel _ _ Model{..} =
+  view_
+    [ id_ "probe-root"
+    , CSS.style_
+      [ CSS.width "100%"
+      , CSS.height "100vh"
+      , CSS.display "flex"
+      , CSS.flexDirection "column"
+      , CSS.padding "24px"
+      , CSS.backgroundColor (CSS.RGB 15 23 42)
+      ]
+    ]
+    [ text_
+      [ id_ "probe-title"
+      , CSS.style_
+        [ CSS.fontSize "24px"
+        , CSS.fontWeight "700"
+        , CSS.color CSS.white
+        , lineHeight
+        , CSS.marginBottom "12px"
+        ]
+      ]
+      [ text "Miso Lynx dual-thread conformance" ]
+    , text_
+      [ id_ "probe-status"
+      , CSS.style_
+        [ CSS.fontSize "15px"
+        , CSS.color CSS.lime
+        , lineHeight
+        , CSS.marginBottom "12px"
+        ]
+      ]
+      [ text (ms
+          ( "count=" <> show probeCount
+         <> " dynamic=" <> show dynamicVisible
+         <> " last=" <> fromMisoString lastEvent
+          ))
+      ]
+    , btsIncrementButton
+    , dynamicSection dynamicVisible
+    , mtsPaintSection
+    , mtsReadSection
+    , childSection probeCount
+    ]
+
+lineHeight :: CSS.Style
+lineHeight = CSS.lineHeight "1.4"
+
+panelStyle :: [CSS.Style]
+panelStyle =
+  [ CSS.width "100%"
+  , CSS.height "64px"
+  , CSS.flexShrink 0
+  , CSS.display "flex"
+  , CSS.alignItems "center"
+  , CSS.justifyContent "center"
+  , CSS.marginBottom "10px"
+  , CSS.borderRadius "10px"
+  ]
+
+btsIncrementButton :: View context Model Action
+btsIncrementButton =
+  view_
+    [ id_ "bts-increment"
+    , VE.onTap IncrementBTS
+    , CSS.style_ (panelStyle <> [CSS.backgroundColor CSS.steelblue])
+    ]
+    [ label "tap: BTS increment + declarative rerender" ]
+
+dynamicSection :: Bool -> View context Model Action
+dynamicSection visible =
+  view_
+    [ id_ "dynamic-section"
+    , CSS.style_
+      [ CSS.width "100%"
+      , CSS.flexShrink 0
+      , CSS.display "flex"
+      , CSS.flexDirection "column"
+      ]
+    ]
+    [ view_
+      [ id_ "dynamic-toggle"
+      , VE.onTap ToggleDynamic
+      , CSS.style_ (panelStyle <> [CSS.backgroundColor CSS.seagreen])
+      ]
+      [ label "tap: BTS remove/insert dynamic child" ]
+    , view_
+      [ id_ "dynamic-slot"
+      , CSS.style_
+        [ CSS.width "100%"
+        , CSS.height "52px"
+        , CSS.flexShrink 0
+        , CSS.marginBottom "10px"
+        ]
+      ]
+      (if visible then [dynamicChild] else [])
+    ]
+
+dynamicChild :: View context Model Action
+dynamicChild =
+  view_
+    [ id_ "dynamic-child"
+    , CSS.style_
+      [ CSS.width "100%"
+      , CSS.height "52px"
+      , CSS.display "flex"
+      , CSS.alignItems "center"
+      , CSS.justifyContent "center"
+      , CSS.backgroundColor CSS.darkslategray
+      , CSS.borderRadius "10px"
+      ]
+    ]
+    [ label "dynamic child is mounted" ]
+
+mtsPaintSection :: View context Model Action
+mtsPaintSection =
+  view_
+    [ id_ "mts-paint-shell"
+    , CSS.style_ (panelStyle <> [CSS.backgroundColor (CSS.RGB 51 65 85)])
+    ]
+    [ view_
+      [ id_ "mts-paint"
+      , event (static (VE.onTapMainWith PaintMTS))
+      , CSS.style_
+        [ CSS.width "94%"
+        , CSS.height "48px"
+        , CSS.display "flex"
+        , CSS.alignItems "center"
+        , CSS.justifyContent "center"
+        , CSS.borderRadius "8px"
+        ]
+      ]
+      [ label "tap: MTS-only background-color" ]
+    ]
+
+mtsReadSection :: View context Model Action
+mtsReadSection =
+  view_
+    [ id_ "mts-read-shell"
+    , CSS.style_ (panelStyle <> [CSS.backgroundColor CSS.mediumpurple])
+    ]
+    [ view_
+      [ id_ "mts-read"
+      , event (static
+          (onMain "tap" emptyDecoder
+            (\() m domRef -> ReadMTS domRef (probeCount m))))
+      , CSS.style_
+        [ CSS.width "94%"
+        , CSS.height "48px"
+        , CSS.display "flex"
+        , CSS.alignItems "center"
+        , CSS.justifyContent "center"
+        ]
+      ]
+      [ label "tap: MTS reads hydrated BTS count" ]
+    ]
+
+label :: MisoString -> View context model action
+label value =
+  text_
+    [ CSS.style_
+      [ CSS.fontSize "15px"
+      , CSS.fontWeight "600"
+      , CSS.color CSS.white
+      , lineHeight
+      ]
+    ]
+    [ text value ]
+-----------------------------------------------------------------------------
+data ChildProps = ChildProps
+  { parentCount :: Int
+  } deriving stock (Eq, Generic)
+    deriving anyclass (ToJSON, FromJSON)
+
+data ChildModel = ChildModel
+  { childCount :: Int
+  } deriving stock (Eq, Generic)
+    deriving anyclass (ToJSON, FromJSON)
+
+data ChildAction = IncrementChild
+  deriving stock (Generic)
+  deriving anyclass (ToJSON, FromJSON)
+
+childComponent :: Component () ChildProps ChildModel ChildAction
+childComponent = component (ChildModel 0) childUpdate childView
+
+childUpdate :: ChildAction -> Effect () ChildProps ChildModel ChildAction
+childUpdate IncrementChild =
+  modify $ \m -> m { childCount = childCount m + 1 }
+
+childView :: () -> ChildProps -> ChildModel -> View () ChildModel ChildAction
+childView _ ChildProps{..} ChildModel{..} =
+  view_
+    [ id_ "child-button"
+    , VE.onTap IncrementChild
+    , CSS.style_ (panelStyle <> [CSS.backgroundColor CSS.indigo])
+    ]
+    [ text_
+      [ id_ "child-status"
+      , CSS.style_
+        [ CSS.fontSize "15px"
+        , CSS.fontWeight "600"
+        , CSS.color CSS.white
+        , lineHeight
+        ]
+      ]
+      [ text (ms
+          ( "tap child: parentCount=" <> show parentCount
+         <> " childCount=" <> show childCount
+          ))
+      ]
+    ]
+
+childSection :: Int -> View () Model Action
+childSection count =
+  view_
+    [ id_ "child-slot"
+    , CSS.style_
+      [ CSS.width "100%"
+      , CSS.flexShrink 0
+      ]
+    ]
+    [ vcomp (ChildProps count) (static (mountStaticWithProps childComponent)) ]
+
+opacityForCount :: Int -> MisoString
+opacityForCount n =
+  ms (show (max 0.35 (min 1 (0.35 + fromIntegral n * 0.13)) :: Double))
+-----------------------------------------------------------------------------

--- a/sample-app-native/Conformance.hs
+++ b/sample-app-native/Conformance.hs
@@ -163,7 +163,7 @@ dynamicSection visible =
         , CSS.marginBottom "10px"
         ]
       ]
-      (if visible then [dynamicChild] else [])
+      [ dynamicChild | visible ]
     ]
 
 dynamicChild :: View context Model Action

--- a/sample-app-native/README.md
+++ b/sample-app-native/README.md
@@ -1,0 +1,20 @@
+# Miso Native Lynx samples
+
+This package builds two executables with different purposes:
+
+- `app-native` is the feature gallery. Build it with
+  `nix build .#sample-app-native-bundle`.
+- `app-native-conformance` is a deterministic, core-elements-only dual-thread
+  fixture. Build it with
+  `nix build .#sample-app-native-conformance-bundle`.
+
+The conformance fixture keeps stable element IDs for first paint, a BTS event
+and declarative update, dynamic subtree removal/reinsertion, MTS-only style
+mutation, MTS hydrated-state access, and nested component state. It stays
+separate from the gallery so an unavailable optional native behavior cannot
+truncate the tree before these runtime invariants execute.
+
+Both bundle derivations produce `main.lynx.bundle` and
+`main.lynx.bundle.sha256`. To run either with the Android host, copy both files
+from the same derivation into `android/app/src/main/assets/`; the Gradle
+`preBuild` gate rejects a missing or mismatched pair.

--- a/sample-app-native/android/README.md
+++ b/sample-app-native/android/README.md
@@ -6,9 +6,9 @@ host. Modeled on the official
 `KotlinEmptyProject`. **Host-only — no native modules** (add a `LynxModule` +
 `SharedPreferences` later if you want the `Miso.Storage` bridge).
 
-> Status: hand-authored integration files. This is **not verified to build** in
-> this repo's CI — it needs the Android toolchain. Generate the Gradle wrapper
-> and open in Android Studio to complete/run it.
+The Nix Android build and CI both inject the generated bundle; the repository
+does not carry a prebuilt binary. A direct Gradle build verifies the generated
+SHA-256 sidecar and fails before packaging if the bundle is missing or stale.
 
 ## What's here
 ```
@@ -22,19 +22,16 @@ app/src/main/java/io/dmj/miso/
   MisoApplication.kt                        # LynxEnv.init + service registration
   MainActivity.kt                           # LynxView + renderTemplateUrl
   MisoTemplateProvider.kt                   # loads bundle from assets/
-app/src/main/assets/main.lynx.bundle        # <-- copy the built bundle here
+app/src/main/assets/main.lynx.bundle        # generated, ignored by Git
+app/src/main/assets/main.lynx.bundle.sha256 # generated provenance sidecar
 ```
 
-## Still needed (one-time, IDE-generated)
-- **Gradle wrapper jar + scripts** (`gradle/wrapper/gradle-wrapper.jar`,
-  `gradlew`, `gradlew.bat`) — binary, not checked in here. Android Studio
-  generates them on first sync, or run `gradle wrapper --gradle-version 8.7`.
-- an app icon / theme if you want more than a bare activity.
-
 ## Build & run
-1. Build the bundle: `bun run js && nix-build -A sample-app-native-bundle`
-2. Copy it into **assets/** (not the module root):
-   `mkdir -p app/src/main/assets && cp result/main.lynx.bundle app/src/main/assets/`
+1. Preferred reproducible build: `nix-build -A sample-app-native-android`.
+2. For a direct Gradle/Android Studio build, first run
+   `nix-build -A sample-app-native-bundle`, then copy both
+   `result/main.lynx.bundle` and `result/main.lynx.bundle.sha256` into
+   `app/src/main/assets/`.
 3. Open `sample-app-native/android` in Android Studio → **Sync** (it downloads
    Gradle 8.7 and the `com.android.application` plugin from the repos in
    `settings.gradle.kts`) → run on a device/emulator (minSdk 24).

--- a/sample-app-native/android/app/build.gradle.kts
+++ b/sample-app-native/android/app/build.gradle.kts
@@ -1,3 +1,5 @@
+import java.security.MessageDigest
+
 // Android host for the miso-native Lynx bundle. Versions/artifacts mirror the
 // official lynx-family integrating-lynx-demo-projects KotlinEmptyProject
 // (Lynx SDK 3.8.0). Native modules are intentionally omitted — this host only
@@ -61,4 +63,26 @@ dependencies {
   implementation("org.lynxsdk.lynx:xelement-svg:3.8.0")
   implementation("org.lynxsdk.lynx:servalsvg:0.0.1-alpha.3")
   implementation("org.lynxsdk.lynx:xelement-refresh:3.8.0")
+}
+
+val lynxBundle = layout.projectDirectory.file("src/main/assets/main.lynx.bundle").asFile
+val lynxBundleChecksum =
+  layout.projectDirectory.file("src/main/assets/main.lynx.bundle.sha256").asFile
+
+tasks.named("preBuild").configure {
+  doFirst {
+    check(lynxBundle.isFile && lynxBundleChecksum.isFile) {
+      "Missing generated Lynx bundle/checksum. Build with " +
+        "`nix-build -A sample-app-native-android`, or copy both files from " +
+        "`nix-build -A sample-app-native-bundle`."
+    }
+    val expected = lynxBundleChecksum.readText().trim().substringBefore(' ')
+    val actual = MessageDigest.getInstance("SHA-256")
+      .digest(lynxBundle.readBytes())
+      .joinToString("") { "%02x".format(it) }
+    check(expected == actual) {
+      "Stale main.lynx.bundle: expected SHA-256 $expected, got $actual. " +
+        "Copy the bundle and checksum from the same generated artifact."
+    }
+  }
 }

--- a/sample-app-native/app.cabal
+++ b/sample-app-native/app.cabal
@@ -22,3 +22,15 @@ executable app-native
     base, miso
   default-language:
     Haskell2010
+
+-- Core-elements-only dual-thread conformance fixture. Keep this separate from
+-- the gallery so optional host behaviors cannot hide runtime regressions.
+executable app-native-conformance
+  import:
+    options
+  main-is:
+    Conformance.hs
+  build-depends:
+    base, miso
+  default-language:
+    Haskell2010

--- a/sample-app-native/conformance.css
+++ b/sample-app-native/conformance.css
@@ -1,0 +1,4 @@
+/* Keep the native page behind the core-only fixture deterministic. */
+page {
+  background-color: #0f172a;
+}


### PR DESCRIPTION
## Summary

This is the reviewable foundation layer for Miso Native after #1562 landed on `master`. It intentionally contains no initial-frame reconciliation or MTS architecture policy.

- isolate Nix package source inputs so generated and untracked artifacts cannot silently enter builds
- generate the Lynx bundle and checksum from the exact source closure used by the build
- add a small native dual-thread conformance fixture that exercises the main/background split

## Review shape

- Base: merged `master` at `e92e444d` (#1562)
- This PR: three foundation/provenance commits, `e92e444d..f123259f`
- Sibling: #1578 — IFR reconciliation, now independently based on `master`
- RFC: #1579 — Option A remains primary; B/B+/C remain experimental

#1578 no longer includes this PR's commits, so the two implementation diffs can be reviewed and landed independently.

## Validation

- TypeScript library and spec typechecks
- Bun baseline: 391 tests, 8,220 assertions
- Nix `sample-app-native-conformance-bundle` build
- generated bundle provenance/checksum verification
- rebase onto merged `master`: clean three-commit replay and `git diff --check`

GitHub Actions are rerunning on the rebased head.

— Posted by Codex, acting as @Huxpro's agent.
