### PR TITLE
fix: reset pendingStaticKey/pendingMainThread before plain On handlers

### DIFF
--- a/src/Miso/Runtime.hs
+++ b/src/Miso/Runtime.hs
@@ -1271,7 +1271,13 @@ setAttrs vnode_@(Object jval) attrs snk vcompId logLevel events model_ = do
       o <- getProp "props" vnode_
       FFI.set k value (Object o)
     On callback -> do
+      -- Reset any 'pendingStaticKey' \/ 'pendingMainThread' left behind by an
+      -- earlier 'OnStatic' attribute on this same node — otherwise a plain
+      -- 'On' handler processed after an 'OnStatic' one would inherit its
+      -- sibling's stale main-thread flag and staticKey (see 'onWithOptions').
       FFI.set "pendingComponentId" vcompId vnode_
+      FFI.set "pendingStaticKey" jsNull vnode_
+      FFI.set "pendingMainThread" False vnode_
       callback model_ snk (VTree vnode_) logLevel events
     OnStatic ptr ->
       -- Stash the handler's 'StaticKey' and owning 'ComponentId' on the node

--- a/tests/app/Main.hs
+++ b/tests/app/Main.hs
@@ -1670,7 +1670,6 @@ main = withJS $ do
             div_ [] (replicate 999 (mount_ testComponent))) :: Component () () Int ())
         mountedComponents >>= (`shouldBe` 1000)
 
-#ifndef GHCJS_OLD
       it "On after OnStatic on the same node must not inherit a stale staticKey" $ do
         -- Regression for: an 'OnStatic' handler stashes 'pendingStaticKey' /
         -- 'pendingMainThread' on the shared vnode object so 'onWithOptions'
@@ -1698,7 +1697,6 @@ main = withJS $ do
         clickStaticKey <- liftIO (clickHandler ! "staticKey")
         clickStaticKeyUndefined <- liftIO (isUndefined clickStaticKey)
         clickStaticKeyUndefined `shouldBe` False
-#endif
 
     describe "Miso.DSL `await` tests" $ do
       it "Successful Promise resolution should result in a value" $ do

--- a/tests/app/Main.hs
+++ b/tests/app/Main.hs
@@ -1686,8 +1686,9 @@ main = withJS $ do
               []
         ComponentState {..} <- liftIO $ (IM.! 1) <$> readIORef components
         VTree (Object ref) <- liftIO (readIORef _componentVTree)
-        childRef <- liftIO (ref ! "children" !! 0)
-        eventsObj <- liftIO (childRef ! "events")
+        -- Both handlers live on the root 'div_', which has no children, so
+        -- inspect the root node's events directly.
+        eventsObj <- liftIO (ref ! "events")
         bubbles <- liftIO (eventsObj ! "bubbles")
         mouseoverHandler <- liftIO (bubbles ! "mouseover")
         mouseoverStaticKey <- liftIO (mouseoverHandler ! "staticKey")

--- a/tests/app/Main.hs
+++ b/tests/app/Main.hs
@@ -1670,6 +1670,33 @@ main = withJS $ do
             div_ [] (replicate 999 (mount_ testComponent))) :: Component () () Int ())
         mountedComponents >>= (`shouldBe` 1000)
 
+      it "On after OnStatic on the same node must not inherit a stale staticKey" $ do
+        -- Regression for: an 'OnStatic' handler stashes 'pendingStaticKey' /
+        -- 'pendingMainThread' on the shared vnode object so 'onWithOptions'
+        -- can read them back; a later plain 'On' handler on the *same* node
+        -- used to inherit those leftovers instead of getting its own fresh
+        -- (unset) values.
+        liftIO $ startApp mempty $
+          component (0 :: Int) noop $ \_ _ _ ->
+            div_
+              [ event (static (onMain "click" emptyDecoder (\() _ _ -> AddOne)))
+              , on "mouseover" emptyDecoder (\() _ _ -> AddOne)
+              ]
+              []
+        ComponentState {..} <- liftIO $ (IM.! 1) <$> readIORef components
+        VTree (Object ref) <- liftIO (readIORef _componentVTree)
+        childRef <- liftIO (ref ! "children" !! 0)
+        eventsObj <- liftIO (childRef ! "events")
+        bubbles <- liftIO (eventsObj ! "bubbles")
+        mouseoverHandler <- liftIO (bubbles ! "mouseover")
+        mouseoverStaticKey <- liftIO (mouseoverHandler ! "staticKey")
+        mouseoverStaticKeyUndefined <- liftIO (isUndefined mouseoverStaticKey)
+        mouseoverStaticKeyUndefined `shouldBe` True
+        clickHandler <- liftIO (bubbles ! "click")
+        clickStaticKey <- liftIO (clickHandler ! "staticKey")
+        clickStaticKeyUndefined <- liftIO (isUndefined clickStaticKey)
+        clickStaticKeyUndefined `shouldBe` False
+
     describe "Miso.DSL `await` tests" $ do
       it "Successful Promise resolution should result in a value" $ do
         -- Create a Promise and immediately resolve it with `42`

--- a/tests/app/Main.hs
+++ b/tests/app/Main.hs
@@ -1670,6 +1670,7 @@ main = withJS $ do
             div_ [] (replicate 999 (mount_ testComponent))) :: Component () () Int ())
         mountedComponents >>= (`shouldBe` 1000)
 
+#ifndef GHCJS_OLD
       it "On after OnStatic on the same node must not inherit a stale staticKey" $ do
         -- Regression for: an 'OnStatic' handler stashes 'pendingStaticKey' /
         -- 'pendingMainThread' on the shared vnode object so 'onWithOptions'
@@ -1696,6 +1697,7 @@ main = withJS $ do
         clickStaticKey <- liftIO (clickHandler ! "staticKey")
         clickStaticKeyUndefined <- liftIO (isUndefined clickStaticKey)
         clickStaticKeyUndefined `shouldBe` False
+#endif
 
     describe "Miso.DSL `await` tests" $ do
       it "Successful Promise resolution should result in a value" $ do


### PR DESCRIPTION
### Summary

A plain `On` attribute processed after an `OnStatic` sibling on the same node inherited the `OnStatic` handler's leftover `pendingMainThread` / `pendingStaticKey`, causing `onWithOptions` to incorrectly tag the plain handler for native main-thread dispatch with a stale `staticKey`.