### PR TITLE
refactor: drop unused `ToJSON`/`FromJSON` context constraints

### DIFF
--- a/src/Miso.hs
+++ b/src/Miso.hs
@@ -1916,7 +1916,7 @@ startApp events comp_ = initComponent events Draw False () comp_ Nothing () Noth
 -- @since 1.9.0.0
 startAppWithContext
 #ifdef NATIVE
-  :: (Eq model, ToJSON model, ToJSON action, FromJSON model, FromJSON action, FromJSON context, ToJSON context, Eq context)
+  :: (Eq model, ToJSON model, ToJSON action, FromJSON model, FromJSON action, Eq context)
 #else
   :: (Eq model, Eq context)
 #endif

--- a/src/Miso/Native.hs
+++ b/src/Miso/Native.hs
@@ -401,7 +401,6 @@ module Miso.Native
 import Miso.Runtime (initComponent)
 import Miso.Types (Events, SomeStaticComponent(..), SomeComponent(..), Hydrate(..))
 import Miso.Types (mountStatic_, mountStaticWithProps, mountStaticUseContext)
-import Miso.JSON (ToJSON, FromJSON)
 -----------------------------------------------------------------------------
 import Miso.Native.Element
 import Miso.Native.FFI
@@ -447,7 +446,7 @@ native events ptr =
 -- @
 --
 nativeWithContext
-  :: (ToJSON context, FromJSON context, Eq context)
+  :: Eq context
   => Events
   -> context
   -> StaticPtr (SomeStaticComponent () context)

--- a/src/Miso/Reload.hs
+++ b/src/Miso/Reload.hs
@@ -145,7 +145,7 @@ reload events = reloadWithContext events ()
 -- @since 1.12.0.0
 reloadWithContext
 #ifdef NATIVE
-  :: (FromJSON action, ToJSON model, ToJSON context, FromJSON context, Eq context, Eq model, ToJSON action)
+  :: (FromJSON action, ToJSON model, Eq context, Eq model, ToJSON action)
 #else
   :: (Eq context, Eq model)
 #endif
@@ -216,7 +216,7 @@ live events vcomp_ = liveWithContext events () vcomp_
 -- @since 1.12.0.0
 liveWithContext
 #ifdef NATIVE
-  :: (Eq context, Eq model, ToJSON model, ToJSON context, ToJSON action, FromJSON context, FromJSON action)
+  :: (Eq context, Eq model, ToJSON model, ToJSON action, FromJSON action)
 #else
   :: (Eq context, Eq model)
 #endif

--- a/src/Miso/Types.hs
+++ b/src/Miso/Types.hs
@@ -451,7 +451,7 @@ data View context model action
 -- nested t'Miso.Types.Component' participates in the same app-global context.
 data SomeComponent context
 #ifdef NATIVE
-   = forall model action props . (FromJSON model, ToJSON model, FromJSON action, ToJSON action, FromJSON props, ToJSON props, FromJSON context, ToJSON context, Eq context, Eq model, Eq props)
+   = forall model action props . (FromJSON model, ToJSON model, FromJSON action, ToJSON action, FromJSON props, ToJSON props, Eq context, Eq model, Eq props)
 #else
    = forall model action props . (Eq context, Eq model, Eq props)
 #endif
@@ -536,7 +536,7 @@ fragment_ key = VFrag (Just (Key key))
 (+>)
   :: forall context childModel childAction model action .
 #ifdef NATIVE
-     (Eq context, Eq childModel, FromJSON childModel, ToJSON childModel, FromJSON childAction, ToJSON childAction, FromJSON context, ToJSON context)
+     (Eq context, Eq childModel, FromJSON childModel, ToJSON childModel, FromJSON childAction, ToJSON childAction)
 #else
      (Eq context, Eq childModel)
 #endif
@@ -572,7 +572,7 @@ key +> child = VComp (SomeComponent (Just (toKey key)) () child)
 -- @since 1.11.0.0
 mountStaticWithProps
 #ifdef NATIVE
-  :: (Eq context, Eq props, Eq model, FromJSON model, ToJSON model, FromJSON action, ToJSON action, FromJSON props, ToJSON props, FromJSON context, ToJSON context)
+  :: (Eq context, Eq props, Eq model, FromJSON model, ToJSON model, FromJSON action, ToJSON action, FromJSON props, ToJSON props)
 #else
   :: (Eq context, Eq props, Eq model)
 #endif
@@ -592,7 +592,7 @@ mountStaticWithProps child = SomeStaticComponent (\props -> SomeComponent Nothin
 mountWithProps
   :: forall context props childModel childAction model action .
 #ifdef NATIVE
-     (Eq context, Eq props, Eq childModel, FromJSON childModel, ToJSON childModel, FromJSON childAction, ToJSON childAction, FromJSON props, ToJSON props, FromJSON context, ToJSON context)
+     (Eq context, Eq props, Eq childModel, FromJSON childModel, ToJSON childModel, FromJSON childAction, ToJSON childAction, FromJSON props, ToJSON props)
 #else
      (Eq context, Eq props, Eq childModel)
 #endif
@@ -618,7 +618,7 @@ mountWithProps props comp = VComp (SomeComponent Nothing props comp)
 mountWithProps_
   :: forall context props childModel childAction model action .
 #ifdef NATIVE
-     (Eq context, Eq props, Eq childModel, FromJSON childAction, FromJSON childModel, ToJSON childModel, ToJSON childAction, FromJSON props, ToJSON props, FromJSON context, ToJSON context)
+     (Eq context, Eq props, Eq childModel, FromJSON childAction, FromJSON childModel, ToJSON childModel, ToJSON childAction, FromJSON props, ToJSON props)
 #else
      (Eq context, Eq childModel, Eq props)
 #endif
@@ -646,7 +646,7 @@ mountWithProps_ key props child = VComp (SomeComponent (Just (Key key)) props ch
 -- @since 1.9.0.0
 mountStatic_
 #ifdef NATIVE
-  :: (Eq context, Eq model, FromJSON model, ToJSON model, FromJSON action, ToJSON action, FromJSON context, ToJSON context)
+  :: (Eq context, Eq model, FromJSON model, ToJSON model, FromJSON action, ToJSON action)
 #else
   :: (Eq context, Eq model)
 #endif
@@ -677,7 +677,7 @@ mountStatic_ child = SomeStaticComponent (const (SomeComponent Nothing () child)
 mount_
   :: forall context childModel childAction model action .
 #ifdef NATIVE
-     (Eq context, Eq childModel, FromJSON childModel, ToJSON childModel, FromJSON childAction, ToJSON childAction, FromJSON context, ToJSON context)
+     (Eq context, Eq childModel, FromJSON childModel, ToJSON childModel, FromJSON childAction, ToJSON childAction)
 #else
      (Eq context, Eq childModel)
 #endif
@@ -735,7 +735,7 @@ vcomp_ = vcomp ()
 -- @since 1.12.0.0
 mountStaticUseContext
 #ifdef NATIVE
-  :: (Eq context, Eq model, FromJSON model, ToJSON model, FromJSON action, ToJSON action, FromJSON context, ToJSON context)
+  :: (Eq context, Eq model, FromJSON model, ToJSON model, FromJSON action, ToJSON action)
 #else
   :: (Eq context, Eq model)
 #endif
@@ -769,7 +769,7 @@ mountStaticUseContext child =
 mountUseContext
   :: forall context childModel childAction model action .
 #ifdef NATIVE
-     (Eq context, Eq childModel, FromJSON childModel, ToJSON childModel, FromJSON childAction, ToJSON childAction, FromJSON context, ToJSON context)
+     (Eq context, Eq childModel, FromJSON childModel, ToJSON childModel, FromJSON childAction, ToJSON childAction)
 #else
      (Eq context, Eq childModel)
 #endif


### PR DESCRIPTION
Now that `context` is not transferred cross thread we can drop the `ToJSON` / `FromJSON` constraints when compiling w/ `-fnative`

- [x] Drop `ToJSON` / `FromJSON` constraints when compiling cross thread