### PR TITLE
fix: error on missing `domRef` in `MOUNT` instead of synthesizing a fake parent node

### DIFF
--- a/src/Miso/Runtime.hs
+++ b/src/Miso/Runtime.hs
@@ -308,8 +308,7 @@ initialize events _componentParentId hydrate isRoot initialProps maybeKey _compo
   -- create-patches (deterministic nodeId parity keeps both trees addressable) —
   -- both governed by the global 'initialDraw' latch in the drawing contexts,
   -- which 'initComponent' clears ONCE the whole root mount finishes (see the note
-  -- there). Flipping it per 'flush' tripped on the first nested child mount and
-  -- leaked the rest of the initial frame as patches, doubling the MTS's paint.
+  -- there).
   initialDraw initializedModel events hydrate isRoot comp vcomponent
   forM_ mount _componentSink
 #ifdef NATIVE
@@ -2286,19 +2285,27 @@ componentListener Proxy (BTS ctx) = void $ do
                         -- which the MTS learns about solely through this message.
                         IM.member componentComponentId <$> readIORef components >>= \case
                           True -> pure ()
-                          False -> do
-                            -- The BTS ships its @{ nodeId }@ 'DOMRef'; resolve it to the real
-                            -- native element via @globalThis.runtime.nodes[nodeId]@ so the MTS
-                            -- 'ComponentInfo' Reader ('componentInfoDOMRef') holds a live ref.
-                            parent_ <- maybe (unObject <$> create) resolveNodeRef componentComponentDOMRef
-                            -- Recover the child's initial @props@ from the wire (the BTS ships
-                            -- them on 'MOUNT'), decoded at the @props@ type recovered above.
-                            case componentComponentPayload of
-                              Just pv | Success initProps <- (fromJSON pv :: Result props) ->
-                                void $ initialize mempty componentComponentId Draw False initProps
-                                  Nothing (Just (staticKey ptr)) comp_ (pure parent_)
-                              _ ->
-                                FFI.consoleError "[COMPONENT]: MOUNT missing/invalid props payload"
+                          False ->
+                            -- The BTS always ships its @{ nodeId }@ 'DOMRef' alongside 'MOUNT'
+                            -- (see 'postComponent' MOUNT); 'Nothing' here means the wire
+                            -- invariant broke, so error out rather than silently mounting
+                            -- against a bogus synthesized parent.
+                            case componentComponentDOMRef of
+                              Nothing ->
+                                FFI.consoleError "[COMPONENT]: MOUNT missing domRef payload"
+                              Just domRef -> do
+                                -- Resolve the shipped 'DOMRef' to the real native element via
+                                -- @globalThis.runtime.nodes[nodeId]@ so the MTS 'ComponentInfo'
+                                -- Reader ('componentInfoDOMRef') holds a live ref.
+                                parent_ <- resolveNodeRef domRef
+                                -- Recover the child's initial @props@ from the wire (the BTS ships
+                                -- them on 'MOUNT'), decoded at the @props@ type recovered above.
+                                case componentComponentPayload of
+                                  Just pv | Success initProps <- (fromJSON pv :: Result props) ->
+                                    void $ initialize mempty componentComponentId Draw False initProps
+                                      Nothing (Just (staticKey ptr)) comp_ (pure parent_)
+                                  _ ->
+                                    FFI.consoleError "[COMPONENT]: MOUNT missing/invalid props payload"
                       UNMOUNT ->
                         IM.lookup componentComponentId <$> readIORef components >>= \case
                           Nothing ->


### PR DESCRIPTION
## Summary

- In `componentListener`'s `MOUNT` handler, `componentComponentDOMRef` (the BTS-shipped mount point for the mirrored MTS component) was resolved with `maybe (unObject <$> create) resolveNodeRef componentComponentDOMRef`, which silently synthesized an empty object as the parent node whenever the `DOMRef` was `Nothing`.
- The only caller that posts `MOUNT` (`postComponent MOUNT ...`) always supplies `Just _componentDOMRef`, so `Nothing` here means the wire invariant broke — not a valid, expected case.
- Silently falling back to a synthesized empty object would mount the child against a bogus parent with no visible failure signal.
- Changed the `Nothing` case to `FFI.consoleError "[COMPONENT]: MOUNT missing domRef payload"` and bail, matching the existing sibling error handling for the missing/invalid `props` payload case just below it.
- Also dropped a stale comment referencing a since-removed `initialDraw`/`flush`-per-mount approach that no longer reflects the current implementation.

## Test plan

- [x] `cabal build lib:miso --flags=native` — builds clean