### PR TITLE
perf: dispatch main-thread events directly, no scratch-node/JS round-trip

### DIFF
--- a/src/Miso/Event.hs
+++ b/src/Miso/Event.hs
@@ -144,13 +144,17 @@ onMainWithOptions
   -- ^ Converts the decoded payload and the element's DOM reference to an @action@
   -> EventHandler model action
 onMainWithOptions phase opts name decoder conversion =
-  EventHandler $ \m snk tree ll events -> do
-    case onWithOptions phase opts name decoder conversion of
-      On cb -> do
-        FFI.set "pendingMainThread" True =<< toObject tree
-        cb m snk tree ll events
-      _ ->
-        error "onMainWithOptions: impossible"
+  EventHandler
+    { eventHandlerInstall = \m snk tree ll events ->
+        case onWithOptions phase opts name decoder conversion of
+          On cb -> do
+            FFI.set "pendingMainThread" True =<< toObject tree
+            cb m snk tree ll events
+          _ ->
+            error "onMainWithOptions: impossible"
+    , eventHandlerDecoder = decoder
+    , eventHandlerConvert = conversion
+    }
 -----------------------------------------------------------------------------
 -- | Attach an event handler with explicit phase and propagation options.
 --

--- a/src/Miso/Runtime.hs
+++ b/src/Miso/Runtime.hs
@@ -129,7 +129,8 @@ import           Control.Exception (SomeException, catch)
 import           Control.Monad (forM, forM_, when, void, (<=<), zipWithM_, forever, foldM, unless)
 import           Control.Monad.Reader (ask, asks)
 import           Control.Monad.State hiding (state)
-import           Miso.JSON (FromJSON, ToJSON, Result(..), Value, encode, fromJSON, jsonStringify, toJSON)
+import           Miso.JSON (FromJSON, ToJSON, Result(..), Value, encode, fromJSON, jsonStringify, toJSON, parseEither)
+import           Miso.Event.Decoder (Decoder(decoder, decodeAt))
 
 #if __GLASGOW_HASKELL__ < 910
 import           Data.Foldable (foldl')
@@ -1287,11 +1288,11 @@ setAttrs vnode_@(Object jval) attrs snk vcompId logLevel events model_ = do
       -- 'False'; 'Miso.Event.mainThread' (part of @callback@) flips it 'True'
       -- so only marked handlers opt in.
       case deRefStaticPtr ptr of
-        EventHandler callback -> do
+        EventHandler {..} -> do
           FFI.set "pendingStaticKey" (staticKey ptr) vnode_
           FFI.set "pendingComponentId" vcompId vnode_
           FFI.set "pendingMainThread" False vnode_
-          callback model_ snk (VTree vnode_) logLevel events
+          eventHandlerInstall model_ snk (VTree vnode_) logLevel events
     Styles styles -> do
       cssObj <- getProp "css" vnode_
       forM_ (M.toList styles) $ \(k,v) -> do
@@ -2348,7 +2349,6 @@ dispatchMainThreadEvent arg =
     skHex     <- fromJSValUnchecked =<< o ! "staticKey"   :: IO MisoString
     eventVal  <- o ! "event"
     targetVal <- o ! "target"
-    eventName <- fromJSValUnchecked =<< Object eventVal ! "type" :: IO MisoString
     unsafeLookupStaticPtr (fromMisoString skHex) >>= \case
       Nothing ->
         FFI.consoleError ("[MTS dispatch] no handler for staticKey " <> skHex)
@@ -2358,41 +2358,26 @@ dispatchMainThreadEvent arg =
       -- MTS additionally requires the forwarded @pendingPayload@ decoded at the
       -- @payload@ type — see note below (not yet wired end-to-end).
       Just ehPtr -> case deRefStaticPtr ehPtr of
-        EventHandler cb -> do
+        EventHandler {..} -> do
           comps <- readIORef components
           case IM.lookup compId comps of
             Nothing ->
               FFI.consoleError ("[MTS dispatch] no component " <> ms (show compId))
             Just ComponentState {..} -> do
-              -- Run the handler with this component's sink to install its
-              -- 'runEvent' (decoder + sink) on a throwaway node, then fire it.
-              scratch <- createNode "vnode" HTML "div"
-              -- 'runEvent' re-reads the live model at fire time via
-              -- @pendingComponentId@ on its node (see 'onWithOptions'); stamp it on
-              -- the scratch node so that lookup resolves instead of throwing.
-              FFI.set "pendingComponentId" compId scratch
-              cb _componentModel _componentSink (VTree scratch) Off mempty
-              runner <- lookupEventRunner scratch eventName
-              forM_ runner $ \fn ->
-                void (call (Object fn) global [eventVal, targetVal])
-  where
-    -- Pull the installed 'runEvent' for @name@ out of the scratch node,
-    -- checking the capture phase then the bubble phase.
-    lookupEventRunner :: Object -> MisoString -> IO (Maybe JSVal)
-    lookupEventRunner scratch name = do
-      evs  <- getProp "events" scratch
-      caps <- getProp "captures" (Object evs)
-      capE <- Object caps ! name
-      capU <- isUndefined capE
-      entry <-
-        if not capU
-          then pure (Just capE)
-          else do
-            bubs <- getProp "bubbles" (Object evs)
-            bubE <- Object bubs ! name
-            bubU <- isUndefined bubE
-            pure (if bubU then Nothing else Just bubE)
-      traverse (\e -> Object e ! "runEvent") entry
+              -- Decode + dispatch directly from the captured 'Decoder' \/
+              -- convert pair — no JS installer round-trip (no scratch node,
+              -- no throwaway 'asyncCallback2') needed on this, the hot path
+              -- for every main-thread event.
+              decodeAtVal <- toJSVal (decodeAt eventHandlerDecoder)
+              mv <- fromJSVal =<< FFI.eventJSON decodeAtVal eventVal
+              case mv of
+                Nothing ->
+                  FFI.consoleError "[MTS dispatch] eventJSON returned no value"
+                Just v -> case parseEither (decoder eventHandlerDecoder) v of
+                  Left msg ->
+                    FFI.consoleError ("[MTS dispatch] decode error: " <> ms msg)
+                  Right result ->
+                    _componentSink (eventHandlerConvert result _componentModel targetVal)
 -----------------------------------------------------------------------------
 -- | Register 'dispatchMainThreadEvent' on @globalThis.runtime@ so the MTS
 -- delegator can invoke it synchronously. MTS only.

--- a/src/Miso/Types.hs
+++ b/src/Miso/Types.hs
@@ -227,6 +227,7 @@ import           Prelude
 import           Miso.DSL
 import           Miso.Effect (Effect, Sub, Sink, DOMRef, ComponentId)
 import           Miso.Event.Types
+import qualified Miso.Event.Decoder
 import           Miso.JSON (Value, ToJSON(..), encode)
 #ifdef NATIVE
 import           Miso.JSON (FromJSON(..))
@@ -845,8 +846,23 @@ instance ToKey Float where toKey = Key . toMisoString
 -- | Convert 'Word' to t'Key'
 instance ToKey Word where toKey = Key . toMisoString
 -----------------------------------------------------------------------------
--- | Wrapper for event handler callbacks, used for cross-thread communication
-newtype EventHandler model action = EventHandler (model -> Sink action -> VTree -> LogLevel -> Events -> IO ())
+-- | Wrapper for event handler callbacks, used for cross-thread communication.
+--
+-- Carries two independent things built from the same @(decoder, convert)@
+-- pair:
+--
+-- * 'eventHandlerInstall' — attaches a real JS listener to a live vnode.
+--   Used by 'Miso.Runtime.setAttrs' during diffing, on both threads.
+-- * 'eventHandlerDecoder' \/ 'eventHandlerConvert' — the decode step exposed
+--   directly, with no JS installer round-trip. Used by the MTS's
+--   @dispatchMainThreadEvent@ to decode + dispatch a main-thread event
+--   synchronously, without reconstructing (and discarding) a JS callback via
+--   a throwaway scratch node on every single event.
+data EventHandler model action = forall result. EventHandler
+  { eventHandlerInstall :: model -> Sink action -> VTree -> LogLevel -> Events -> IO ()
+  , eventHandlerDecoder :: Miso.Event.Decoder.Decoder result
+  , eventHandlerConvert :: result -> model -> DOMRef -> action
+  }
 -----------------------------------------------------------------------------
 -- | Embed a fully-applied @static@ event handler.
 --


### PR DESCRIPTION
## Summary

`dispatchMainThreadEvent` (the MTS entry point for every main-thread — `OnStatic`/`onMain` — event) previously reconstructed a JS callback from scratch on *every single dispatch* instead of decoding and dispatching directly. This PR removes that indirection.

### Before

For each main-thread event, `dispatchMainThreadEvent` (`Runtime.hs`) would:
- allocate a throwaway scratch DOM node (`createNode`)
- stamp `pendingComponentId` onto it
- re-run the handler's installer closure, which wraps a **brand-new** `asyncCallback2` JS function and attaches it to the scratch node's `events` object
- look the freshly-installed `runEvent` callback back up off the node by event name (checking capture then bubble phase)
- invoke it via a JS `call (...) global [eventVal, targetVal]` round-trip

All of that just to re-derive the `(Decoder, toAction)` pair that was already known at the call site — it was thrown away every time only to be rebuilt.

### After

- `EventHandler` (`Types.hs`) now carries the decoder/convert pair directly, alongside the existing installer closure:
  - `eventHandlerInstall` — the original `model -> Sink action -> VTree -> LogLevel -> Events -> IO ()` closure, **unchanged**, still used by `setAttrs`'s `OnStatic` branch to attach a real JS listener during diffing (needed on both BTS and MTS's own initial-frame paint).
  - `eventHandlerDecoder` / `eventHandlerConvert` — the `Decoder result` and `result -> model -> DOMRef -> action` captured directly from `onMainWithOptions`'s arguments (existentially quantified over `result`, since `EventHandler` has no `result` type parameter).
- `onMainWithOptions` (`Event.hs`) is the only construction site for `EventHandler` — every `*Main` / `*MainWith` combinator across all the Native element modules (`ScrollView`, `View`, `Input`, `Image`, `List`, `Text`, `Frame`, `Webview`, `Overlay`, `Refresh`, `Viewpager`, `ScrollCoordinator`, `Svg`) already delegates through it, so it's the single call site that needed updating.
- `dispatchMainThreadEvent` now decodes the event directly via `eventHandlerDecoder`'s `decoder` / `decodeAt` (mirroring the exact decode step `onWithOptions` itself uses) and dispatches via `eventHandlerConvert` + `_componentSink`, entirely in Haskell, in place — no scratch node, no throwaway JS callback, no JS `call` round-trip.
- `setAttrs`'s `OnStatic` branch (`Runtime.hs`) updated to call `eventHandlerInstall` instead of pattern-matching a single-field constructor; behavior there is unchanged.

### API surface

No public API changes. `on`, `onMain`, `onClick`, `event`, and every `*MainWith` combinator keep identical types/signatures. The change is confined to `EventHandler`'s internal representation (still exported with `(..)`, but never constructed/destructed outside the library).

## Test plan

- [x] `cabal build lib:miso --flags=native` — full library (136 modules) builds clean
- [x] `cabal build lib:miso` (non-native) — builds clean
- [x] `cabal build app-native app-native-conformance` — both sample-app-native executables, which exercise `onMain` / `event (static (mainThread ...))` / `*MainWith` handlers, build and link cleanly