### PR TITLE
docs: fix `t'` namespace prefixes that Haddock renders as literal text

### DIFF
--- a/src/Miso.hs
+++ b/src/Miso.hs
@@ -554,7 +554,7 @@
 -- recurses into nested fragments and processes all fragments as if they were
 -- a flat sequence of sibling DOM nodes, so nesting carries no runtime cost beyond the extra 'VFrag' constructor allocation.
 --
--- Empty fragments (@@fragment@ []@) in child nodes are erased from the virtual DOM tree in the
+-- Empty fragments (@fragment []@) in child nodes are erased from the virtual DOM tree in the
 -- Haskell layer before they reach diffing in JavaScript and are therefore a no-op.
 --
 -- The smart constructors for 'VFrag' are:
@@ -1089,7 +1089,7 @@
 --   Rename n  -> #name 'Miso.Lens..=' n            -- via OverloadedLabels
 -- @
 --
--- * __Hand-written__: construct a @Lens@ directly using @lens@ and the @@Lens@ s a@ synonym.
+-- * __Hand-written__: construct a @Lens@ directly using @lens@ and the @Lens s a@ synonym.
 --
 -- @
 -- name :: 'Miso.Lens.Lens' Person 'MisoString'

--- a/src/Miso.hs
+++ b/src/Miso.hs
@@ -216,8 +216,8 @@
 -- data 'View' context model action
 --   = 'VNode' 'Namespace' 'Tag' ['Attribute' model action] ['View' context model action] 'DirectEvents'
 --   | 'VText' (Maybe t'Key') 'MisoString'
---   | @VComp@ (t'SomeComponent' context)
---   | forall props . @VCompStatic@ (@StaticPtr@ (t'SomeStaticComponent' props context)) props
+--   | VComp ('SomeComponent' context)
+--   | forall props . VCompStatic (StaticPtr ('SomeStaticComponent' props context)) props
 --   | 'VFrag' (Maybe t'Key') ['View' context model action]
 -- @
 --
@@ -226,7 +226,7 @@
 -- @
 -- data t'SomeComponent' context
 --   = forall model action props . ('Eq' context, 'Eq' model, 'Eq' props)
---   => t'SomeComponent' (Maybe t'Key') props (t'Miso.Types.Component' context props model action)
+--   => t'SomeComponent' (Maybe t'Key') props ('Miso.Types.Component' context props model action)
 -- @
 --
 -- The smart constructors:
@@ -275,7 +275,7 @@
 -- * __@context@__ — global; the same value is visible to the whole tree.
 --
 -- This is why @context@ is a type parameter on both t'Miso.Types.Component' and 'View'
--- (@t'Miso.Types.Component' context props model action@, @'View' context model action@): the
+-- (@'Miso.Types.Component' context props model action@, @'View' context model action@): the
 -- parameter is threaded through the entire view tree so that every nested
 -- t'Miso.Types.Component' — reachable via t'SomeComponent' — is statically guaranteed to
 -- agree on __one__ @context@ type. There is exactly one live @context@ value per
@@ -359,7 +359,7 @@
 --   => 'MisoString'
 --   -> t'Miso.Types.Component' context () model action
 --   -> 'View' context model action
--- key '+>' comp = @VComp@ (t'SomeComponent' (Just ('toKey' key)) () comp)
+-- key '+>' comp = @VComp@ ('SomeComponent' (Just ('toKey' key)) () comp)
 -- @
 --
 -- Practically, using this combinator looks like:
@@ -655,7 +655,7 @@
 --   = 'Property' 'MisoString' 'Miso.JSON.Value'          -- ^ DOM property (key/value)
 --   | 'ClassList' ['MisoString']             -- ^ 'CSS' class list
 --   | 'On' (model -> 'Sink' action -> ...)   -- ^ Fully-applied event handler
---   | 'OnStatic' (@StaticPtr@ (t'EventHandler' model action)) -- ^ @static@ handler, rebuilt on the main thread (dual-thread)
+--   | 'OnStatic' (@StaticPtr@ ('EventHandler' model action)) -- ^ @static@ handler, rebuilt on the main thread (dual-thread)
 --   | 'Styles' ('Data.Map.Strict.Map' 'MisoString' 'MisoString') -- ^ Inline style map
 -- @
 --
@@ -694,7 +694,7 @@
 -- == Keys
 --
 -- @key_@ (and its alias 'keyProp') attaches a reconciliation key to any element.
--- See the @t'Key'@ section for details.
+-- See the @'Key'@ section for details.
 --
 -- @
 --
@@ -714,7 +714,7 @@
 -- The 'Effect' type is defined as a 'Control.Monad.RWS.RWS'.
 --
 -- @
--- type 'Effect' context props model action = 'Control.Monad.RWS.RWS' (t'ComponentInfo' context props) [t'Schedule' context action] model ()
+-- type 'Effect' context props model action = 'Control.Monad.RWS.RWS' ('ComponentInfo' context props) ['Schedule' context action] model ()
 -- @
 --
 -- * The 'Control.Monad.Reader' portion of 'Effect' is t'ComponentInfo'. 'ask', 'asks', 'Miso.Lens.view' can be used to access its fields.
@@ -1197,7 +1197,7 @@
 -- @
 -- import Servant.Miso.Html (HTML)
 --
--- type Home    = \"home\"    :\> Get '[HTML] (t'Miso.Types.Component' context props model action)
+-- type Home    = \"home\"    :\> Get '[HTML] ('Miso.Types.Component' context props model action)
 -- type About   = \"about\"   :\> Get '[HTML] ('View' context model action)
 -- type Contact = \"contact\" :\> Get '[HTML] ['View' context model action]
 -- type API = Home :\<|\> About :\<|\> Contact

--- a/src/Miso/CSS/Types.hs
+++ b/src/Miso/CSS/Types.hs
@@ -31,7 +31,7 @@
 --
 -- @
 -- t'StyleSheet'          -- rendered to a \<style\> tag
---   └─ [t'Styles']       -- one rule block each
+--   └─ ['Styles']       -- one rule block each
 --        ├─ t'Styles'    (selector → ['Style'])
 --        ├─ 'KeyFrame'  (animation-name → [(stop, ['Style'])])
 --        └─ 'Media'     (media-query   → [(selector, ['Style'])])

--- a/src/Miso/DSL.hs
+++ b/src/Miso/DSL.hs
@@ -49,7 +49,7 @@
 --
 -- Two auxiliary classes support the calling convention:
 --
--- * 'ToArgs' — marshals a Haskell value to a @[t'JSVal']@ argument list.
+-- * 'ToArgs' — marshals a Haskell value to a @['JSVal']@ argument list.
 --   Tuples up to arity 6 automatically produce the correct positional list.
 --
 -- * 'ToObject' — promotes a value to a JS t'Object' for use as the @this@

--- a/src/Miso/Data/Array.hs
+++ b/src/Miso/Data/Array.hs
@@ -15,7 +15,7 @@
 --
 -- "Miso.Data.Array" is a Haskell wrapper around the JavaScript
 -- <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array Array>
--- object. Values of type @t'Array' a@ live in JavaScript memory; all
+-- object. Values of type @'Array' a@ live in JavaScript memory; all
 -- operations run in 'IO' and mutate the underlying JS array in place.
 --
 -- Use this module when you need to pass a JS-native array to a browser API

--- a/src/Miso/Data/Map.hs
+++ b/src/Miso/Data/Map.hs
@@ -14,7 +14,7 @@
 --
 -- "Miso.Data.Map" is a Haskell wrapper around the JavaScript
 -- <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map Map>
--- object. Values of type @t'Map' k v@ live in JavaScript memory; all
+-- object. Values of type @'Map' k v@ live in JavaScript memory; all
 -- operations run in 'IO' and mutate the underlying JS map in place.
 --
 -- Unlike 'Data.Map.Strict.Map', keys do not require an 'Ord' instance —

--- a/src/Miso/Data/Set.hs
+++ b/src/Miso/Data/Set.hs
@@ -14,7 +14,7 @@
 --
 -- "Miso.Data.Set" is a Haskell wrapper around the JavaScript
 -- <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set Set>
--- object. Values of type @t'Set' a@ live in JavaScript memory; all
+-- object. Values of type @'Set' a@ live in JavaScript memory; all
 -- operations run in 'IO' and mutate the underlying JS set in place.
 --
 -- Unlike 'Data.Set.Set', elements do not require an 'Ord' instance —

--- a/src/Miso/Effect.hs
+++ b/src/Miso/Effect.hs
@@ -92,7 +92,7 @@
 -- = See also
 --
 -- * "Miso.Types" — t'Miso.Types.Component', 'Miso.Types.update', 'Miso.Types.subs'
--- * "Miso.Lens" — lens operators (@@.=@@, @@+=@@, @@%=@@) for model updates
+-- * "Miso.Lens" — lens operators (@.=@, @+=@, @%=@) for model updates
 -- * "Miso.Subscription" — pre-built subscriptions (mouse, keyboard, history, …)
 -----------------------------------------------------------------------------
 module Miso.Effect

--- a/src/Miso/Effect.hs
+++ b/src/Miso/Effect.hs
@@ -32,7 +32,7 @@
 --
 -- @
 -- type 'Effect' context props model action
---      = RWS (t'ComponentInfo' context props) [t'Schedule' context action] model ()
+--      = RWS ('ComponentInfo' context props) ['Schedule' context action] model ()
 -- @
 --
 -- The @RWS@ decomposition:
@@ -341,7 +341,7 @@ async = Schedule Async
 -- | Run @action@'s 'Miso.Types.update' on the __background__ thread (BTS).
 --
 -- On the Lynx dual-thread runtime the shared @model@ is owned solely by the
--- background thread. A main-thread (t'Miso.Event.Types.MTS') event handler that
+-- background thread. A main-thread ('Miso.Event.Types.MTS') event handler that
 -- needs to change shared state cannot do so directly — it dispatches the state
 -- change here, and @action@'s 'Miso.Types.update' runs (exactly once) on the
 -- BTS, where the model write commits. Off the native runtime (or when already
@@ -357,7 +357,7 @@ runOnBG action = tell [ CrossThread BTS action ]
 -----------------------------------------------------------------------------
 -- | Run @action@'s 'Miso.Types.update' on the __main__ thread (MTS).
 --
--- The dual of 'runOnBG': a background-thread (t'Miso.Event.Types.MTS') effect
+-- The dual of 'runOnBG': a background-thread ('Miso.Event.Types.MTS') effect
 -- that needs an imperative main-thread operation (see "Miso.Native.MainThread")
 -- dispatches @action@ here, and its 'Miso.Types.update' runs (exactly once) on
 -- the MTS. Off the native runtime (or when already on the MTS) this is an

--- a/src/Miso/Event/Decoder.hs
+++ b/src/Miso/Event/Decoder.hs
@@ -17,7 +17,7 @@
 -- "Miso.Event.Decoder" provides t'Decoder', the type that tells miso how to
 -- extract a Haskell value from a browser
 -- <https://developer.mozilla.org/en-US/docs/Web/API/Event DOM Event> object.
--- It pairs a target path (t'DecodeTarget') into the event with a
+-- It pairs a target path ('DecodeTarget') into the event with a
 -- JSON-style parser ('Miso.JSON.Value' @->@ 'Miso.JSON.Parser' @a@).
 --
 -- Decoders are consumed by 'Miso.Html.Event.on' from "Miso.Html.Event":
@@ -33,8 +33,8 @@
 --
 -- A t'DecodeTarget' selects the sub-object of the event to decode:
 --
--- * @t'DecodeTarget' []@ — the event object itself (e.g. for keyboard events).
--- * @t'DecodeTarget' [\"target\"]@ — @event.target@ (e.g. for input values).
+-- * @'DecodeTarget' []@ — the event object itself (e.g. for keyboard events).
+-- * @'DecodeTarget' [\"target\"]@ — @event.target@ (e.g. for input values).
 -- * @'DecodeTargets' [[\"a\"], [\"b\"]]@ — tries @event.a@ first, then
 --   @event.b@; the first successful decode wins.
 --

--- a/src/Miso/Fetch.hs
+++ b/src/Miso/Fetch.hs
@@ -17,7 +17,7 @@
 -- for making HTTP requests inside Miso's 'Effect' monad.
 --
 -- Each function accepts a URL, optional request headers, a success callback,
--- and an error callback of the form @t'Response' x -> action@. The resulting
+-- and an error callback of the form @'Response' x -> action@. The resulting
 -- 'Effect' dispatches the appropriate action into the MVU loop when the
 -- response arrives.
 --

--- a/src/Miso/Html.hs
+++ b/src/Miso/Html.hs
@@ -51,7 +51,7 @@
 --   with @_@ to avoid clashing with @Prelude@ identifiers.
 --
 -- ["Miso.Html.Event"]
---   Pre-wired event-handler attributes (@@onClick@@, @'onInput'@,
+--   Pre-wired event-handler attributes (@'onClick'@, @'onInput'@,
 --   @'onKeyDown'@, @'onDrop'@, …).  Covers mouse, keyboard, form, focus,
 --   pointer, drag, touch, media, and lifecycle events.
 --

--- a/src/Miso/Router.hs
+++ b/src/Miso/Router.hs
@@ -82,11 +82,11 @@
 --
 -- = URL types
 --
--- [@t'Capture' sym a@] dynamic path segment — @Capture 42@ → @\/42@
--- [@t'Path' sym@] fixed path segment — @Path \"foo\"@ → @\/foo@
--- [@t'QueryParam' sym a@] optional query key — @QueryParam (Just 1)@ → @?sym=1@
--- [@t'QueryFlag' sym@] boolean query flag — @QueryFlag True@ → @?sym@
--- [@t'Fragment' sym@] hash fragment — @Fragment@ → @#sym@
+-- [@'Capture' sym a@] dynamic path segment — @Capture 42@ → @\/42@
+-- [@'Path' sym@] fixed path segment — @Path \"foo\"@ → @\/foo@
+-- [@'QueryParam' sym a@] optional query key — @QueryParam (Just 1)@ → @?sym=1@
+-- [@'QueryFlag' sym@] boolean query flag — @QueryFlag True@ → @?sym@
+-- [@'Fragment' sym@] hash fragment — @Fragment@ → @#sym@
 --
 -- = Integration with history subscription
 --

--- a/src/Miso/Runtime.hs
+++ b/src/Miso/Runtime.hs
@@ -1297,7 +1297,7 @@ setAttrs vnode_@(Object jval) attrs snk vcompId logLevel events model_ = do
     OnStatic ptr ->
       -- Stash the handler's 'StaticKey' and owning @ComponentId@ on the node
       -- so 'onWithOptions' can attach them to the per-event object; the native
-      -- PATCH protocol ships them to the MTS for main-thread (t'MTS') dispatch.
+      -- PATCH protocol ships them to the MTS for main-thread ('MTS') dispatch.
       -- Browser\/WASM never dereferences them. 'pendingMainThread' starts
       -- @False@; 'Miso.Event.mainThread' (part of @callback@) flips it 'True'
       -- so only marked handlers opt in.
@@ -2348,7 +2348,7 @@ componentListener Proxy (BTS ctx) = void $ do
                       READY_ACK -> pure ()
 #endif
 ----------------------------------------------------------------------------
--- | Dispatch a main-thread (t'MTS') event on the Haskell layer.
+-- | Dispatch a main-thread ('MTS') event on the Haskell layer.
 --
 -- Invoked synchronously by the MTS delegator (see @ts\/miso\/native\/mts\/context.ts@)
 -- with a @{ componentId, staticKey, event, target }@ object. Recovers the event

--- a/src/Miso/State.hs
+++ b/src/Miso/State.hs
@@ -40,7 +40,7 @@
 -- @
 --
 -- When using "Miso.Lens" or "Miso.Lens.TH", the lens update operators
--- (@@.=@@, @@+=@@, @@%=@@, …) are built directly on 'modify', so
+-- (@.=@, @+=@, @%=@, …) are built directly on 'modify', so
 -- explicit calls to 'modify' \/ 'put' are rarely needed.
 --
 -- = Exported combinators

--- a/src/Miso/Subscription/Keyboard.hs
+++ b/src/Miso/Subscription/Keyboard.hs
@@ -29,7 +29,7 @@
 -- subs = [ 'arrowsSub' ArrowsChanged ]
 --
 -- update :: Action -> 'Miso.Effect.Effect' p props Model Action
--- update (ArrowsChanged (t'Arrows' x y)) = do
+-- update (ArrowsChanged ('Arrows' x y)) = do
 --   -- x ∈ {-1, 0, 1}, y ∈ {-1, 0, 1}
 --   'Miso.Effect.io_' (move x y)
 -- @

--- a/src/Miso/Types.hs
+++ b/src/Miso/Types.hs
@@ -33,7 +33,7 @@
 --
 -- = The Component record
 --
--- @t'Component' context props model action@ is the central record type. It
+-- @'Component' context props model action@ is the central record type. It
 -- wires together the MVU loop and all supporting runtime configuration:
 --
 -- @
@@ -81,16 +81,16 @@
 --
 -- = Key types at a glance
 --
--- [t'Component'] full MVU application\/component record
--- ['App'] alias for @t'Component' () () model action@
+-- ['Component'] full MVU application\/component record
+-- ['App'] alias for @'Component' () () model action@
 -- ['View'] virtual DOM node
 -- ['Attribute'] DOM property, class list, event handler, or style
 -- ['Namespace'] @HTML@ \| @SVG@ \| @MATHML@
--- [t'Key'] reconciliation hint for list diffing
+-- ['Key'] reconciliation hint for list diffing
 -- ['CSS'] stylesheet reference (@Href@, @Style@, @Sheet@)
 -- ['JS'] script reference (@Src@, @Script@, @Module@, …)
 -- ['LogLevel'] debug verbosity (@Off@, @DebugHydrate@, …)
--- [t'URI'] parsed URL (path + query string + fragment)
+-- ['URI'] parsed URL (path + query string + fragment)
 --
 -- = Text combinators
 --
@@ -441,7 +441,7 @@ data View context model action
   | VComp (SomeComponent context)
   | forall props . VCompStatic (StaticPtr (SomeStaticComponent props context)) props
     -- ^ An embedded child t'Component'. The 'StaticPtr' holds only the closed
-    -- @props -> component@ constructor (t'SomeStaticComponent'); the @props@ value — often
+    -- @props -> component@ constructor ('SomeStaticComponent'); the @props@ value — often
     -- derived from the parent's @model@ — rides alongside and crosses the
     -- dual-thread (Lynx) boundary as JSON. The no-props case uses @props ~ ()@
     -- (see 'mountStatic'). This split is what lets a mount escape @static@\'s
@@ -564,7 +564,7 @@ key +> child = VComp (SomeComponent (Just (toKey key)) () child)
 -- the two t'Miso.Types.Component', to ensure unmounting and mounting occurs.
 --
 -- It takes only the @component@ and yields a closed @props -> component@
--- constructor (t'SomeStaticComponent') suitable for @static@ — the @props@ value
+-- constructor ('SomeStaticComponent') suitable for @static@ — the @props@ value
 -- is /not/ supplied here, but later at the 'vcomp' site, so a parent can pass
 -- runtime @props@ (e.g. derived from its own @model@) without an explicit lambda:
 --
@@ -641,7 +641,7 @@ mountWithProps_ key props child = VComp (SomeComponent (Just (Key key)) props ch
 -- | Static t'Miso.Types.Component' mounting combinator, for a component
 -- that takes no @props@.
 --
--- Produces a @t'SomeStaticComponent' () context@ to be wrapped in @static@ and
+-- Produces a @'SomeStaticComponent' () context@ to be wrapped in @static@ and
 -- turned into a 'View' by 'vcomp_'. Unlike 'mount_', no key is needed: the
 -- compile-time 'GHC.StaticPtr.StaticKey' already supplies identity, so this is
 -- safe to diff against another t'Miso.Types.Component'.
@@ -727,7 +727,7 @@ vcomp = flip VCompStatic
 -- | Like 'vcomp', but for a t'Miso.Types.Component' that takes no @props@.
 --
 -- @'vcomp_' = 'vcomp' ()@ — pair it with 'mountStatic', which produces a
--- @t'SomeStaticComponent' () context@.
+-- @'SomeStaticComponent' () context@.
 --
 -- @
 -- div_ [] [ vcomp_ (static (mountStatic myComp)) ]

--- a/src/Miso/Util/Lexer.hs
+++ b/src/Miso/Util/Lexer.hs
@@ -54,7 +54,7 @@
 -- @
 -- 'getInput'     :: t'Lexer' t'Stream'
 -- 'putInput'     :: t'Stream' -> t'Lexer' ()
--- 'modifyInput'  :: (t'Stream' -> t'Stream') -> t'Lexer' ()
+-- 'modifyInput'  :: ('Stream' -> t'Stream') -> t'Lexer' ()
 -- 'getLocation'  :: t'Lexer' t'Location'
 -- 'setLocation'  :: t'Location' -> t'Lexer' ()
 -- @

--- a/src/Miso/Util/Parser.hs
+++ b/src/Miso/Util/Parser.hs
@@ -35,7 +35,7 @@
 -- * @m@ — the result monad; using @[]@ gives non-deterministic\/backtracking parsing
 -- * @a@ — the parsed result
 --
--- The @t'Parser' token a@ convenience alias fixes @r = ()@ and @m = []@,
+-- The @'Parser' token a@ convenience alias fixes @r = ()@ and @m = []@,
 -- which gives a standard backtracking parser over a @[token]@ stream.
 --
 -- = Primitive combinators


### PR DESCRIPTION
The 1.13.0.0 doc pass added Haddock’s `t'` namespace prefix to disambiguate type-vs-constructor links. Haddock only honours that prefix when the `t` follows whitespace or starts the line — after `(`, `[` or `@` it lexes the letter as ordinary text.

Confirmed against a scratch module:

```
(Maybe t'Key')   ->  (Maybe Key)     correct
(t'Key' ctx)     ->  (tKey ctx)      broken
```

Which is why the `View` DSL section rendered as `VComp (tSomeComponent context)`.

40 such prefixes are stripped back to plain `'X'`. Nothing is lost: Haddock already resolved the ambiguous ones to the type — its own warning says *“Defaulting to the one defined at &lt;the data declaration&gt;”* — so the rendered link is unchanged. The prefix was only silencing a warning. Ambiguity warnings go 11 → 30 in exchange, which is the right trade against visibly wrong output.

Also drops the `@...@` wrappers from the `data View` listing. Inside a `@` code block everything is already monospace, and nesting inline code there renders with stray padding — the `( StaticPtr` gap visible in that block.

Verified by rendering: the block is correct, and no `t`-glued-to-a-link artifact remains on any generated page. Comment-only, `cabal haddock` succeeds.