### PR TITLE
feat: Add `-faeson` cabal flag: define `Miso.JSON` in terms of `Data.Aeson`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -97,6 +97,12 @@ jobs:
      - name: Nix garbage collection
        run: cabal clean && nix-collect-garbage -d
 
+     - name: (WASM) Miso integration tests (aeson)
+       run: nix-build -A playwright-wasm-aeson && ./result/bin/playwright
+
+     - name: Nix garbage collection
+       run: cabal clean && nix-collect-garbage -d
+
      - name: (GHCJS) Miso integration tests
        run: nix-build -A playwright-ghcjs && ./result/bin/playwright
 
@@ -183,6 +189,9 @@ jobs:
 
      - name: (WASM) Miso integration tests
        run: nix-build -A playwright-wasm && ./result/bin/playwright
+
+     - name: (WASM) Miso integration tests (aeson)
+       run: nix-build -A playwright-wasm-aeson && ./result/bin/playwright
 
      - name: (x86) Miso GHC (GHC 9.12.2) test suite
        run: nix develop --command bash -c 'cabal build exe:component-tests'

--- a/default.nix
+++ b/default.nix
@@ -160,6 +160,24 @@ rec {
     exit "$exit_code"
   '';
 
+  # Same as playwright-wasm, but miso is built with the 'aeson' cabal flag
+  # (Miso.JSON defined in terms of Data.Aeson).
+  playwright-wasm-aeson = pkgs.writeScriptBin "playwright" ''
+    #!${pkgs.stdenv.shell}
+    export PLAYWRIGHT_BROWSERS_PATH=${pkgs.playwright-driver.browsers}
+    export PATH="${pkgs.lib.makeBinPath [ pkgs.http-server pkgs.bun ]}:$PATH"
+    bun install playwright@1.53
+    cd tests
+    nix develop .#wasm --command bash -c 'make aeson'
+    http-server ./public &
+    bun run ../ts/echo-server.ts &
+    bun run ../ts/playwright.ts
+    exit_code=$?
+    pkill http-server
+    pkill -f echo-server
+    exit "$exit_code"
+  '';
+
   inherit (pkgs)
     nurl;
 

--- a/miso.cabal
+++ b/miso.cabal
@@ -57,6 +57,10 @@ common cpp
     cpp-options:
       -DBENCH
 
+  if flag(aeson)
+    cpp-options:
+      -DAESON
+
 common client
   if impl(ghcjs) || arch(javascript) || arch(wasm32)
     if flag(native) && flag(production)
@@ -114,6 +118,17 @@ flag template-haskell
     False
   description:
     Checks if template-haskell is enabled. If so, allows Miso.Lens.TH
+
+flag aeson
+  manual:
+    True
+  default:
+    False
+  description:
+    When enabled, the functions exposed by Miso.JSON are defined in terms
+    of aeson (Data.Aeson), and its types (Value, Object, Parser) become
+    aeson's. Miso's own Generic deriving machinery is not exported in this
+    mode; aeson provides its own.
 
 library
   import:
@@ -297,6 +312,11 @@ library
       Miso.FFI.QQ
     build-depends:
       template-haskell >= 2.21 && < 2.25
+
+  if flag(aeson)
+    build-depends:
+      aeson      >= 2.0 && < 3,
+      scientific < 0.4
 
   ghc-options:
     -Wall

--- a/src/Miso/JSON.hs
+++ b/src/Miso/JSON.hs
@@ -162,7 +162,11 @@ module Miso.JSON
   , withBool
     -- * Type conversion
   , FromJSON(parseJSON)
+#ifdef AESON
+  , Parser
+#else
   , Parser (..)
+#endif
   , parseMaybe
   , ToJSON(..)
   -- * Misc.
@@ -184,6 +188,7 @@ module Miso.JSON
   , Options (..)
   , defaultOptions
   -- * Generics
+#ifndef AESON
   , GToJSON (..)
   , GToFields (..)
   , GToJSONRep (..)
@@ -196,6 +201,7 @@ module Miso.JSON
   , GFromJSONRep (..)
   , GFromJSONSum (..)
   , GFromJSONSumNullary (..)
+#endif
   , genericToJSON
   , genericParseJSON
   -- * Modifiers
@@ -206,12 +212,28 @@ module Miso.JSON
 import qualified GHCJS.Marshal as Marshal
 #endif
 ----------------------------------------------------------------------------
-import           Control.Applicative
 import           Control.Monad
 #if __GLASGOW_HASKELL__ <= 865
 import           Control.Monad.Fail
 import           GHC.Natural (Natural)
 #endif
+#ifdef AESON
+import           Data.Aeson.Types
+  ( ToJSON (..), FromJSON (..), Parser, Options (..), Key
+  , defaultOptions, camelTo2, genericToJSON, genericParseJSON
+  , object, emptyArray, emptyObject, parseMaybe, (.!=)
+  )
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Types as Aeson
+import qualified Data.Aeson.Key as Key
+import           Data.Bifunctor (first)
+import           Data.Scientific (Scientific, toRealFloat, fromFloatDigits)
+#ifndef VANILLA
+import           Data.Aeson.Types (ToJSONKey (..), FromJSONKey (..), FromJSONKeyFunction (..), toJSONKeyText)
+import qualified Data.Aeson.KeyMap as KeyMap
+#endif
+#else
+import           Control.Applicative
 import           Data.Char
 import qualified Data.Map.Strict as M
 import           Data.Map.Strict (Map)
@@ -223,16 +245,24 @@ import           Data.Kind
 import qualified Data.Text.Lazy as LT
 import           Data.Word
 import           GHC.Generics
+#endif
 ----------------------------------------------------------------------------
 import           Miso.DSL.FFI
+#ifdef AESON
+import           Miso.String (FromMisoString, ToMisoString, MisoString, ms, pack)
+#else
 import           Miso.String (FromMisoString, ToMisoString, MisoString, ms, singleton, pack)
+#endif
 import qualified Miso.String as MS
 import           Miso.JSON.Types
 import qualified Miso.JSON.Parser as Parser
+#ifndef AESON
 import           Numeric (showHex)
+#endif
 ----------------------------------------------------------------------------
 #ifndef VANILLA
 import           Control.Monad.Trans.Maybe
+import           Data.Foldable (toList)
 import           System.IO.Unsafe (unsafePerformIO)
 import qualified Data.Text as T
 #endif
@@ -244,6 +274,32 @@ import qualified Data.Text as T
 -- object [ \"name\" .= (\"Alice\" :: MisoString), \"age\" .= (30 :: Int) ]
 -- @
 infixr 8 .=
+#ifdef AESON
+(.=) :: ToJSON v => MisoString -> v -> Pair
+k .= v  = (toKey k, toJSON v)
+----------------------------------------------------------------------------
+-- | Convert a t'MisoString' to an aeson 'Key'.
+toKey :: MisoString -> Key
+toKey = Key.fromText . MS.fromMisoString
+----------------------------------------------------------------------------
+-- 'object', 'emptyObject', 'emptyArray', and '.!=' are re-exported from aeson.
+----------------------------------------------------------------------------
+-- | Look up a required key in a JSON t'Object'.
+-- Fails with a parse error if the key is absent.
+(.:) :: FromJSON a => Object -> MisoString -> Parser a
+m .: k = (Aeson..:) m (toKey k)
+----------------------------------------------------------------------------
+-- | Look up an optional key in a JSON t'Object'.
+-- Returns 'Nothing' if the key is absent; delegates to 'parseJSON' if present.
+(.:?) :: FromJSON a => Object -> MisoString -> Parser (Maybe a)
+m .:? k = (Aeson..:?) m (toKey k)
+----------------------------------------------------------------------------
+-- | Like '.:?' but always wraps a present value in 'Just', so a key with a
+-- @null@ JSON value decodes to @Just Null@ rather than 'Nothing'.
+-- Useful when you need to distinguish a missing key from an explicit null.
+(.:!) :: FromJSON a => Object -> MisoString -> Parser (Maybe a)
+m .:! k = (Aeson..:!) m (toKey k)
+#else
 (.=) :: ToJSON v => MisoString -> v -> Pair
 k .= v  = (k, toJSON v)
 ----------------------------------------------------------------------------
@@ -281,7 +337,26 @@ m .:! k = maybe (pure Nothing) (fmap Just . parseJSON) (M.lookup k m)
 -- @o '.:?' \"count\" '.!=' 0@
 (.!=) :: Parser (Maybe a) -> a -> Parser a
 mv .!= def = fmap (fromMaybe def) mv
+#endif
 ----------------------------------------------------------------------------
+#ifdef AESON
+#ifndef VANILLA
+-- On the JavaScript and WASM backends t'MisoString' is @JSString@, which
+-- aeson does not know about; these orphans make it a first-class JSON
+-- citizen so code written against "Miso.JSON" keeps compiling.
+instance ToJSON MisoString where
+  toJSON = String . MS.fromMisoString
+----------------------------------------------------------------------------
+instance FromJSON MisoString where
+  parseJSON = withText "MisoString" pure
+----------------------------------------------------------------------------
+instance ToJSONKey MisoString where
+  toJSONKey = toJSONKeyText MS.fromMisoString
+----------------------------------------------------------------------------
+instance FromJSONKey MisoString where
+  fromJSONKey = FromJSONKeyText ms
+#endif
+#else
 -- | A type that can be serialised to a JSON 'Value'.
 --
 -- Instances for the most common Haskell types are provided. Derive via
@@ -621,7 +696,9 @@ instance ToJSON Integer where toJSON = Number . fromInteger
 ----------------------------------------------------------------------------
 -- | Possibly lossy due to conversion to 'Double'
 instance ToJSON Natural where toJSON = Number . fromInteger . naturalToInteger
+#endif
 ----------------------------------------------------------------------------
+#ifndef AESON
 -- | A lightweight JSON parse monad. Wraps @Either MisoString a@ so that
 -- parse failures carry a human-readable error message.
 --
@@ -679,7 +756,19 @@ parseEither m v = unParser (m v)
 ----------------------------------------------------------------------------
 pfail :: MisoString -> Parser a
 pfail message = Parser (Left message)
+#else
 ----------------------------------------------------------------------------
+-- | Run a parser function, returning @'Left' errMsg@ on failure.
+parseEither
+  :: (a -> Parser b)
+  -- ^ Parser function to apply
+  -> a
+  -- ^ Input value to parse
+  -> Either MisoString b
+parseEither m v = first ms (Aeson.parseEither m v)
+#endif
+----------------------------------------------------------------------------
+#ifndef AESON
 -- | A type that can be deserialised from a JSON 'Value'.
 --
 -- Instances for the most common Haskell types are provided. Derive via
@@ -993,7 +1082,78 @@ instance FromJSON Char where
 ----------------------------------------------------------------------------
 instance FromJSON v => FromJSON (Map MisoString v) where
   parseJSON = withObject "FromJSON v => Map MisoString v" $ mapM parseJSON
+#endif
 ----------------------------------------------------------------------------
+#ifdef AESON
+-- | Succeed only when the 'Value' is a t'Bool'; fail with 'typeMismatch' otherwise.
+withBool
+  :: MisoString
+  -- ^ Expected type name used in the error message (e.g. @\"MyType\"@)
+  -> (Bool -> Parser a)
+  -- ^ Continuation receiving the unwrapped t'Bool'
+  -> Value
+  -- ^ JSON value to inspect
+  -> Parser a
+withBool expected = Aeson.withBool (MS.unpack expected)
+----------------------------------------------------------------------------
+-- | Succeed only when the 'Value' is a JSON string ('MisoString');
+-- fail with 'typeMismatch' otherwise.
+withText
+  :: MisoString
+  -- ^ Expected type name used in the error message
+  -> (MisoString -> Parser a)
+  -- ^ Continuation receiving the unwrapped string
+  -> Value
+  -- ^ JSON value to inspect
+  -> Parser a
+withText expected f = Aeson.withText (MS.unpack expected) (f . ms)
+----------------------------------------------------------------------------
+-- | Succeed only when the 'Value' is a JSON array; fail with 'typeMismatch' otherwise.
+-- The inner parser receives the list of elements.
+withArray
+  :: MisoString
+  -- ^ Expected type name used in the error message
+  -> ([Value] -> Parser a)
+  -- ^ Continuation receiving the list of array elements
+  -> Value
+  -- ^ JSON value to inspect
+  -> Parser a
+withArray expected f = Aeson.withArray (MS.unpack expected) (f . foldr (:) [])
+----------------------------------------------------------------------------
+-- | Succeed only when the 'Value' is a JSON object; fail with 'typeMismatch' otherwise.
+-- The inner parser receives the t'Object' map for key lookups with @.:@ etc.
+withObject
+  :: MisoString
+  -- ^ Expected type name used in the error message
+  -> (Object -> Parser a)
+  -- ^ Continuation receiving the t'Object' key\/value map
+  -> Value
+  -- ^ JSON value to inspect
+  -> Parser a
+withObject expected = Aeson.withObject (MS.unpack expected)
+----------------------------------------------------------------------------
+-- | Succeed only when the 'Value' is a JSON number; fail with 'typeMismatch' otherwise.
+-- The inner parser receives the underlying 'Double'.
+withNumber
+  :: MisoString
+  -- ^ Expected type name used in the error message
+  -> (Double -> Parser a)
+  -- ^ Continuation receiving the numeric value as a 'Double'
+  -> Value
+  -- ^ JSON value to inspect
+  -> Parser a
+withNumber expected f = Aeson.withScientific (MS.unpack expected) (f . toRealFloat)
+----------------------------------------------------------------------------
+-- | Produce a parse failure describing a type mismatch.
+-- Used by the @with*@ combinators and useful in hand-written 'FromJSON' instances.
+typeMismatch
+  :: MisoString
+  -- ^ Human-readable name of the expected type (e.g. @\"Int\"@)
+  -> Value
+  -- ^ The actual 'Value' that was encountered
+  -> Parser a
+typeMismatch expected = Aeson.typeMismatch (MS.unpack expected)
+#else
 -- | Succeed only when the 'Value' is a t'Bool'; fail with 'typeMismatch' otherwise.
 withBool
   :: MisoString
@@ -1076,6 +1236,7 @@ typeMismatch expected actual =
         Bool _ -> "Boolean"
         Null -> "Null"
     )
+#endif
 ----------------------------------------------------------------------------
 -- | Encode a value as a JSON 'MisoString'.
 --
@@ -1100,6 +1261,10 @@ encodePure = ms . toJSON
 instance FromMisoString Value where
   fromMisoStringEither = Parser.decodePure
 ----------------------------------------------------------------------------
+#ifdef AESON
+instance ToMisoString Value where
+  toMisoString = ms . Aeson.encode
+#else
 -- | Escape special characters in a string for JSON serialization
 -- Handles: \, ", and all JSON control characters per RFC 8259
 escapeJSONString :: MisoString -> MisoString
@@ -1139,6 +1304,7 @@ instance ToMisoString Value where
       "{" <>
         MS.intercalate "," [ "\"" <> escapeJSONString k <> "\"" <> ":" <> ms v | (k,v) <- M.toList o ]
       <> "}"
+#endif
 ----------------------------------------------------------------------------
 -- | Decode a JSON 'MisoString' into a Haskell value, returning 'Nothing' on failure.
 --
@@ -1284,6 +1450,55 @@ fromJSON value =
     Left s -> Error s
     Right x -> Success x
 ----------------------------------------------------------------------------
+#ifndef VANILLA
+-- Bridge helpers so the FFI marshalling code below is agnostic to whether
+-- 'Value' is miso's own representation or aeson's (Scientific numbers,
+-- Text strings, Vector arrays, KeyMap objects).
+#ifdef AESON
+numberToDouble :: Scientific -> Double
+numberToDouble = toRealFloat
+-----------------------------------------------------------------------------
+doubleToNumber :: Double -> Value
+doubleToNumber = Number . fromFloatDigits
+-----------------------------------------------------------------------------
+stringToMiso :: T.Text -> MisoString
+stringToMiso = ms
+-----------------------------------------------------------------------------
+mkString :: MisoString -> Value
+mkString = String . MS.fromMisoString
+-----------------------------------------------------------------------------
+mkArray :: [Value] -> Value
+mkArray = toJSON
+-----------------------------------------------------------------------------
+mkObject :: [(MisoString, Value)] -> Value
+mkObject kvs = Object (KeyMap.fromList [ (toKey k, v) | (k, v) <- kvs ])
+-----------------------------------------------------------------------------
+objectAssocs :: Object -> [(MisoString, Value)]
+objectAssocs o = [ (ms (Key.toText k), v) | (k, v) <- KeyMap.toList o ]
+#else
+numberToDouble :: Double -> Double
+numberToDouble = id
+-----------------------------------------------------------------------------
+doubleToNumber :: Double -> Value
+doubleToNumber = Number
+-----------------------------------------------------------------------------
+stringToMiso :: MisoString -> MisoString
+stringToMiso = id
+-----------------------------------------------------------------------------
+mkString :: MisoString -> Value
+mkString = String
+-----------------------------------------------------------------------------
+mkArray :: [Value] -> Value
+mkArray = Array
+-----------------------------------------------------------------------------
+mkObject :: [(MisoString, Value)] -> Value
+mkObject = Object . M.fromList
+-----------------------------------------------------------------------------
+objectAssocs :: Object -> [(MisoString, Value)]
+objectAssocs = M.toList
+#endif
+#endif
+-----------------------------------------------------------------------------
 -- | Convert a Miso JSON 'Value' to a raw JavaScript value via FFI.
 #ifdef GHCJS_BOTH
 toJSVal_Value :: Value -> IO JSVal
@@ -1293,14 +1508,14 @@ toJSVal_Value = \case
   Bool bool_ ->
     Marshal.toJSVal bool_
   String string ->
-    Marshal.toJSVal string
+    Marshal.toJSVal (stringToMiso string)
   Number double ->
-    Marshal.toJSVal double
+    Marshal.toJSVal (numberToDouble double)
   Array arr ->
-    toJSVal_List =<< mapM toJSVal_Value arr
+    toJSVal_List =<< mapM toJSVal_Value (toList arr)
   Object hms -> do
     o <- create_ffi
-    forM_ (M.toList hms) $ \(k,v) -> do
+    forM_ (objectAssocs hms) $ \(k,v) -> do
       v' <- toJSVal_Value v
       setProp_ffi k v' o
     pure o
@@ -1313,15 +1528,15 @@ fromJSVal_Value :: JSVal -> IO (Maybe Value)
 fromJSVal_Value jsval_ = do
   typeof jsval_ >>= \case
     0 -> return (Just Null)
-    1 -> Just . Number <$> Marshal.fromJSValUnchecked jsval_
-    2 -> Just . String <$> Marshal.fromJSValUnchecked jsval_
+    1 -> Just . doubleToNumber <$> Marshal.fromJSValUnchecked jsval_
+    2 -> Just . mkString <$> Marshal.fromJSValUnchecked jsval_
     3 -> fromJSValUnchecked_Int jsval_ >>= \case
       0 -> pure $ Just (Bool False)
       1 -> pure $ Just (Bool True)
       _ -> pure Nothing
     4 -> do xs <- Marshal.fromJSValUnchecked jsval_
             values <- forM xs fromJSVal_Value
-            pure (Array <$> sequence values)
+            pure (mkArray <$> sequence values)
     5 -> do keys <- Marshal.fromJSValUnchecked =<< listProps_ffi jsval_
             result <-
               runMaybeT $ forM keys $ \k -> do
@@ -1332,7 +1547,7 @@ fromJSVal_Value jsval_ = do
             pure (toObject <$> result)
     _ -> error "fromJSVal_Value: Unknown JSON type"
   where
-    toObject = Object . M.fromList
+    toObject = mkObject
 #endif
 -----------------------------------------------------------------------------
 #ifdef WASM
@@ -1340,15 +1555,15 @@ fromJSVal_Value :: JSVal -> IO (Maybe Value)
 fromJSVal_Value jsval = do
   typeof jsval >>= \case
     0 -> return (Just Null)
-    1 -> Just . Number <$> fromJSValUnchecked_Double jsval
-    2 -> pure $ Just $ String $ (JSString jsval)
+    1 -> Just . doubleToNumber <$> fromJSValUnchecked_Double jsval
+    2 -> pure $ Just $ mkString $ (JSString jsval)
     3 -> fromJSValUnchecked_Int jsval >>= \case
       0 -> pure $ Just (Bool False)
       1 -> pure $ Just (Bool True)
       _ -> pure Nothing
     4 -> do xs <- fromJSValUnchecked_List jsval
             values <- forM xs fromJSVal_Value
-            pure (Array <$> sequence values)
+            pure (mkArray <$> sequence values)
     5 -> do keys <- fromJSValUnchecked_List =<< listProps_ffi jsval
             result <-
               runMaybeT $ forM keys $ \k -> do
@@ -1359,7 +1574,7 @@ fromJSVal_Value jsval = do
             pure (toObject <$> result)
     _ -> error "fromJSVal_Value: Unknown JSON type"
   where
-    toObject = Object . M.fromList
+    toObject = mkObject
 #endif
 -----------------------------------------------------------------------------
 #ifdef VANILLA
@@ -1400,14 +1615,14 @@ toJSVal_Value = \case
   Bool bool_ ->
     toJSVal_Bool bool_
   String string ->
-    toJSVal_JSString string
+    toJSVal_JSString (stringToMiso string)
   Number double ->
-    toJSVal_Double double
+    toJSVal_Double (numberToDouble double)
   Array arr ->
-    toJSVal_List =<< mapM toJSVal_Value arr
+    toJSVal_List =<< mapM toJSVal_Value (toList arr)
   Object hms -> do
     o <- create_ffi
-    forM_ (M.toList hms) $ \(k,v) -> do
+    forM_ (objectAssocs hms) $ \(k,v) -> do
       v' <- toJSVal_Value v
       setProp_ffi k v' o
     pure o

--- a/src/Miso/JSON/Parser.hs
+++ b/src/Miso/JSON/Parser.hs
@@ -35,8 +35,22 @@
 -- * "Miso.JSON.Types" — 'Miso.JSON.Types.Value' and 'Miso.JSON.Types.Result' types
 -- * "Miso.Util.Parser" — the underlying parser combinator library
 ----------------------------------------------------------------------------
+{-# LANGUAGE CPP #-}
+----------------------------------------------------------------------------
 module Miso.JSON.Parser (decodePure) where
 ----------------------------------------------------------------------------
+#ifdef AESON
+import qualified Data.Aeson as Aeson
+----------------------------------------------------------------------------
+import           Miso.JSON.Types (Value)
+import           Miso.String (MisoString, fromMisoString)
+----------------------------------------------------------------------------
+-- | Parses JSON text into a t'Value' purely, returning a message on failure.
+--
+-- Defined in terms of aeson's pure parser when the @aeson@ flag is enabled.
+decodePure :: MisoString -> Either String Value
+decodePure = Aeson.eitherDecode . fromMisoString
+#else
 import           Data.Bifunctor (Bifunctor(first))
 import           Data.Functor (void)
 import           Data.Map.Strict (Map)
@@ -105,4 +119,5 @@ decodePure = first show
   . either (Left . LexicalError) (parse value . fst)
   . runLexer tokens
   . mkStream
+#endif
 ----------------------------------------------------------------------------

--- a/src/Miso/JSON/Types.hs
+++ b/src/Miso/JSON/Types.hs
@@ -57,9 +57,13 @@ module Miso.JSON.Types
 ----------------------------------------------------------------------------
 import Control.Applicative (Alternative (..))
 import Control.Monad (MonadPlus(..), ap)
+#ifdef AESON
+import Data.Aeson.Types (Value (..), Pair, Object)
+#else
 import Data.Map.Strict (Map)
-----------------------------------------------------------------------------
 import Data.String (IsString(fromString))
+#endif
+----------------------------------------------------------------------------
 import Miso.String (MisoString, toMisoString)
 ----------------------------------------------------------------------------
 #if __GLASGOW_HASKELL__ <= 881
@@ -67,6 +71,7 @@ import Prelude hiding (fail)
 import Control.Monad.Fail (MonadFail (..))
 #endif
 ----------------------------------------------------------------------------
+#ifndef AESON
 -- | A parsed JSON value.
 --
 -- The JSON data model: numbers are 'Double', objects are keyed by
@@ -90,6 +95,7 @@ type Pair = (MisoString, Value)
 ----------------------------------------------------------------------------
 -- | A JSON object: its members keyed by name.
 type Object = Map MisoString Value
+#endif
 ----------------------------------------------------------------------------
 -- | The outcome of decoding a t'Value' into a Haskell type.
 --

--- a/src/Miso/Native/Element/List/Event.hs
+++ b/src/Miso/Native/Element/List/Event.hs
@@ -162,7 +162,7 @@ instance FromJSON ListEventSource where
     0 -> pure DIFF
     1 -> pure LAYOUT
     2 -> pure SCROLL
-    x -> typeMismatch "ListEventSource" (Number x)
+    x -> typeMismatch "ListEventSource" (toJSON x)
 -----------------------------------------------------------------------------
 -- | The scroll state a @<list>@ has just entered — at rest, under the
 -- user's finger, coasting, or animating to a snap point.
@@ -195,7 +195,7 @@ instance FromJSON ScrollStateChange where
     2 -> pure Dragging
     3 -> pure InertialScrolling
     4 -> pure SmoothAnimationScrolling
-    x -> typeMismatch "ScrollStateChange" (Number x)
+    x -> typeMismatch "ScrollStateChange" (toJSON x)
 -----------------------------------------------------------------------------
 scrollStateDecoder :: Decoder ScrollStateChange
 scrollStateDecoder = ["detail"] `at` withObject "ScrollStateChange" (.: "state")

--- a/src/Miso/Native/Element/Text/Event.hs
+++ b/src/Miso/Native/Element/Text/Event.hs
@@ -183,7 +183,7 @@ instance FromJSON Direction where
   parseJSON = withText "Direction" $ \case
     "forward" -> pure Forward
     "backward" -> pure Backward
-    x -> typeMismatch "Direction" (String x)
+    x -> typeMismatch "Direction" (toJSON x)
 -----------------------------------------------------------------------------
 -- | Payload of a @<text>@ layout event: how many lines were laid out,
 -- per-line detail, and the resulting size.

--- a/src/Miso/Native/Element/View/Event.hs
+++ b/src/Miso/Native/Element/View/Event.hs
@@ -194,7 +194,7 @@ instance FromJSON AnimationType where
   parseJSON = withText "animation-type" $ \case
     "keyframe-animation" -> pure KeyFrameAnimation
     "transition-animation" -> pure TransitionAnimation
-    x -> typeMismatch "animation-type" (String x)
+    x -> typeMismatch "animation-type" (toJSON x)
 ----------------------------------------------------------------------------
 -- | Animation decoder for use with events like 'onAnimationStart'
 animationDecoder :: Decoder AnimationEvent
@@ -266,7 +266,7 @@ instance FromJSON UIAppearanceDetailEventType where
   parseJSON = withText "UIAppearanceDetailEventType" $ \case
     "uiappear" -> pure UIAppear
     "uidisappear" -> pure UIDisappear
-    x -> typeMismatch "UIAppearanceDetailEventType" (String x)
+    x -> typeMismatch "UIAppearanceDetailEventType" (toJSON x)
 -----------------------------------------------------------------------------
 -- | Payload of a @<view>@ appearance event: whether the element appeared
 -- or disappeared, plus the exposure identifiers Lynx assigns it.

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,15 +1,21 @@
-.PHONY= update build optim
+.PHONY= update build build-aeson optim aeson
 
 all: update build optim
+
+# Same as 'all', but with miso built against aeson (the 'aeson' cabal flag)
+aeson: update build-aeson optim
 
 update:
 	wasm32-wasi-cabal update
 
+build-aeson: CABAL_OPTS = --constraint="miso +aeson"
+build-aeson: build
+
 build:
-	wasm32-wasi-cabal build component-tests
+	wasm32-wasi-cabal build component-tests $(CABAL_OPTS)
 	rm -rf public
 	cp -r static public
-	$(eval my_wasm=$(shell wasm32-wasi-cabal list-bin component-tests | tail -n 1))
+	$(eval my_wasm=$(shell wasm32-wasi-cabal list-bin component-tests $(CABAL_OPTS) | tail -n 1))
 	$(shell wasm32-wasi-ghc --print-libdir)/post-link.mjs --input $(my_wasm) --output public/ghc_wasm_jsffi.js
 	cp -v $(my_wasm) public/
 

--- a/tests/app/Main.hs
+++ b/tests/app/Main.hs
@@ -214,6 +214,27 @@ data Nullary = Nullary
   deriving stock (Generic, Show, Eq)
   deriving anyclass (JSON.ToJSON, JSON.FromJSON)
 ----------------------------------------------------------------------------
+-- JSON helpers that work whether miso is built with its own JSON
+-- representation or with the aeson flag (where Value is aeson's type:
+-- Vector arrays, KeyMap objects, Scientific numbers).
+jsonArray :: [JSON.Value] -> JSON.Value
+jsonArray = JSON.toJSON
+----------------------------------------------------------------------------
+lookupKey :: MisoString -> JSON.Value -> Maybe JSON.Value
+lookupKey k v =
+  case JSON.fromJSON v :: JSON.Result (Map MisoString JSON.Value) of
+    JSON.Success m -> M.lookup k m
+    JSON.Error _   -> Nothing
+----------------------------------------------------------------------------
+memberKey :: MisoString -> JSON.Value -> Bool
+memberKey k v = case lookupKey k v of
+  Just _  -> True
+  Nothing -> False
+----------------------------------------------------------------------------
+isError :: JSON.Result a -> Bool
+isError (JSON.Error _) = True
+isError _              = False
+----------------------------------------------------------------------------
 getAge :: Person -> IO Int
 getAge = inline "return age;"
 ----------------------------------------------------------------------------
@@ -321,9 +342,7 @@ main = withJS $ do
         case result of
           Right Response{..} -> do
             status `shouldBe` Just 200
-            case body of
-              JSON.Object o -> M.member "url" o `shouldBe` True
-              _             -> False `shouldBe` True
+            memberKey "url" body `shouldBe` True
           Left _ -> False `shouldBe` True
 
       it "Should getJSON_ report an HTTP error status" $ do
@@ -343,11 +362,8 @@ main = withJS $ do
         case result of
           Right Response{..} -> do
             status `shouldBe` Just 200
-            case body of
-              JSON.Object o ->
-                M.lookup "json" o `shouldBe`
-                  Just (JSON.Object (M.fromList [("px", JSON.Number 3), ("py", JSON.Number 4)]))
-              _ -> False `shouldBe` True
+            lookupKey "json" body `shouldBe`
+              Just (JSON.object [("px", JSON.Number 3), ("py", JSON.Number 4)])
           Left _ -> False `shouldBe` True
 
       it "Should putJSON_ successfully" $ do
@@ -613,19 +629,19 @@ main = withJS $ do
       it "Should decode a string" $ do
         decodePure "\"a foo bar \"" `shouldBe` Right (JSON.String "a foo bar ")
       it "Should decode an empty list" $ do
-        decodePure "[]" `shouldBe` Right (JSON.Array [])
+        decodePure "[]" `shouldBe` Right (jsonArray [])
       it "Should decode an empty with an empty string" $ do
-        decodePure "[\"\"]" `shouldBe` Right (JSON.Array [ JSON.String "" ])
+        decodePure "[\"\"]" `shouldBe` Right (jsonArray [ JSON.String "" ])
       it "Should decode an empty object" $ do
         decodePure "{}" `shouldBe` Right (JSON.Object mempty)
       it "Should decode a homogenous list" $ do
         decodePure "[1,2,3]" `shouldBe`
-          Right (JSON.Array [JSON.Number 1, JSON.Number 2, JSON.Number 3])
+          Right (jsonArray [JSON.Number 1, JSON.Number 2, JSON.Number 3])
       it "Should decode a heterogenous list" $ do
         decodePure "[1,true,null]" `shouldBe`
-          Right (JSON.Array [JSON.Number 1, JSON.Bool True, JSON.Null])
+          Right (jsonArray [JSON.Number 1, JSON.Bool True, JSON.Null])
         decodePure "{\"a\":true,\"b\":1.1}"
-          `shouldBe` Right (JSON.Object (M.fromList [("a",JSON.Bool True),("b",JSON.Number 1.1)]))
+          `shouldBe` Right (JSON.object [("a",JSON.Bool True),("b",JSON.Number 1.1)])
 
     describe "Miso.JSON generic encoding tests" $ do
       -- Nullary sum constructors → bare String (allNullaryToStringTag = True)
@@ -654,7 +670,7 @@ main = withJS $ do
       -- not spread as multiple positional elements (parseProd gFieldCount fix)
       it "encodes single-constructor list field as bare array" $ do
         JSON.toJSON (WrapperList ["x", "y", "z"])
-          `shouldBe` JSON.Array [JSON.String "x", JSON.String "y", JSON.String "z"]
+          `shouldBe` jsonArray [JSON.String "x", JSON.String "y", JSON.String "z"]
       it "round-trips single-constructor list field" $ do
         (JSON.fromJSON (JSON.toJSON (WrapperList ["x", "y", "z"])) :: JSON.Result WrapperList)
           `shouldBe` JSON.Success (WrapperList ["x", "y", "z"])
@@ -670,7 +686,7 @@ main = withJS $ do
         JSON.toJSON (Rectangle 3.0 4.0)
           `shouldBe` JSON.object
             [ ("tag", JSON.String "Rectangle")
-            , ("contents", JSON.Array [JSON.Number 3.0, JSON.Number 4.0])
+            , ("contents", jsonArray [JSON.Number 3.0, JSON.Number 4.0])
             ]
       -- Sum nullary → {"tag":"C"}
       it "encodes sum nullary constructor as tagged object" $ do
@@ -747,7 +763,7 @@ main = withJS $ do
         JSON.toJSON (NestedList ["a", "b", "c"])
           `shouldBe` JSON.object
             [ ("tag",      JSON.String "NestedList")
-            , ("contents", JSON.Array [JSON.String "a", JSON.String "b", JSON.String "c"])
+            , ("contents", jsonArray [JSON.String "a", JSON.String "b", JSON.String "c"])
             ]
       it "round-trips single-field list constructor" $ do
         (JSON.fromJSON (JSON.toJSON (NestedList ["a", "b", "c"])) :: JSON.Result NestedList)
@@ -777,7 +793,7 @@ main = withJS $ do
           ]
         -- decoding with default opts fails (looks for "firstName")
         (JSON.fromJSON val :: JSON.Result CamelRecord)
-          `shouldBe` JSON.Error "Key not found: firstName"
+          `shouldSatisfy` isError
         -- decoding with matching opts succeeds
         JSON.parseEither (JSON.genericParseJSON opts) val
           `shouldBe` Right (CamelRecord "John" "Doe")
@@ -808,7 +824,7 @@ main = withJS $ do
         result `shouldBe` Right (NestedList ["a", "b"])
       -- #8: parseProd 0-field constructor only accepts Array []
       it "encodes 0-field constructor as Array []" $ do
-        JSON.toJSON Nullary `shouldBe` JSON.Array []
+        JSON.toJSON Nullary `shouldBe` jsonArray []
       it "round-trips 0-field constructor" $ do
         (JSON.fromJSON (JSON.toJSON Nullary) :: JSON.Result Nullary)
           `shouldBe` JSON.Success Nullary
@@ -850,19 +866,19 @@ main = withJS $ do
       -- [a] for non-Char encodes as a JSON array (default toJSONList)
       it "encodes [Int] as a JSON array" $ do
         JSON.toJSON ([1,2,3] :: [Int])
-          `shouldBe` JSON.Array [JSON.Number 1, JSON.Number 2, JSON.Number 3]
+          `shouldBe` jsonArray [JSON.Number 1, JSON.Number 2, JSON.Number 3]
       it "encodes empty [Int] as an empty JSON array" $ do
-        JSON.toJSON ([] :: [Int]) `shouldBe` JSON.Array []
+        JSON.toJSON ([] :: [Int]) `shouldBe` jsonArray []
       -- [String] is an array of JSON strings (each element via the Char path)
       it "encodes [String] as an array of JSON strings" $ do
         JSON.toJSON (["foo", "bar"] :: [String])
-          `shouldBe` JSON.Array [JSON.String "foo", JSON.String "bar"]
+          `shouldBe` jsonArray [JSON.String "foo", JSON.String "bar"]
       -- nested lists still nest as arrays
       it "encodes [[Int]] as a JSON array of arrays" $ do
         JSON.toJSON ([[1,2],[3]] :: [[Int]])
-          `shouldBe` JSON.Array
-            [ JSON.Array [JSON.Number 1, JSON.Number 2]
-            , JSON.Array [JSON.Number 3]
+          `shouldBe` jsonArray
+            [ jsonArray [JSON.Number 1, JSON.Number 2]
+            , jsonArray [JSON.Number 3]
             ]
       -- round-trips through toJSON/fromJSON
       it "round-trips String through toJSON/fromJSON" $ do
@@ -1560,10 +1576,10 @@ main = withJS $ do
       it "Should marshal a Value(Object)" $ do
         (`shouldBe` Just (JSON.object [ "foo" JSON..= True ])) =<< liftIO (fromJSVal =<< toJSVal (JSON.object [ "foo" JSON..= True ]))
       it "Should marshal a Value(Array)" $ do
-        (`shouldBe` Just (JSON.Array [ JSON.Number 1.0, JSON.Number 2.0 ])) =<<
-          liftIO (fromJSVal =<< toJSVal (JSON.Array [ JSON.Number 1.0, JSON.Number 2.0 ]))
+        (`shouldBe` Just (jsonArray [ JSON.Number 1.0, JSON.Number 2.0 ])) =<<
+          liftIO (fromJSVal =<< toJSVal (jsonArray [ JSON.Number 1.0, JSON.Number 2.0 ]))
       it "Should marshal a Value(Number)" $ do
-        (`shouldBe` Just (JSON.Number pi)) =<< liftIO (fromJSVal =<< toJSVal (JSON.Number pi))
+        (`shouldBe` Just (JSON.toJSON (pi :: Double))) =<< liftIO (fromJSVal =<< toJSVal (JSON.toJSON (pi :: Double)))
       it "Should marshal a Value(Bool(False))" $ do
         (`shouldBe` Just (JSON.Bool False)) =<< liftIO (fromJSVal =<< toJSVal (JSON.Bool False))
       it "Should marshal a Value(Bool(True))" $ do
@@ -1593,9 +1609,9 @@ main = withJS $ do
       it "Should marshal a Natural" $ do
         JSON.fromJSON (JSON.toJSON (99 :: Natural)) `shouldBe` (JSON.Success (99 :: Natural))
         JSON.fromJSON (JSON.toJSON (0 :: Natural)) `shouldBe` (JSON.Success (0 :: Natural))
-        (JSON.fromJSON (JSON.Number $ -99.00) :: JSON.Result Natural) `shouldBe` JSON.Error "Cannot parse negative number as Natural: -99"
-        ((JSON.fromJSON (JSON.Number $ 0/0)) :: JSON.Result Natural) `shouldBe` JSON.Error "Cannot parse NaN as Natural: NaN"
-        (JSON.fromJSON (JSON.Number 15.24) :: JSON.Result Natural) `shouldBe` JSON.Success 15
+        (JSON.fromJSON (JSON.Number $ -99.00) :: JSON.Result Natural) `shouldSatisfy` isError
+        ((JSON.fromJSON (JSON.toJSON (0/0 :: Double))) :: JSON.Result Natural) `shouldSatisfy` isError
+        (JSON.fromJSON (JSON.Number 15) :: JSON.Result Natural) `shouldBe` JSON.Success 15
       it "Should marshal a MisoString" $ do
         (`shouldBe` Just ("foo" :: MisoString)) =<< liftIO (fromJSVal =<< toJSVal ("foo" :: MisoString))
       it "Should marshal a (Maybe Bool)" $ do


### PR DESCRIPTION
When the (default: off) `aeson` flag is enabled, `-DAESON` is set and `Miso.JSON` keeps its API but is implemented on top of `aeson`:

* `Value`/`Object`/`Pair`/`Parser` become aeson's types; Result stays miso's (`MisoString` error messages), with `fromJSON`/`parseEither` converting.
* Accessors `(.:)`, `(.:?)`, `(.:!)`, `(.=)` keep `MisoString` keys via `Key` conversion; `withArray` still hands the continuation [`Value`] (`Foldable` over `aeson`'s `Vector`); `withNumber` still yields `Double` (via `Scientific`).
* Miso's `Generic` deriving machinery (`GToJSON` et al) is CPP'd out of the export list; `aeson`'s `genericToJSON`/`Options`/`camelTo2` are re-exported.
* On JS/WASM backends, orphan `To`/`FromJSON`(`Key`) instances make `JSString` a first-class JSON citizen, and the `JSVal` marshalling arms go through small representation-agnostic bridge helpers.
* `Miso.JSON.Parser.decodePure` delegates to aeson's pure parser.
* The test suite is now representation-agnostic (`jsonArray`/`lookupKey` helpers, no direct `Map`/`[Value]` construction, no exact error strings).
* New tests/Makefile 'aeson' target and `playwright-wasm-aeson` nix derivation, wired into CI after `playwright-wasm`.