### PR TITLE
`feat`: Add `Miso.Native.Lynxtron` bridge module and Lynxtron desktop sample

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ haddocks/
 sample-app-native/android/app/src/main/assets/main.lynx.bundle
 sample-app-native/android/app/src/main/assets/main.lynx.bundle.sha256
 
+
+# Lynxtron desktop host (hand-written, not TS output)
+!sample-app-native/desktop/*.js

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to `miso` are documented here.
 
+## Unreleased
+
+### Added
+
+- **Lynxtron desktop bridge.** New `Miso.Native.Lynxtron` module binding the
+  card ↔ Node.js bridge of [Lynxtron](https://github.com/lynx-family/lynxtron),
+  the Electron-style desktop host for Lynx bundles: `invokeNode` / `sendNode`
+  (card → main process), `nodeEventSub` (`sendGlobalEvent` → `Sub`),
+  `callExposed` (`contextBridge.exposeInLynxBTS` functions, Promise-aware), and
+  `isLynxtron`. Bundles built with `mkLynxBundle` load in Lynxtron unchanged.
+  Sample: `app-native-lynxtron` + `sample-app-native/desktop/` host, built
+  with `nix build .#sample-app-native-lynxtron-bundle`.
+
 ## 1.13.0.0
 
 ### Added

--- a/flake.nix
+++ b/flake.nix
@@ -100,6 +100,15 @@
             styles = ./sample-app-native/conformance.css;
           };
 
+          # Lynxtron desktop sample: exercises the card <-> Node bridge
+          # (Miso.Native.Lynxtron). Host it with sample-app-native/desktop.
+          sample-app-native-lynxtron-bundle = pkgs.mkLynxBundle {
+            name = "sample-app-native-lynxtron-bundle";
+            jsDrv = pkgs.pkgsCross.ghcjs.haskell.packages.ghcNative.sample-app-native;
+            exeName = "app-native-lynxtron";
+            styles = ./sample-app-native/conformance.css;
+          };
+
           # Util
           inherit (pkgs.haskell.packages.ghc9122)
             miso-from-html;

--- a/miso.cabal
+++ b/miso.cabal
@@ -238,6 +238,7 @@ library
       Miso.Native.Element.View.Property
       Miso.Native.Event
       Miso.Native.FFI
+      Miso.Native.Lynxtron
       Miso.Native.Module
       Miso.Native.X.Element
       Miso.Native.X.Element.BlurView

--- a/sample-app-native/Lynxtron.hs
+++ b/sample-app-native/Lynxtron.hs
@@ -1,0 +1,202 @@
+-----------------------------------------------------------------------------
+{-# LANGUAGE DeriveAnyClass     #-}
+{-# LANGUAGE DeriveGeneric      #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE LambdaCase         #-}
+{-# LANGUAGE OverloadedStrings  #-}
+{-# LANGUAGE RecordWildCards    #-}
+{-# LANGUAGE StaticPointers     #-}
+-----------------------------------------------------------------------------
+-- | Lynxtron desktop sample. Exercises every channel of the card ↔ Node bridge
+-- from "Miso.Native.Lynxtron":
+--
+--   * 'invokeNode'   — ask the main process for its @os@ info (request/reply)
+--   * 'sendNode'     — log a line to the main process' stdout (fire-and-forget)
+--   * 'callExposed'  — call @contextBridge.exposeInLynxBTS@ functions from
+--                      @desktop/preload.js@ (sync + async, nested)
+--   * 'nodeEventSub' — receive the 1 Hz @tick@ the main process pushes with
+--                      @win.sendGlobalEvent@
+--
+-- The Node side lives in @desktop/main.js@ and @desktop/preload.js@. The same
+-- bundle still boots on iOS / Android; 'isLynxtron' reports which host we're on.
+module Main where
+-----------------------------------------------------------------------------
+import           GHC.Generics (Generic)
+import           Miso hiding (text_)
+import qualified Miso.CSS as CSS
+import           Miso.Html.Property (id_)
+import           Miso.JSON (FromJSON, ToJSON, Value(..), object, (.=))
+import           Miso.Native
+import           Miso.Native.Lynxtron
+import qualified Miso.Native.Element.View.Event as VE
+-----------------------------------------------------------------------------
+data Action
+  = Boot
+  | Detected Bool
+  | AskOs
+  | GotOs OsInfo
+  | Greet
+  | Greeted MisoString
+  | CheckFile
+  | FileChecked Bool
+  | LogLine
+  | Tick Int
+  | BridgeError MisoString
+  deriving stock (Generic)
+  deriving anyclass (ToJSON, FromJSON)
+
+-- | Reply shape of the @os-info@ handler in @desktop/main.js@.
+data OsInfo = OsInfo
+  { platform :: MisoString
+  , arch     :: MisoString
+  , hostname :: MisoString
+  , node     :: MisoString
+  } deriving stock (Eq, Show, Generic)
+    deriving anyclass (ToJSON, FromJSON)
+
+data Model = Model
+  { desktop   :: Maybe Bool
+  , osInfo    :: Maybe OsInfo
+  , greeting  :: MisoString
+  , fileState :: MisoString
+  , ticks     :: Int
+  , sent      :: Int
+  , lastError :: MisoString
+  } deriving stock (Eq, Generic)
+    deriving anyclass (ToJSON, FromJSON)
+-----------------------------------------------------------------------------
+main :: IO ()
+main =
+  nativeWithContext nativeEvents ()
+    (static (mountStatic app))
+
+app :: Component () () Model Action
+app = (component initialModel updateModel viewModel)
+  { subs        = [ nodeEventSub "tick" (either BridgeError Tick) ]
+  , mount       = Just Boot
+  }
+  where
+    initialModel = Model
+      { desktop   = Nothing
+      , osInfo    = Nothing
+      , greeting  = "-"
+      , fileState = "-"
+      , ticks     = 0
+      , sent      = 0
+      , lastError = ""
+      }
+-----------------------------------------------------------------------------
+updateModel :: Action -> Effect () () Model Action
+updateModel = \case
+  Boot ->
+    io (Detected <$> isLynxtron)
+  Detected b ->
+    modify $ \m -> m { desktop = Just b }
+
+  -- card -> node, request/reply (lynxBridge.handle('os-info', ...))
+  AskOs ->
+    io_' $ \sink -> invokeNode "os-info" (object []) (sink . either BridgeError GotOs)
+  GotOs info ->
+    modify $ \m -> m { osInfo = Just info, lastError = "" }
+
+  -- node -> card API (contextBridge.exposeInLynxBTS, async fn)
+  Greet ->
+    io_' $ \sink -> callExposedWith "greet" [String "miso"] (sink . either BridgeError Greeted)
+  Greeted s ->
+    modify $ \m -> m { greeting = s, lastError = "" }
+
+  -- node -> card API, nested object + Promise
+  CheckFile ->
+    io_' $ \sink -> callExposedWith "fileApi.exists" [String "package.json"] (sink . either BridgeError FileChecked)
+  FileChecked b ->
+    modify $ \m -> m { fileState = if b then "package.json exists" else "package.json missing", lastError = "" }
+
+  -- card -> node, fire-and-forget (win.on('-lynx-message'))
+  LogLine -> do
+    n <- (+ 1) . sent <$> get
+    modify $ \m -> m { sent = n }
+    io_ $ sendNode "log" (object [ "line" .= ("hello from miso #" <> ms (show n) :: MisoString) ])
+
+  -- node -> card global event (win.sendGlobalEvent('tick', n))
+  Tick n ->
+    modify $ \m -> m { ticks = n }
+
+  BridgeError e ->
+    modify $ \m -> m { lastError = e }
+  where
+    -- run a BTS IO action that dispatches its result back through the sink
+    io_' = withSink
+-----------------------------------------------------------------------------
+viewModel :: () -> () -> Model -> View () Model Action
+viewModel _ _ Model{..} =
+  view_
+    [ id_ "root"
+    , CSS.style_
+      [ CSS.width "100%"
+      , CSS.height "100vh"
+      , CSS.display "flex"
+      , CSS.flexDirection "column"
+      , CSS.padding "24px"
+      , CSS.backgroundColor (CSS.RGB 15 23 42)
+      ]
+    ]
+    [ heading "miso × Lynxtron"
+    , statusLine $ case desktop of
+        Nothing    -> "detecting host…"
+        Just True  -> "host: Lynxtron (NativeModules.bridge present)"
+        Just False -> "host: not Lynxtron — bridge calls will no-op"
+    , statusLine ("ticks from main process: " <> ms (show ticks))
+    , tapButton "ask-os" "invokeNode \"os-info\"" AskOs CSS.steelblue
+    , statusLine $ case osInfo of
+        Nothing        -> "os: -"
+        Just OsInfo{..} -> "os: " <> platform <> "/" <> arch <> " on " <> hostname <> " (node " <> node <> ")"
+    , tapButton "greet" "callExposed \"greet\" (async)" Greet CSS.seagreen
+    , statusLine ("greeting: " <> greeting)
+    , tapButton "check-file" "callExposed \"fileApi.exists\" (nested)" CheckFile CSS.darkslategray
+    , statusLine ("file: " <> fileState)
+    , tapButton "log" "sendNode \"log\" (fire-and-forget)" LogLine (CSS.RGB 124 58 237)
+    , statusLine ("sent: " <> ms (show sent) <> " — check the terminal running lynxtron")
+    , errorLine lastError
+    ]
+-----------------------------------------------------------------------------
+heading :: MisoString -> View context Model Action
+heading s =
+  text_
+    [ CSS.style_
+      [ CSS.fontSize "24px", CSS.fontWeight "700", CSS.color CSS.white
+      , CSS.lineHeight "1.4", CSS.marginBottom "12px" ]
+    ]
+    [ text s ]
+
+statusLine :: MisoString -> View context Model Action
+statusLine s =
+  text_
+    [ CSS.style_
+      [ CSS.fontSize "14px", CSS.color CSS.lime, CSS.lineHeight "1.4"
+      , CSS.marginBottom "10px" ]
+    ]
+    [ text s ]
+
+errorLine :: MisoString -> View context Model Action
+errorLine "" = view_ [] []
+errorLine e =
+  text_
+    [ CSS.style_ [ CSS.fontSize "13px", CSS.color CSS.tomato, CSS.lineHeight "1.4" ] ]
+    [ text ("error: " <> e) ]
+
+tapButton :: MisoString -> MisoString -> Action -> CSS.Color -> View context Model Action
+tapButton ident caption action bg =
+  view_
+    [ id_ ident
+    , VE.onTap action
+    , CSS.style_
+      [ CSS.width "100%", CSS.height "56px", CSS.flexShrink 0
+      , CSS.display "flex", CSS.alignItems "center", CSS.justifyContent "center"
+      , CSS.marginBottom "8px", CSS.borderRadius "10px", CSS.backgroundColor bg
+      ]
+    ]
+    [ text_
+      [ CSS.style_ [ CSS.fontSize "15px", CSS.fontWeight "600", CSS.color CSS.white ] ]
+      [ text caption ]
+    ]
+-----------------------------------------------------------------------------

--- a/sample-app-native/README.md
+++ b/sample-app-native/README.md
@@ -18,3 +18,22 @@ Both bundle derivations produce `main.lynx.bundle` and
 `main.lynx.bundle.sha256`. To run either with the Android host, copy both files
 from the same derivation into `android/app/src/main/assets/`; the Gradle
 `preBuild` gate rejects a missing or mismatched pair.
+
+## Lynxtron (desktop)
+
+`app-native-lynxtron` is a desktop sample for
+[Lynxtron](https://github.com/lynx-family/lynxtron), an Electron-style host
+that runs ordinary Lynx bundles in Node-managed windows. It exercises every
+channel of `Miso.Native.Lynxtron` (request/reply, fire-and-forget, Node → card
+events, and `contextBridge.exposeInLynxBTS` functions).
+
+```bash
+nix build .#sample-app-native-lynxtron-bundle     # => ./result/main.lynx.bundle
+cd sample-app-native/desktop
+npm install                                        # pulls @lynx-js/lynxtron + binary (macOS / Windows)
+npm start                                          # loads ../../result/main.lynx.bundle
+```
+
+`desktop/main.js` is the main process (`LynxWindow`, `lynxBridge.handle`,
+`sendGlobalEvent`); `desktop/preload.js` exposes Node functions to the card.
+Point `MISO_BUNDLE` at another bundle to host it instead.

--- a/sample-app-native/README.md
+++ b/sample-app-native/README.md
@@ -30,8 +30,8 @@ events, and `contextBridge.exposeInLynxBTS` functions).
 ```bash
 nix build .#sample-app-native-lynxtron-bundle     # => ./result/main.lynx.bundle
 cd sample-app-native/desktop
-npm install                                        # pulls @lynx-js/lynxtron + binary (macOS / Windows)
-npm start                                          # loads ../../result/main.lynx.bundle
+npm install   # or: bun install — pulls @lynx-js/lynxtron + binary (macOS / Windows)
+npm start     # or: bun run start — loads ../../result/main.lynx.bundle
 ```
 
 `desktop/main.js` is the main process (`LynxWindow`, `lynxBridge.handle`,

--- a/sample-app-native/app.cabal
+++ b/sample-app-native/app.cabal
@@ -34,3 +34,15 @@ executable app-native-conformance
     base, miso
   default-language:
     Haskell2010
+
+-- Lynxtron desktop sample: exercises the card <-> Node bridge. Host lives in
+-- ./desktop (main.js, preload.js).
+executable app-native-lynxtron
+  import:
+    options
+  main-is:
+    Lynxtron.hs
+  build-depends:
+    base, miso
+  default-language:
+    Haskell2010

--- a/sample-app-native/desktop/.gitignore
+++ b/sample-app-native/desktop/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/sample-app-native/desktop/.gitignore
+++ b/sample-app-native/desktop/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 package-lock.json
+bun.lock

--- a/sample-app-native/desktop/main.js
+++ b/sample-app-native/desktop/main.js
@@ -1,0 +1,59 @@
+// Lynxtron main process for the miso sample. Pairs with ../Lynxtron.hs.
+//
+// Usage:
+//   nix build ..#sample-app-native-lynxtron-bundle -o bundle   (from repo root)
+//   cd sample-app-native/desktop && npm install && npm start
+//
+// Set MISO_BUNDLE to point at a different main.lynx.bundle.
+const { app, LynxWindow, lynxBridge } = require('@lynx-js/lynxtron');
+const os = require('node:os');
+const path = require('node:path');
+const fs = require('node:fs');
+
+const bundle =
+  process.env.MISO_BUNDLE ||
+  path.resolve(__dirname, '../../result/main.lynx.bundle');
+
+// card -> node, request/reply: Haskell `invokeNode "os-info"`.
+lynxBridge.handle('os-info', () => ({
+  platform: process.platform,
+  arch: process.arch,
+  hostname: os.hostname(),
+  node: process.versions.node,
+}));
+
+async function createWindow() {
+  if (!fs.existsSync(bundle)) {
+    console.error(`bundle not found: ${bundle}\nbuild it with: nix build .#sample-app-native-lynxtron-bundle`);
+    app.quit();
+    return;
+  }
+  const win = new LynxWindow({
+    width: 520,
+    height: 720,
+    title: 'miso × Lynxtron',
+    lynxPreference: {
+      // node -> card API surface: Haskell `callExposed`.
+      preload: path.join(__dirname, 'preload.js'),
+    },
+  });
+
+  // card -> node, fire-and-forget: Haskell `sendNode "log" {...}`.
+  win.on('-lynx-message', (name, params) => {
+    if (name === 'log') console.log('[card]', params.line);
+    else console.log('[card message]', name, params);
+  });
+
+  win.show();
+  await win.loadFile(bundle);
+
+  // node -> card global event: Haskell `nodeEventSub "tick"`.
+  let n = 0;
+  const timer = setInterval(() => {
+    if (win.isDestroyed()) return clearInterval(timer);
+    win.sendGlobalEvent('tick', ++n);
+  }, 1000);
+}
+
+app.whenReady().then(createWindow);
+app.on('window-all-closed', () => app.quit());

--- a/sample-app-native/desktop/package.json
+++ b/sample-app-native/desktop/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "miso-lynxtron-sample",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Lynxtron desktop host for the miso `app-native-lynxtron` bundle",
+  "main": "main.js",
+  "scripts": {
+    "start": "lynxtron ."
+  },
+  "devDependencies": {
+    "@lynx-js/lynxtron": "^0.0.15"
+  }
+}

--- a/sample-app-native/desktop/package.json
+++ b/sample-app-native/desktop/package.json
@@ -9,5 +9,8 @@
   },
   "devDependencies": {
     "@lynx-js/lynxtron": "^0.0.15"
-  }
+  },
+  "trustedDependencies": [
+    "@lynx-js/lynxtron"
+  ]
 }

--- a/sample-app-native/desktop/preload.js
+++ b/sample-app-native/desktop/preload.js
@@ -1,0 +1,17 @@
+// Runs in the Lynx background thread with Node access. Everything passed to
+// `exposeInLynxBTS` appears as `NativeModules.nodejs.exposed.<name>` and is
+// reachable from Haskell via `Miso.Native.Lynxtron.callExposed`.
+const { contextBridge } = require('@lynx-js/lynxtron/context-bridge');
+const fs = require('node:fs/promises');
+
+contextBridge.exposeInLynxBTS({
+  // async — callExposed awaits the Promise
+  greet: async (who) => `hello, ${who}, from node ${process.versions.node}`,
+
+  // nested object — addressed as "fileApi.exists"
+  fileApi: {
+    exists: async (p) => {
+      try { await fs.access(p); return true; } catch { return false; }
+    },
+  },
+});

--- a/src/Miso/Native/Lynxtron.hs
+++ b/src/Miso/Native/Lynxtron.hs
@@ -1,0 +1,201 @@
+-----------------------------------------------------------------------------
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Miso.Native.Lynxtron
+-- Copyright   :  (C) 2016-2026 David M. Johnson
+-- License     :  BSD3-style (see the file LICENSE)
+-- Maintainer  :  David M. Johnson <code@dmj.io>
+-- Stability   :  experimental
+-- Portability :  non-portable
+--
+-- Bindings to the <https://github.com/lynx-family/lynxtron Lynxtron> desktop
+-- host. Lynxtron is Electron with the Chromium half replaced by Lynx: a Node.js
+-- __main process__ (@app@, @LynxWindow@, @Menu@, @Tray@, @dialog@, …) hosts
+-- ordinary @.lynx.bundle@s as windows. The bundle miso already produces for
+-- iOS \/ Android (see @mkLynxBundle@) loads unchanged; this module covers the
+-- one thing that is Lynxtron-specific — the __card ↔ Node bridge__.
+--
+-- Four channels exist, all on the background thread (BTS):
+--
+-- +--------------------+-----------------------------------+----------------------------------------------------+
+-- | Direction          | Haskell (card, BTS)               | Node (main process)                                |
+-- +====================+===================================+====================================================+
+-- | card → node, reply | 'invokeNode'                      | @lynxBridge.handle(name, (ev, args) => result)@    |
+-- +--------------------+-----------------------------------+----------------------------------------------------+
+-- | card → node, fire  | 'sendNode'                        | @win.on('-lynx-message', (name, args) => …)@       |
+-- +--------------------+-----------------------------------+----------------------------------------------------+
+-- | node → card, event | 'nodeEventSub'                    | @win.sendGlobalEvent(name, payload)@               |
+-- +--------------------+-----------------------------------+----------------------------------------------------+
+-- | node → card, API   | 'callExposed'                     | preload: @contextBridge.exposeInLynxBTS({ f })@    |
+-- +--------------------+-----------------------------------+----------------------------------------------------+
+--
+-- The bridge lives on the BTS @NativeModules@ object, so — like everything in
+-- "Miso.Native.Module" — these are plain 'IO' actions that must run on the
+-- BTS: from the @update@ of a BTS handler (@event . static@), an 'Miso.Effect.io_',
+-- or a background-thread subscription. 'nodeEventSub' guards itself with
+-- 'onBTS'; the rest log to the console and no-op if the bridge is missing
+-- (e.g. when the same bundle runs on a mobile host or the web).
+--
+-- @since 1.14.0.0
+----------------------------------------------------------------------------
+module Miso.Native.Lynxtron
+  ( -- * Card → Node
+    invokeNode
+  , sendNode
+    -- * Node → Card
+  , nodeEventSub
+  , callExposed
+  , callExposedWith
+    -- * Introspection
+  , isLynxtron
+  ) where
+----------------------------------------------------------------------------
+import           Control.Exception (try, SomeException, displayException)
+import           Control.Monad (void, when)
+----------------------------------------------------------------------------
+import           Miso.DSL
+import           Miso.Effect (Sub)
+import           Miso.FFI (consoleError, onBTS)
+import           Miso.JSON
+  ( Value, ToJSON(..), FromJSON, fromJSON, Result(..), toJSVal_Value, fromJSVal_Value )
+import           Miso.Native.Module (callNativeModule, callNativeModuleWith, getNativeModule)
+import           Miso.String (MisoString, ms, fromMisoString)
+----------------------------------------------------------------------------
+-- | 'True' when running inside a Lynxtron window — i.e. @NativeModules.bridge@
+-- is present. Lets one bundle branch between desktop and mobile behaviour.
+--
+-- __N.B.__ must be run on the background thread (BTS); always 'False' on the MTS.
+isLynxtron :: IO Bool
+isLynxtron = do
+  bts <- onBTS
+  if not bts then pure False else do
+    r <- try (getNativeModule "bridge")
+    case r of
+      Left (_ :: SomeException) -> pure False
+      Right b -> not <$> isUndefined b
+----------------------------------------------------------------------------
+-- | Request \/ reply round-trip to the main process:
+-- @NativeModules.bridge.call(name, params, callback)@. Node answers with
+-- @lynxBridge.handle(name, (event, args) => result)@ (or
+-- @event.sendReply(result)@) and the continuation receives the decoded reply.
+--
+-- > invokeNode "read-file" (object ["path" .= "/etc/hosts"]) $ \case
+-- >   Right (contents :: MisoString) -> sink (GotFile contents)
+-- >   Left err                       -> sink (BridgeError err)
+--
+-- __N.B.__ must be run on the background thread (BTS).
+invokeNode
+  :: (ToJSON params, FromJSON result)
+  => MisoString
+  -- ^ Channel name (matches @lynxBridge.handle(name, …)@)
+  -> params
+  -- ^ Payload, JSON-encoded
+  -> (Either MisoString result -> IO ())
+  -- ^ Continuation, fired exactly once
+  -> IO ()
+invokeNode name params k =
+  callNativeModuleWith "bridge" "call" [toJSON' name, toJSON params] k
+----------------------------------------------------------------------------
+-- | Fire-and-forget message to the main process:
+-- @NativeModules.bridge.send(name, params)@. Node observes it via
+-- @win.on('-lynx-message', (name, params) => …)@.
+--
+-- __N.B.__ must be run on the background thread (BTS).
+sendNode :: ToJSON params => MisoString -> params -> IO ()
+sendNode name params =
+  callNativeModule "bridge" "send" [toJSON' name, toJSON params]
+----------------------------------------------------------------------------
+-- | Subscribe to global events pushed from the main process with
+-- @win.sendGlobalEvent(name, payload)@. Wraps
+-- @lynx.getJSModule('GlobalEventEmitter').addListener(name, …)@.
+--
+-- > subs = [ nodeEventSub "tick" (either BridgeError Tick) ]
+--
+-- Subs start on both threads (see "Miso.Native"); this one is BTS-only and the
+-- MTS copy returns immediately.
+nodeEventSub
+  :: FromJSON payload
+  => MisoString
+  -- ^ Event name
+  -> (Either MisoString payload -> action)
+  -- ^ Decode result → action
+  -> Sub action
+nodeEventSub name f sink = do
+  bts <- onBTS
+  when bts $ do
+    emitter <- jsg "lynx" # "getJSModule" $ ["GlobalEventEmitter" :: MisoString]
+    undef   <- isUndefined emitter
+    if undef
+      then consoleError "nodeEventSub: GlobalEventEmitter is undefined"
+      else do
+        cb <- asyncCallback1 $ \jval -> do
+          mv <- fromJSVal_Value jval
+          case fromJSON <$> mv of
+            Just (Success x) -> sink (f (Right x))
+            Just (Error e)   -> sink (f (Left (ms e)))
+            Nothing          -> sink (f (Left "nodeEventSub: unreadable payload"))
+        lynx  <- jsg "lynx"
+        nameV <- toJSVal name
+        void $ emitter # "addListener" $ [nameV, cb, lynx]
+----------------------------------------------------------------------------
+-- | Call a function the main process exposed through a preload script with
+-- @contextBridge.exposeInLynxBTS({ f: … })@ — i.e.
+-- @NativeModules.nodejs.exposed.f(args…)@. The exposed function may be sync or
+-- @async@; a returned Promise is awaited. Nested objects are addressed with a
+-- dotted path (@"fileApi.exists"@).
+--
+-- > r <- callExposed "hostname" []
+-- > r <- callExposed "fileApi.exists" [String "/tmp/x"]
+--
+-- __N.B.__ must be run on the background thread (BTS).
+callExposed :: FromJSON result => MisoString -> [Value] -> IO (Either MisoString result)
+callExposed path args = do
+  r <- try $ do
+    exposed <- getNativeModule "nodejs" ! ("exposed" :: MisoString)
+    undef   <- isUndefined exposed
+    when undef $ consoleError "callExposed: NativeModules.nodejs.exposed is undefined"
+    (owner, fn) <- resolve exposed (splitDots path)
+    jsArgs  <- traverse toJSVal_Value args
+    ret     <- owner # fn $ jsArgs
+    settled <- isPromise ret >>= \p -> if p then await ret else pure ret
+    mv <- fromJSVal_Value settled
+    pure $ case fromJSON <$> mv of
+      Just (Success x) -> Right x
+      Just (Error e)   -> Left (ms e)
+      Nothing          -> Left "callExposed: unreadable result"
+  case r of
+    Left (e :: SomeException) -> do
+      let msg = ms (displayException e)
+      consoleError ("callExposed: " <> msg)
+      pure (Left msg)
+    Right v -> pure v
+  where
+    resolve obj [fn]     = pure (obj, fn)
+    resolve obj (p : ps) = (obj ! p) >>= \o -> resolve o ps
+    resolve obj []       = pure (obj, "")
+----------------------------------------------------------------------------
+-- | Continuation-passing 'callExposed', convenient inside 'Miso.Effect.io_'.
+callExposedWith
+  :: FromJSON result
+  => MisoString -> [Value] -> (Either MisoString result -> IO ()) -> IO ()
+callExposedWith path args k = callExposed path args >>= k
+----------------------------------------------------------------------------
+isPromise :: JSVal -> IO Bool
+isPromise v = do
+  undef <- isUndefined v
+  nul   <- isNull v
+  if undef || nul then pure False else do
+    th <- v ! ("then" :: MisoString)
+    u  <- isUndefined th
+    pure (not u)
+
+toJSON' :: MisoString -> Value
+toJSON' = toJSON
+
+splitDots :: MisoString -> [MisoString]
+splitDots s = case break (== '.') (fromMisoString s) of
+  (a, [])      -> [ms a]
+  (a, _ : rest) -> ms a : splitDots (ms rest)
+----------------------------------------------------------------------------


### PR DESCRIPTION
`Lynxtron` (https://github.com/lynx-family/lynxtron) is an Electron-style desktop host that runs ordinary .lynx.bundle files in Node-managed windows, so the bundle `mkLynxBundle` already produces loads unchanged. The only Lynxtron-specific surface is the card <-> Node bridge, which this module binds on the BTS:

  `invokeNode`     NativeModules.bridge.call   <-> lynxBridge.handle
  `sendNode`       NativeModules.bridge.send   <-> win.on('-lynx-message')
  `nodeEventSub`   GlobalEventEmitter          <-  win.sendGlobalEvent
  `callExposed`    NativeModules.nodejs.exposed <- contextBridge.exposeInLynxBTS
  `isLynxtron`     host detection

Sample: `sample-app-native/Lynxtron.hs` (`app-native-lynxtron` executable, `nix build .#sample-app-native-lynxtron-bundle`) plus a Node host in `sample-app-native/desktop` (`main.js`, `preload.js`) exercising every channel.