### PR TITLE
feat: Eagerly free short-lived `JSVal` handles in the WASM runtime

### DIFF
--- a/ffi/ghc/Miso/DSL/FFI.hs
+++ b/ffi/ghc/Miso/DSL/FFI.hs
@@ -105,6 +105,9 @@ isUndefined_ffi = undefined
 -----------------------------------------------------------------------------
 freeFunction_ffi :: JSVal -> IO ()
 freeFunction_ffi = undefined
+
+freeJSVal_ffi :: JSVal -> IO ()
+freeJSVal_ffi _ = pure ()
 -----------------------------------------------------------------------------
 -- | Schedules a callback to run before the next repaint.
 --

--- a/ffi/js/Miso/DSL/FFI.hs
+++ b/ffi/js/Miso/DSL/FFI.hs
@@ -66,6 +66,7 @@ module Miso.DSL.FFI
   , isNull_ffi
   , jsNull
   , freeFunction_ffi
+  , freeJSVal_ffi
   , listProps_ffi
   , requestAnimationFrame
   , cancelAnimationFrame
@@ -201,6 +202,11 @@ isUndefined_ffi = isUndefined
 freeFunction_ffi :: JSVal -> IO ()
 freeFunction_ffi _ = pure ()
 {-# INLINE freeFunction_ffi #-}
+-----------------------------------------------------------------------------
+-- | No-op on GHCJS: 'JSVal's are ordinary JS references collected by the JS GC.
+freeJSVal_ffi :: JSVal -> IO ()
+freeJSVal_ffi _ = pure ()
+{-# INLINE freeJSVal_ffi #-}
 -----------------------------------------------------------------------------
 foreign import javascript unsafe
 #if GHCJS_NEW

--- a/ffi/wasm/Miso/DSL/FFI.hs
+++ b/ffi/wasm/Miso/DSL/FFI.hs
@@ -68,6 +68,7 @@ module Miso.DSL.FFI
   , isNull_ffi
   , jsNull
   , freeFunction_ffi
+  , freeJSVal_ffi
   , requestAnimationFrame
   , cancelAnimationFrame
   , listProps_ffi
@@ -418,6 +419,11 @@ foreign import javascript unsafe "return $2[$1]"
 freeFunction_ffi :: JSVal -> IO ()
 freeFunction_ffi = freeJSVal
 {-# INLINE freeFunction_ffi #-}
+-----------------------------------------------------------------------------
+-- | Eagerly release a 'JSVal' handle. See 'Miso.DSL.freeJSVal'.
+freeJSVal_ffi :: JSVal -> IO ()
+freeJSVal_ffi = freeJSVal
+{-# INLINE freeJSVal_ffi #-}
 -----------------------------------------------------------------------------
 foreign import javascript unsafe
   """

--- a/src/Miso/DSL.hs
+++ b/src/Miso/DSL.hs
@@ -146,6 +146,7 @@ module Miso.DSL
   , requestAnimationFrame
   , cancelAnimationFrame
   , freeFunction
+  , freeJSVal
   , (!!)
   , isUndefined
   , isNull
@@ -599,7 +600,9 @@ call o this args = do
   o' <- toJSVal =<< toObject o
   this' <- toJSVal =<< toObject this
   args' <- toJSVal =<< toArgs args
-  invokeFunction o' this' args'
+  result <- invokeFunction o' this' args'
+  freeJSVal args'
+  pure result
 {-# INLINABLE call #-}
 -----------------------------------------------------------------------------
 -- | Calls a JS function on an t'Object' at a field with specified arguments.
@@ -609,7 +612,13 @@ infixr 2 #
   o' <- toJSVal =<< toObject o
   func <- getProp_ffi k o'
   args' <- toJSVal =<< toArgs args
-  invokeFunction func o' args'
+  result <- invokeFunction func o' args'
+  -- @func@ and the argument array are temporaries nobody else can reach;
+  -- release them eagerly (see 'freeJSVal'). The argument elements may be the
+  -- caller's handles, so only the array itself is freed.
+  freeJSVal func
+  freeJSVal args'
+  pure result
 {-# INLINABLE (#) #-}
 -----------------------------------------------------------------------------
 -- | Calls a JavaScript t'Function' with the given arguments and marshals
@@ -641,7 +650,9 @@ new
 new constr args = do
   obj <- toJSVal =<< toObject constr
   argv <- toJSVal =<< toArgs args
-  new_ffi obj argv
+  result <- new_ffi obj argv
+  freeJSVal argv
+  pure result
 {-# INLINABLE new #-}
 -----------------------------------------------------------------------------
 -- | Creates a new JS t'Object'
@@ -847,6 +858,30 @@ instance (ToJSVal arg1, ToJSVal arg2, ToJSVal arg3, ToJSVal arg4, ToJSVal arg5, 
 freeFunction :: Function -> IO ()
 freeFunction (Function x) = freeFunction_ffi x
 {-# INLINABLE freeFunction #-}
+-----------------------------------------------------------------------------
+-- | Eagerly release a 'JSVal' handle.
+--
+-- On the WASM backend every 'JSVal' carries a weak pointer and a C finalizer
+-- so that the JavaScript value can be released once the handle is garbage
+-- collected. The RTS must evacuate every such weak pointer on every GC (dead
+-- or alive) before it can run the finalizer, so short-lived handles created
+-- in bulk (e.g. while building a virtual DOM) make each GC pause scale with
+-- the number of handles allocated since the last one. 'freeJSVal' unlinks
+-- the weak pointer and releases the JavaScript side immediately, so the
+-- handle costs the GC nothing.
+--
+-- Only the Haskell handle is released: the JavaScript value itself stays
+-- alive for as long as something on the JavaScript side references it.
+--
+-- Using a 'JSVal' after it has been freed is undefined behaviour, so only
+-- free handles that no other Haskell code (including callbacks that close
+-- over them) can reach. Note that on WASM a 'JSString' /is/ a 'JSVal', so
+-- never free a handle obtained from 'toJSVal' on a string you do not own.
+--
+-- No-op on the GHCJS and native backends.
+freeJSVal :: JSVal -> IO ()
+freeJSVal = freeJSVal_ffi
+{-# INLINABLE freeJSVal #-}
 -----------------------------------------------------------------------------
 instance FromJSVal Function where
   fromJSVal = pure . Just . Function

--- a/src/Miso/Event.hs
+++ b/src/Miso/Event.hs
@@ -216,6 +216,9 @@ onWithOptions phase options eventName Decoder{..} toAction =
                 FFI.consoleError ("[COMPONENT]: No component found at ID: " <> ms vcompId)
               Just ComponentState {..} ->
                 sink (toAction event _componentModel domRef)
+    -- The runtime frees this callback when the vtree that owns it is
+    -- replaced; see Note [Freeing event handler callbacks] in "Miso.Runtime".
+    registerEventHandler cb
     FFI.set "runEvent" cb eventHandlerObject
     FFI.set "options" jsOptions eventHandlerObject
     -- Only 'mainThread'-marked handlers carry their 'StaticKey' \/ @ComponentId@

--- a/src/Miso/Event.hs
+++ b/src/Miso/Event.hs
@@ -233,6 +233,10 @@ onWithOptions phase options eventName Decoder{..} toAction =
       mCid <- fromJSVal pendingCid :: IO (Maybe Int)
       maybe (pure ()) (\c -> FFI.set "componentId" (c :: Int) eventHandlerObject) mCid
     FFI.set eventName eo (Object eventObj)
+    -- The handler object is now reachable from the node; release the scratch
+    -- handles. @decodeAtVal@, @cb@ and @n@ are captured by the callback and
+    -- must stay alive. See Note [Freeing VTree handles] in "Miso.Runtime".
+    mapM_ freeJSVal [eventsVal, eventObj, eo, jsOptions, pendingMT]
 -----------------------------------------------------------------------------
 -- | Fire an action immediately after the DOM element is inserted into the document.
 --

--- a/src/Miso/FFI/Internal.hs
+++ b/src/Miso/FFI/Internal.hs
@@ -441,7 +441,8 @@ updateRef
 {-# INLINABLE updateRef #-}
 updateRef jsval1 jsval2 = do
   moduleMiso <- jsg "miso"
-  void $ moduleMiso # "updateRef" $ (jsval1, jsval2)
+  freeJSVal =<< (moduleMiso # "updateRef" $ (jsval1, jsval2))
+  freeJSVal moduleMiso
 -----------------------------------------------------------------------------
 -- | Convenience function to write inline javascript.
 --
@@ -487,7 +488,8 @@ populateClass
 {-# INLINABLE populateClass #-}
 populateClass domRef classes = do
   moduleMiso <- jsg "miso"
-  void $ moduleMiso # "populateClass" $ (domRef, classes)
+  freeJSVal =<< (moduleMiso # "populateClass" $ (domRef, classes))
+  freeJSVal moduleMiso
 -----------------------------------------------------------------------------
 -- | Retrieves a reference to document body.
 --
@@ -512,7 +514,11 @@ getDocument = jsg "document"
 --
 getDrawingContext :: IO JSVal
 {-# INLINABLE getDrawingContext #-}
-getDrawingContext = jsg "miso" ! "drawingContext"
+getDrawingContext = do
+  moduleMiso <- jsg "miso"
+  context <- moduleMiso ! "drawingContext"
+  freeJSVal moduleMiso
+  pure context
 -----------------------------------------------------------------------------
 -- | Retrieves a reference to the event context.
 --
@@ -577,7 +583,9 @@ diff
 diff (Object a) (Object b) c = do
   moduleMiso <- jsg "miso"
   context <- getDrawingContext
-  void $ moduleMiso # "diff" $ [a,b,c,context]
+  freeJSVal =<< (moduleMiso # "diff" $ [a,b,c,context])
+  freeJSVal moduleMiso
+  freeJSVal context
 -----------------------------------------------------------------------------
 -- | Initialize event delegation from a mount point.
 delegator :: JSVal -> JSVal -> Bool -> IO JSVal -> IO ()
@@ -863,7 +871,8 @@ flush :: IO ()
 {-# INLINABLE flush #-}
 flush = do
   context <- getDrawingContext
-  void $ context # "flush" $ ([] :: [JSVal])
+  freeJSVal =<< (context # "flush" $ ([] :: [JSVal]))
+  freeJSVal context
 -----------------------------------------------------------------------------
 -- | Type that holds an [Image](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/img).
 newtype Image = Image JSVal

--- a/src/Miso/Runtime.hs
+++ b/src/Miso/Runtime.hs
@@ -130,6 +130,7 @@ import           Control.Exception (SomeException, catch)
 import           Control.Monad (forM, forM_, when, void, (<=<), zipWithM_, forever, foldM, unless)
 import           Control.Monad.Reader (ask, asks)
 import           Control.Monad.State hiding (state)
+import qualified Miso.JSON as JSON
 import           Miso.JSON (FromJSON, ToJSON, Result(..), Value, encode, fromJSON, jsonStringify, toJSON, parseEither)
 import           Miso.Event.Decoder (Decoder(decoder, decodeAt))
 
@@ -1151,15 +1152,22 @@ buildVTree events_ parentId_ vcompId hydrate snk logLevel_ model_ = \case
     -- never reads it (all HTML/SVG/MathML nodes carry an empty set anyway).
     FFI.set "directEvents" (Set.toList _directEvents) vnode_
 #endif
-    vchildren <- toJSVal =<< procreate vnode_
+    children_ <- procreate vnode_
+    vchildren <- toJSVal (map snd children_)
     FFI.set "children" vchildren vnode_
-    flip (FFI.set "type") vnode_ =<< toJSVal VNodeType
+    nodeType <- toJSVal VNodeType
+    FFI.set "type" nodeType vnode_
+    -- The children are now linked into the tree on the JS side; release the
+    -- handles we no longer need. See Note [Freeing VTree handles].
+    freeJSVal nodeType
+    freeJSVal vchildren
+    mapM_ freeKid children_
     pure (VTree vnode_)
       where
         procreate parentVTree = do
           kidsViews <- foldM (buildKid parentVTree) [] kids
           let ordered = reverse kidsViews
-          setNextSibling ordered
+          setNextSibling (map snd ordered)
           pure ordered
             where
               setNextSibling xs =
@@ -1169,7 +1177,7 @@ buildVTree events_ parentId_ vcompId hydrate snk logLevel_ model_ = \case
               buildKid p acc kid = do
                 VTree child <- buildVTree events_ parentId_ vcompId hydrate snk logLevel_ model_ kid
                 FFI.set "parent" p child
-                pure (child : acc)
+                pure ((kid, child) : acc)
   VText key t -> do
     vtree <- create
     flip (FFI.set "type") vtree =<< toJSVal VTextType
@@ -1181,22 +1189,58 @@ buildVTree events_ parentId_ vcompId hydrate snk logLevel_ model_ = \case
     frag <- create
     FFI.set "type" VFragType frag
     forM_ maybeKey $ \(Key k) -> FFI.set "key" k frag
-    vchildren <- toJSVal =<< procreateFragChildren frag
+    children_ <- procreateFragChildren frag
+    vchildren <- toJSVal (map snd children_)
     FFI.set "children" vchildren frag
+    freeJSVal vchildren
+    mapM_ freeKid children_
     pure (VTree frag)
       where
         procreateFragChildren parentVTree = do
           kidsViews <- foldM buildKid [] kids
           let ordered = reverse kidsViews
-          zipWithM_ (flip setField "nextSibling") ordered (drop 1 ordered)
+          zipWithM_ (flip setField "nextSibling") (map snd ordered) (drop 1 (map snd ordered))
           pure ordered
             where
               buildKid acc (VFrag _ []) = pure acc
               buildKid acc kid = do
                 VTree child <- buildVTree events_ parentId_ vcompId hydrate snk logLevel_ model_ kid
                 FFI.set "parent" parentVTree child
-                pure (child : acc)
+                pure ((kid, child) : acc)
   where
+    -- Note [Freeing VTree handles]
+    -- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    -- On WASM each 'JSVal' handle carries a weak pointer that every GC must
+    -- evacuate before it can discover the handle is dead, so the hundreds of
+    -- short-lived handles created per frame while building a vtree make GC
+    -- pauses scale with the size of the tree (see 'freeJSVal'). Once a child
+    -- has been linked into its parent on the JS side the JavaScript object is
+    -- kept alive by the tree and the Haskell handle is dead weight, so we free
+    -- it -- unless something on the Haskell side can still reach it:
+    --
+    --  * Nodes with event handlers: the handler closure captures the node
+    --    ('onWithOptions' reads @pendingComponentId@ from it at event time).
+    --  * Components: 'buildComp' installs callbacks that close over the
+    --    component object.
+    --
+    -- The root handle is returned to the caller and is never freed here.
+    freeKid :: (View context model action, Object) -> IO ()
+    freeKid (kid, Object child) = when (freeable kid) (freeJSVal child)
+
+    freeable :: View context model action -> Bool
+    freeable = \case
+      VNode _ _ attrs _ _ -> not (any isEvent attrs)
+      VText {} -> True
+      VFrag {} -> True
+      VComp {} -> False
+      VCompStatic {} -> False
+
+    isEvent :: Attribute model action -> Bool
+    isEvent = \case
+      On {} -> True
+      OnStatic {} -> True
+      _ -> False
+
     -- Shared construction for @VComp@ and @VCompStatic@. The only difference is
     -- the 'StaticKey' passed to 'initialize': 'Nothing' for dynamic components,
     -- @Just (staticKey ptr)@ for statically-referenced ones.
@@ -1261,6 +1305,9 @@ createNode typ ns tag = do
   FFI.set "bubbles" bubbles eventsObj
   FFI.set "ns" ns vnode_
   FFI.set "tag" tag vnode_
+  -- All five scratch objects are now reachable from the vnode on the JS
+  -- side; release the Haskell handles. See Note [Freeing VTree handles].
+  mapM_ (freeJSVal . unObject) [cssObj, propsObj, eventsObj, captures, bubbles]
   pure vnode_
 -----------------------------------------------------------------------------
 -- | Helper function for populating "props" and "css" fields on a virtual
@@ -1285,6 +1332,11 @@ setAttrs vnode_@(Object jval) attrs snk vcompId logLevel events model_ = do
       value <- toJSVal v
       o <- getProp "props" vnode_
       FFI.set k value (Object o)
+      freeJSVal o
+      -- Only handles created by 'toJSVal' itself are ours to free: a
+      -- 'String' shares the handle of its 'MisoString' and 'Null' is a
+      -- shared constant. See Note [Freeing VTree handles].
+      when (freshValue v) (freeJSVal value)
     On callback -> do
       -- Reset any 'pendingStaticKey' \/ 'pendingMainThread' left behind by an
       -- earlier 'OnStatic' attribute on this same node — otherwise a plain
@@ -1311,6 +1363,13 @@ setAttrs vnode_@(Object jval) attrs snk vcompId logLevel events model_ = do
       cssObj <- getProp "css" vnode_
       forM_ (M.toList styles) $ \(k,v) -> do
         FFI.set k v (Object cssObj)
+      freeJSVal cssObj
+  where
+    freshValue :: Value -> Bool
+    freshValue = \case
+      JSON.String {} -> False
+      JSON.Null -> False
+      _ -> True
 -----------------------------------------------------------------------------
 -- | Registers components in the global state
 registerComponent :: MonadIO m => ComponentState context props model action -> m ()

--- a/src/Miso/Runtime.hs
+++ b/src/Miso/Runtime.hs
@@ -36,6 +36,7 @@ module Miso.Runtime
     initialize
   , freshComponentId
   , buildVTree
+  , registerEventHandler
   , renderStyles
   , renderScripts
   , Hydrate(..)
@@ -256,12 +257,16 @@ initialize events _componentParentId hydrate isRoot initialProps maybeKey _compo
         newVTree <-
           buildVTree events _componentParentId _componentId Draw
             _componentSink logLevel newModel (view currentContext currentProps newModel)
+        newHandlers <- collectEventHandlers
         oldVTree <- readIORef _componentVTree
         _frame <- requestAnimationFrame rAFCallback
         _timestamp :: Double <- takeMVar frame
         Diff.diff (Just oldVTree) (Just newVTree) _componentDOMRef
         FFI.updateRef oldVTree newVTree
         atomicWriteIORef _componentVTree newVTree
+        -- The old tree can no longer dispatch; free its handler callbacks.
+        -- See Note [Freeing event handler callbacks].
+        swapEventHandlers _componentId newHandlers
         FFI.flush
 
 #ifdef NATIVE
@@ -497,6 +502,7 @@ initialDraw initializedModel events hydrate isRoot Component {..} ComponentState
   currentContext <- readIORef globalContext
   vtree <- buildVTree events _componentParentId _componentId hydrate _componentSink logLevel
     initializedModel (view currentContext _componentProps initializedModel)
+  vtreeHandlers0 <- collectEventHandlers
 #ifdef BENCH
   end <- FFI.now
   when isRoot $ FFI.consoleLog $ ms (printf "buildVTree: %.3f ms" (end - start) :: String)
@@ -505,6 +511,7 @@ initialDraw initializedModel events hydrate isRoot Component {..} ComponentState
     Draw -> do
       Diff.diff Nothing (Just vtree) _componentDOMRef
       atomicWriteIORef _componentVTree vtree
+      swapEventHandlers _componentId vtreeHandlers0
     Hydrate -> do
       if isRoot
         then do
@@ -512,14 +519,20 @@ initialDraw initializedModel events hydrate isRoot Component {..} ComponentState
           if hydrated
             then do
               atomicWriteIORef _componentVTree vtree
+              swapEventHandlers _componentId vtreeHandlers0
             else do
               newTree <-
                 buildVTree events _componentParentId _componentId Draw
                   _componentSink logLevel initializedModel (view currentContext _componentProps initializedModel)
+              newHandlers <- collectEventHandlers
+              -- the discarded hydration tree's callbacks are unreachable
+              mapM_ freeFunction vtreeHandlers0
               Diff.diff Nothing (Just newTree) _componentDOMRef
               atomicWriteIORef _componentVTree newTree
-        else
+              swapEventHandlers _componentId newHandlers
+        else do
           atomicWriteIORef _componentVTree vtree
+          swapEventHandlers _componentId vtreeHandlers0
 -----------------------------------------------------------------------------
 -- | Pulls the next Component for processing out of the queue, along with
 -- its events.
@@ -633,6 +646,67 @@ dequeueAt vcompId q =
 globalWaiter :: Waiter
 {-# NOINLINE globalWaiter #-}
 globalWaiter = unsafePerformIO waiter
+-----------------------------------------------------------------------------
+-- Note [Freeing event handler callbacks]
+-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-- Every 'On' attribute exports a fresh Haskell callback to JavaScript on
+-- every draw ('Miso.Event.onWithOptions'). On the WASM backend an exported
+-- callback pins its closure with a stable pointer that is only released
+-- when JavaScript's FinalizationRegistry notices the function is
+-- unreachable -- which requires a JavaScript GC and in practice lags far
+-- behind, so redrawing components leak callbacks (and everything their
+-- closures capture, including the model of the frame they were built in).
+--
+-- Instead we track ownership explicitly: 'Miso.Event.onWithOptions' calls
+-- 'registerEventHandler' for every callback it exports, collecting them
+-- into 'handlerCollector' for the duration of one 'buildVTree'. After the
+-- new tree has been diffed in, the previous tree's callbacks can never be
+-- dispatched again (event delegation always consults the current vtree),
+-- so 'swapEventHandlers' frees them and records the new set. Unmounting a
+-- component frees its recorded set.
+--
+-- Draws are serialized by the scheduler and the collector is harvested
+-- before the draw awaits the next animation frame, so a child component
+-- mounting synchronously mid-diff collects into an empty collector and
+-- harvests it before returning.
+-----------------------------------------------------------------------------
+-- | Callbacks exported to JavaScript during the current 'buildVTree'.
+{-# NOINLINE handlerCollector #-}
+handlerCollector :: IORef [Function]
+handlerCollector = unsafePerformIO (newIORef [])
+-----------------------------------------------------------------------------
+-- | Event handler callbacks owned by each mounted component's current vtree.
+{-# NOINLINE vtreeHandlers #-}
+vtreeHandlers :: IORef (IntMap [Function])
+vtreeHandlers = unsafePerformIO (newIORef mempty)
+-----------------------------------------------------------------------------
+-- | Called by 'Miso.Event.onWithOptions' for every callback it exports.
+-- See Note [Freeing event handler callbacks].
+registerEventHandler :: JSVal -> IO ()
+registerEventHandler cb =
+  atomicModifyIORef' handlerCollector $ \cbs -> (Function cb : cbs, ())
+-----------------------------------------------------------------------------
+-- | Take ownership of the callbacks exported by the 'buildVTree' that just
+-- finished. See Note [Freeing event handler callbacks].
+collectEventHandlers :: IO [Function]
+collectEventHandlers = atomicModifyIORef' handlerCollector (\cbs -> ([], cbs))
+-----------------------------------------------------------------------------
+-- | Record @new@ as the component's current handler set and free the
+-- previous one. Call only after the new vtree has replaced the old one.
+-- See Note [Freeing event handler callbacks].
+swapEventHandlers :: ComponentId -> [Function] -> IO ()
+swapEventHandlers vcompId newHandlers = do
+  oldHandlers <- atomicModifyIORef' vtreeHandlers $ \m ->
+    (IM.insert vcompId newHandlers m, IM.findWithDefault [] vcompId m)
+  mapM_ freeFunction oldHandlers
+-----------------------------------------------------------------------------
+-- | Free and forget a component's handler set (on unmount).
+-- See Note [Freeing event handler callbacks].
+freeEventHandlers :: ComponentId -> IO ()
+freeEventHandlers vcompId = do
+  oldHandlers <- atomicModifyIORef' vtreeHandlers $ \m ->
+    (IM.delete vcompId m, IM.findWithDefault [] vcompId m)
+  mapM_ freeFunction oldHandlers
 -----------------------------------------------------------------------------
 #ifdef NATIVE
 btsReady :: Waiter
@@ -1112,6 +1186,7 @@ unmountComponent cs@ComponentState {..} = do
   finalizeEventSources _componentId
   unloadScripts cs
   freeLifecycleHooks cs
+  freeEventHandlers _componentId
   modifyComponent _componentParentId $ do
     children.at _componentId .= Nothing
   atomicModifyIORef' components $ \m -> (IM.delete _componentId m, ())


### PR DESCRIPTION
On the WASM backend every `JSVal` carries a `Weak#` with a C finalizer so the JavaScript value can be released once the handle is collected. The RTS evacuates every weak pointer at the start of every GC, dead or alive, so a program that allocates hundreds of short-lived handles per frame (as `buildVTree` does) makes each GC pause scale with the number of handles created since the last one. Profiling `miso-mario` with `-hT` showed ~14 MB of `DEAD_WEAK` / `C_FINALIZER_LIST` being copied at every collection, producing ~100 ms pauses, while the application's own live data was ~50 KB.

Add `Miso.DSL.freeJSVal` (`GHC.Wasm.Prim.freeJSVal` on WASM, a no-op elsewhere) and use it to release handles the runtime creates and nothing else can reach:

  * `(#)`, `call`, `new`: the looked-up function and the argument array.
  * `updateRef`, `populateClass`, `getDrawingContext`, `diff`, `flush`: the `jsg "miso"` handle and the ignored call result.
  * `createNode`: the `css`/`props`/`events`/`captures`/`bubbles` scratch objects once they are attached to the `vnode`.
  * `setAttrs`: `getProp` results and Property values freshly marshalled from `Number`/`Bool`/`Array`/`Object` (never `String`, which shares the caller's `JSString` handle, nor `Null`, which is a shared constant).
  * `buildVTree`: the children array, the node type, and child node handles once linked into the parent -- except nodes with event handlers (the handler closure reads the node at event time) and components (their callbacks close over the component object).
  * `onWithOptions`: its scratch handles; `decodeAtVal`, the callback and the node stay alive.

Handles received from the caller (strings in the `View`, in particular) are never freed. See Note [Freeing `VTree` handles] in `Miso.Runtime`.

Measured on `miso-mario` (`-H64m -A32m`): `C_FINALIZER_LIST` per GC 7.3 MB ->
2.3 MB. `DEAD_WEAK` is unchanged because `finalizeWeak#` cannot unlink from the singly-linked weak list; `markWeakPtrList` still evacuates dead weaks, which is an RTS limitation to be addressed upstream.