### PR TITLE
feat: Parameterize `Sub` by `model`, add `canvasSub`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,16 @@ All notable changes to `miso` are documented here.
   secure context (HTTPS or `localhost`); on browsers without the API
   (e.g. Firefox) the error callback fires and `cookieChangeSub` is a no-op.
 
+- **`canvasSub`.** New `Miso.Subscription.Canvas` module. `canvasSub` drives
+  a `<canvas>` in a tight `requestAnimationFrame` loop, bypassing virtual DOM
+  construction entirely — unlike `Miso.Canvas`, whose `draw` runs during the
+  diffing process on discrete events. Pair it with `onCreatedWith` /
+  `onDestroyed` and `startSub` / `stopSub` to start the loop when the canvas
+  mounts and stop it on unmount. The draw callback receives each frame's
+  high-resolution timestamp and a snapshot of the component's current model
+  (see the `Sub` change below), and the queued frame is cancelled before the
+  callback is freed on teardown.
+
 - **`Miso.Trace`.** A browser-console analogue of `Debug.Trace` for
   debugging pure code such as `view` functions or helpers called from
   `update`. `trace`, `traceId`, `traceWith`, `traceShow`, `traceShowId`,
@@ -139,6 +149,17 @@ All notable changes to `miso` are documented here.
   key moved into `SomeComponent (Maybe Key) …`, and `VComp` / `VCompStatic` /
   `SomeStaticComponent` were restructured. Downstream `view` and attribute
   signatures must be updated accordingly.
+
+- **Breaking: `Sub` gained a `model` type parameter.** `Sub action` is now
+  `Sub model action`, and a subscription receives a second argument — an
+  `IO model` that returns a snapshot of the component's current model:
+  `type Sub model action = Sink action -> IO model -> IO ()`. This lets
+  long-running subscriptions (like `canvasSub`) read the latest model
+  without threading it through actions. All bundled subscriptions were
+  updated; user-defined subscriptions that ignore the model need only accept
+  (and discard) the extra argument, e.g.
+  `tickSub sink _ = forever (threadDelay delay >> sink Tick)`. `mapSub`,
+  `createSub`, and `startSub` were updated accordingly.
 
 - **Breaking: `Miso.Binding` was removed.** The experimental lens-based
   parent/child model synchronisation mechanism (`Binding`, `Bindings`,

--- a/miso.cabal
+++ b/miso.cabal
@@ -185,10 +185,11 @@ library
     Miso.Runtime.Internal
     Miso.State
     Miso.Subscription
+    Miso.Subscription.Canvas
+    Miso.Subscription.Cookie
     Miso.Subscription.History
     Miso.Subscription.Keyboard
     Miso.Subscription.Mouse
-    Miso.Subscription.Cookie
     Miso.Subscription.OnLine
     Miso.Subscription.RAF
     Miso.Subscription.Util

--- a/src/Miso.hs
+++ b/src/Miso.hs
@@ -961,7 +961,9 @@
 -- = Subscriptions
 --
 -- A t'Sub' is any long-running operation that is external to a t'Miso.Types.Component', but that can write
--- to a t'Miso.Types.Component' 'Sink'. 'Sub' come in two flavors, a dynamic 'Sub' (via 'startSub' / 'stopSub') and 'subs'.
+-- to a t'Miso.Types.Component' 'Sink'. Along with the 'Sink', a 'Sub' receives an @IO model@ action
+-- returning a snapshot of its t'Miso.Types.Component'\'s current model (ignore it if unneeded).
+-- 'Sub' come in two flavors, a dynamic 'Sub' (via 'startSub' / 'stopSub') and 'subs'.
 --
 -- * 'subs'
 --
@@ -969,8 +971,8 @@
 -- main :: t'IO' ()
 -- main = 'startApp' 'Miso.Event.Types.defaultEvents' app { 'subs' = [ timerSub ] }
 --
--- timerSub :: 'Sub' Action
--- timerSub sink = 'Control.Monad.forever' $ ('Control.Concurrent.threadDelay' 100000) >> sink Log
+-- timerSub :: 'Sub' Model Action
+-- timerSub sink _getModel = 'Control.Monad.forever' $ ('Control.Concurrent.threadDelay' 100000) >> sink Log
 --
 -- data Action = Log
 -- @
@@ -979,7 +981,7 @@
 -- When a t'Miso.Types.Component' unmounts, these 'Sub' will be stopped, and their resources finalized.
 --
 -- @
--- 'onLineSub' :: ('Bool' -> action) -> 'Sub' action
+-- 'onLineSub' :: ('Bool' -> action) -> 'Sub' model action
 -- 'onLineSub' f sink = 'Miso.Subscription.Util.createSub' acquire release sink
 --   where
 --     release (cb1, cb2) = do
@@ -1002,8 +1004,8 @@
 --   StopTimer -> 'stopSub' "timer"
 --   Log -> 'io_' ('Miso.FFI.consoleLog' "log")
 --     where
---       timerSub :: 'Sub' Action
---       timerSub sink = 'Control.Monad.forever' $ ('Control.Concurrent.threadDelay' 100000) >> sink Log
+--       timerSub :: 'Sub' Model Action
+--       timerSub sink _getModel = 'Control.Monad.forever' $ ('Control.Concurrent.threadDelay' 100000) >> sink Log
 --
 -- data Action = Log
 -- @

--- a/src/Miso/Effect.hs
+++ b/src/Miso/Effect.hs
@@ -61,19 +61,20 @@
 --
 -- = Subscriptions
 --
--- A 'Sub' is a function that receives a 'Sink' and runs forever (typically
--- on a forked thread). Register subscriptions in 'Miso.Types.subs':
+-- A 'Sub' is a function that receives a 'Sink' and an @IO model@ (a snapshot
+-- of the owning component's current model) and runs forever (typically on a
+-- forked thread). Register subscriptions in 'Miso.Types.subs':
 --
 -- @
--- tickSub :: 'Sub' Action
--- tickSub sink = forever $ do
+-- tickSub :: 'Sub' Model Action
+-- tickSub sink _getModel = forever $ do
 --   threadDelay 16667
 --   sink Tick
 --
 -- myComponent = ('Miso.component' model update view) { 'Miso.Types.subs' = [tickSub] }
 -- @
 --
--- Use 'mapSub' to adapt a @Sub a@ into a @Sub b@ with a mapping function.
+-- Use 'mapSub' to adapt a @Sub model a@ into a @Sub model b@ with a mapping function.
 --
 -- = Component metadata
 --
@@ -325,6 +326,11 @@ type ComponentId = Int
 -- For example usage see "Miso.Subscription"
 --
 -- The 'Sink' function is used to write to the global event queue.
+--
+-- The @IO model@ action returns a snapshot of the owning
+-- t'Miso.Types.Component'\'s current model, and is safe to call for the
+-- lifetime of the 'Sub'. Subscriptions that don't need the model can
+-- simply ignore it.
 type Sub model action = Sink action -> IO model -> IO ()
 -----------------------------------------------------------------------------
 -- | Function to write to the global event queue for processing by the scheduler.

--- a/src/Miso/Effect.hs
+++ b/src/Miso/Effect.hs
@@ -325,7 +325,7 @@ type ComponentId = Int
 -- For example usage see "Miso.Subscription"
 --
 -- The 'Sink' function is used to write to the global event queue.
-type Sub action = Sink action -> IO ()
+type Sub model action = Sink action -> IO model -> IO ()
 -----------------------------------------------------------------------------
 -- | Function to write to the global event queue for processing by the scheduler.
 type Sink action = action -> IO ()
@@ -470,10 +470,10 @@ runEffect = execRWS
 mapSub
   :: (a -> b)
   -- ^ Function to map actions produced by the subscription
-  -> Sub a
+  -> Sub m a
   -- ^ Source subscription delivering @a@ actions
-  -> Sub b
-mapSub f sub = \g -> sub (g . f)
+  -> Sub m b
+mapSub f sub = \g m -> sub (g . f) m
 -----------------------------------------------------------------------------
 -- | Schedule a single 'IO' action, executed synchronously. For asynchronous
 -- execution, see 'io'.

--- a/src/Miso/Runtime.hs
+++ b/src/Miso/Runtime.hs
@@ -312,7 +312,10 @@ initialize events _componentParentId hydrate isRoot initialProps maybeKey _compo
 
   when isRoot (delegator _componentDOMRef _componentVTree events (logLevel `elem` [DebugEvents, DebugAll]))
   registerComponent vcomponent
-  initSubs subs _componentSubThreads _componentSink
+  -- dmj: This is safe to do because component model presence is an invariant during Sub lifetime
+  -- Sub lifetime is totally eclipsed by Component lifetime. Sub get killed before a Component unmounts.
+  let getModel = (_componentModel . (IM.! _componentId)) <$> readIORef components
+  initSubs getModel subs _componentSubThreads _componentSink
   -- Runs on every thread. On Lynx the MTS paints the initial frame directly
   -- (fast first frame) while the BTS builds the same VTree but suppresses its
   -- create-patches (deterministic nodeId parity keeps both trees addressable) —
@@ -345,10 +348,10 @@ initialize events _componentParentId hydrate isRoot initialProps maybeKey _compo
 #endif
   pure vcomponent
 -----------------------------------------------------------------------------
-initSubs :: [Sub action] -> IORef (Map MisoString ThreadId) -> Sink action -> IO ()
-initSubs subs_ _componentSubThreads _componentSink = do
+initSubs :: IO model -> [Sub model action] -> IORef (Map MisoString ThreadId) -> Sink action -> IO ()
+initSubs getModel subs_ _componentSubThreads _componentSink = do
   forM_ subs_ $ \sub_ -> do
-    threadId <- forkIO (sub_ _componentSink)
+    threadId <- forkIO (sub_ _componentSink getModel)
     subKey <- freshSubId
     atomicModifyIORef' _componentSubThreads $ \m ->
       (M.insert subKey threadId m, ())
@@ -1505,7 +1508,7 @@ startSub
   :: ToMisoString subKey
   => subKey
   -- ^ The key used to track the 'Sub'
-  -> Sub action
+  -> Sub model action
   -- ^ The 'Sub'
   -> Effect context props model action
 startSub subKey sub = do
@@ -1525,10 +1528,17 @@ startSub subKey sub = do
               ThreadDied -> startThread compState
               _ -> pure ()
   where
-    startThread ComponentState {..} = do
-      tid <- forkIO (sub _componentSink)
-      atomicModifyIORef' _componentSubThreads $ \m ->
-        (M.insert (ms subKey) tid m, ())
+    startThread ComponentState
+      { _componentId = vcompId
+      , _componentSink = vcompSink
+      , _componentSubThreads = subThreads
+      } = do
+        -- dmj: same invariant as initSubs, the Sub lifetime is eclipsed by the
+        -- Component lifetime, so the model is always present during lookup.
+        let getModel = (_componentModel . (IM.! vcompId)) <$> readIORef components
+        tid <- forkIO (sub vcompSink getModel)
+        atomicModifyIORef' subThreads $ \m ->
+          (M.insert (ms subKey) tid m, ())
 -----------------------------------------------------------------------------
 -- | Stops a named 'Sub' dynamically, during the life of a t'Miso.Types.Component'.
 -- All 'Sub' started will be stopped automatically if a t'Miso.Types.Component' is unmounted.

--- a/src/Miso/Runtime.hs
+++ b/src/Miso/Runtime.hs
@@ -312,9 +312,7 @@ initialize events _componentParentId hydrate isRoot initialProps maybeKey _compo
 
   when isRoot (delegator _componentDOMRef _componentVTree events (logLevel `elem` [DebugEvents, DebugAll]))
   registerComponent vcomponent
-  -- dmj: This is safe to do because component model presence is an invariant during Sub lifetime
-  -- Sub lifetime is totally eclipsed by Component lifetime. Sub get killed before a Component unmounts.
-  let getModel = (_componentModel . (IM.! _componentId)) <$> readIORef components
+  getModel <- mkGetModel _componentId initializedModel
   initSubs getModel subs _componentSubThreads _componentSink
   -- Runs on every thread. On Lynx the MTS paints the initial frame directly
   -- (fast first frame) while the BTS builds the same VTree but suppresses its
@@ -355,6 +353,23 @@ initSubs getModel subs_ _componentSubThreads _componentSink = do
     subKey <- freshSubId
     atomicModifyIORef' _componentSubThreads $ \m ->
       (M.insert subKey threadId m, ())
+-----------------------------------------------------------------------------
+-- | Builds the @IO model@ handed to each 'Sub': a total lookup of the
+-- component's current model. A 'Sub' is normally killed before its component
+-- is deleted from 'components', but teardown is not atomic — 'killThread'
+-- returns on exception delivery, before the 'Sub' finalizer has run, so e.g.
+-- a still-queued requestAnimationFrame callback can fire after the component
+-- is gone. In that window the last observed model is returned rather than
+-- crashing on a missing key.
+mkGetModel :: ComponentId -> model -> IO (IO model)
+mkGetModel vcompId initialModel = do
+  lastModel <- newIORef initialModel
+  pure $
+    IM.lookup vcompId <$> readIORef components >>= \case
+      Nothing -> readIORef lastModel
+      Just ComponentState { _componentModel = currentModel } -> do
+        atomicWriteIORef lastModel currentModel
+        pure currentModel
 -----------------------------------------------------------------------------
 -- | Diffs two values (models, props, context), returning True if they differ
 -- and a redraw / propagation is necessary. Pointer equality via 'StableName'
@@ -1532,10 +1547,9 @@ startSub subKey sub = do
       { _componentId = vcompId
       , _componentSink = vcompSink
       , _componentSubThreads = subThreads
+      , _componentModel = currentModel
       } = do
-        -- dmj: same invariant as initSubs, the Sub lifetime is eclipsed by the
-        -- Component lifetime, so the model is always present during lookup.
-        let getModel = (_componentModel . (IM.! vcompId)) <$> readIORef components
+        getModel <- mkGetModel vcompId currentModel
         tid <- forkIO (sub vcompSink getModel)
         atomicModifyIORef' subThreads $ \m ->
           (M.insert (ms subKey) tid m, ())

--- a/src/Miso/Subscription.hs
+++ b/src/Miso/Subscription.hs
@@ -45,6 +45,7 @@
 -- ['onLineSub'] @online@ \/ @offline@ change — "Miso.Subscription.OnLine"
 -- ['rAFSub'] every @requestAnimationFrame@ tick — "Miso.Subscription.RAF"
 -- ['cookieChangeSub'] @cookieStore change@ events — "Miso.Subscription.Cookie"
+-- ['canvasSub'] canvas support — "Miso.Subscription.Canvas"
 --
 -- = History helpers
 --
@@ -77,6 +78,8 @@ module Miso.Subscription
   , module Miso.Subscription.RAF
     -- ** Cookie Store
   , module Miso.Subscription.Cookie
+    -- ** Canvas
+  , module Miso.Subscription.Canvas
   ) where
 -----------------------------------------------------------------------------
 import Miso.Subscription.Mouse
@@ -86,4 +89,5 @@ import Miso.Subscription.Window
 import Miso.Subscription.OnLine
 import Miso.Subscription.RAF
 import Miso.Subscription.Cookie
+import Miso.Subscription.Canvas
 -----------------------------------------------------------------------------

--- a/src/Miso/Subscription/Canvas.hs
+++ b/src/Miso/Subscription/Canvas.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 -----------------------------------------------------------------------------
 -- |
--- Module      :  Miso.Subscription.Cookie
+-- Module      :  Miso.Subscription.Canvas
 -- Copyright   :  (C) 2016-2026 David M. Johnson
 -- License     :  BSD3-style (see the file LICENSE)
 -- Maintainer  :  David M. Johnson <code@dmj.io>
@@ -58,7 +58,7 @@ import Miso.Subscription.Util
 -- @
 --
 -- 'canvasSub' is meant to bypass virtual DOM creation, creating a more efficient canvas
--- draw. This works by calling requestForAnimationFrame in a tight loop around a freshly
+-- draw. This works by calling requestAnimationFrame in a tight loop around a freshly
 -- initialized canvas (per 'onCreated').
 --
 -- The difference between 'canvasSub' and "Miso.Canvas" is that this operates in a tight
@@ -69,7 +69,7 @@ canvasSub
   :: DOMRef
   -- ^ The canvas 'JSVal' (meant to be consumed from 'onCreatedWith')
   -> MisoString
-  -- ^ "2d" or "3d"
+  -- ^ "2d", "webgpu", "webgl2"
   -> (Double -> model -> Canvas state)
   -- ^ Canvas callback in 60fps, high precision timestamp, model snapshot
   -- as args to Canvas DSL templating
@@ -79,7 +79,7 @@ canvasSub canvasRef dim builder snk getModel = do
     where
       acquire = do
         ctx <- canvasRef # "getContext" $ dim
-        cbRef <- newIORef (error "rAFSub: uninitialized, impossible")
+        cbRef <- newIORef (error "canvasSub: uninitialized, impossible")
         idRef <- newIORef (0 :: Int)
         callback <-
           syncCallback1 $ \jsval -> do

--- a/src/Miso/Subscription/Canvas.hs
+++ b/src/Miso/Subscription/Canvas.hs
@@ -1,0 +1,99 @@
+-----------------------------------------------------------------------------
+{-# LANGUAGE OverloadedStrings #-}
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Miso.Subscription.Cookie
+-- Copyright   :  (C) 2016-2026 David M. Johnson
+-- License     :  BSD3-style (see the file LICENSE)
+-- Maintainer  :  David M. Johnson <code@dmj.io>
+-- Stability   :  experimental
+-- Portability :  non-portable
+--
+-----------------------------------------------------------------------------
+module Miso.Subscription.Canvas
+  ( -- ** Subscriptions
+    canvasSub
+  ) where
+-----------------------------------------------------------------------------
+import Control.Monad.Reader (runReaderT)
+import Control.Monad (void)
+import Data.IORef
+-----------------------------------------------------------------------------
+import Miso.Canvas
+import Miso.DSL
+import Miso.Effect
+import Miso.String
+import Miso.Subscription.Util
+-----------------------------------------------------------------------------
+-- | 'Sub' for canvas operations, meant to be used with 'onCreated' / 'onDestroyed'
+--
+-- Example usage below
+--
+-- @
+-- import Miso.Canvas
+--
+-- data Action = InitCanvas DOMRef | StopCanvas
+--
+-- canvasComponent :: 'Component' context props model action
+-- canvasComponent = 'component' m u v
+--   where
+--     m = ()
+--     u = \case
+--       InitCanvas domRef ->
+--         startSub "galaxy" $ canvasSub domRef "2d" $ \_timeStamp currentModel -> do
+--           drawScene currentModel
+--       StopCanvas ->
+--         stopSub "galaxy"
+--     v _context _props () =
+--       'canvas_' [ onCreatedWith InitCanvas, onDestroyed StopCanvas ] []
+--
+-- drawScene :: Model -> 'Canvas' ()
+-- drawScene m = do
+--   'clearRect' (0, 0, 800, 480)
+--   'fillStyle' ('color' Color.'Miso.CSS.Color.cornflowerblue')
+--   'fillRect'  (0, 0, 800, 480)
+--   'fillStyle' ('color' Color.'Miso.CSS.Color.white')
+--   'font'      \"24px sans-serif\"
+--   'fillText'  (\"Hello, miso!\", 32, 48)
+-- @
+--
+-- 'canvasSub' is meant to bypass virtual DOM creation, creating a more efficient canvas
+-- draw. This works by calling requestForAnimationFrame in a tight loop around a freshly
+-- initialized canvas (per 'onCreated').
+--
+-- The difference between 'canvasSub' and "Miso.Canvas" is that this operates in a tight
+-- rAF loop. The latter operates on a discrete event basis and the draw is called during
+-- the diffing process.
+--
+canvasSub
+  :: DOMRef
+  -- ^ The canvas 'JSVal' (meant to be consumed from 'onCreatedWith')
+  -> MisoString
+  -- ^ "2d" or "3d"
+  -> (Double -> model -> Canvas state)
+  -- ^ Canvas callback in 60fps, high precision timestamp, model snapshot
+  -- as args to Canvas DSL templating
+  -> Sub model action
+canvasSub canvasRef dim builder snk getModel = do
+  createSub acquire release snk getModel
+    where
+      acquire = do
+        ctx <- canvasRef # "getContext" $ dim
+        cbRef <- newIORef (error "rAFSub: uninitialized, impossible")
+        idRef <- newIORef (0 :: Int)
+        callback <-
+          syncCallback1 $ \jsval -> do
+            void . flip runReaderT ctx =<<
+              builder <$> fromJSValUnchecked jsval <*> getModel
+            writeIORef idRef =<< requestAnimationFrame =<< readIORef cbRef
+        writeIORef cbRef callback
+        writeIORef idRef =<< requestAnimationFrame callback
+        pure (callback, idRef)
+  
+      -- N.B. the queued frame must be cancelled before the callback is
+      -- freed: the browser holds a reference to it, and invoking a freed
+      -- callback on the next frame crashes the runtime.
+      release (callback, idRef) = do
+        cancelAnimationFrame =<< readIORef idRef
+        freeFunction (Function callback)
+-----------------------------------------------------------------------------

--- a/src/Miso/Subscription/Cookie.hs
+++ b/src/Miso/Subscription/Cookie.hs
@@ -77,7 +77,7 @@ import qualified Miso.FFI.Internal as FFI
 cookieChangeSub
   :: (CookieChangeEvent -> action)
   -- ^ Callback: receives the change event on every cookie modification
-  -> Sub action
+  -> Sub model action
 cookieChangeSub f sink = createSub acquire release sink
   where
     acquire = FFI.cookieStoreAddEventListener $ \ev ->

--- a/src/Miso/Subscription/History.hs
+++ b/src/Miso/Subscription/History.hs
@@ -145,7 +145,7 @@ go n = void $ getHistory # "go" $ [n]
 uriSub
   :: (URI -> action)
   -- ^ Callback fired with the new t'URI' on every URL change
-  -> Sub action
+  -> Sub model action
 uriSub f sink = createSub acquire release sink
   where
     release = FFI.windowRemoveEventListener "popstate"
@@ -158,7 +158,7 @@ routerSub
   :: Router route
   => (Either RoutingError route -> action)
   -- ^ Callback fired with the decoded route (or 'RoutingError') on every URL change
-  -> Sub action
+  -> Sub model action
 routerSub f = uriSub $ \uri -> f (route uri)
 -----------------------------------------------------------------------------
 -- | Retrieves the current relative URI by inspecting @pathname@, @search@

--- a/src/Miso/Subscription/Keyboard.hs
+++ b/src/Miso/Subscription/Keyboard.hs
@@ -107,11 +107,11 @@ toArrows (up, down, left, right) set' = Arrows
       check = any (`S.member` set')
 -----------------------------------------------------------------------------
 -- | Maps t'Arrows' onto a Keyboard subscription.
-arrowsSub :: (Arrows -> action) -> Sub action
+arrowsSub :: (Arrows -> action) -> Sub model action
 arrowsSub = directionSub ([38], [40], [37], [39])
 -----------------------------------------------------------------------------
 -- | Maps t'Arrows' onto a Keyboard subscription for directions (W+A+S+D keys).
-wasdSub :: (Arrows -> action) -> Sub action
+wasdSub :: (Arrows -> action) -> Sub model action
 wasdSub = directionSub ([87], [83], [65], [68])
 -----------------------------------------------------------------------------
 -- | Maps a specified list of keys to directions (up, down, left, right).
@@ -121,12 +121,12 @@ directionSub
   -- ^ @(up, down, left, right)@ keyCode lists for each direction
   -> (Arrows -> action)
   -- ^ Callback fired with the current t'Arrows' state on every key change
-  -> Sub action
+  -> Sub model action
 directionSub dirs = keyboardSub . (. toArrows dirs)
 -----------------------------------------------------------------------------
 -- | Returns 'Sub' for keyboard events.
 -- The callback will be called with the Set of currently pressed @keyCode@s.
-keyboardSub :: (IntSet -> action) -> Sub action
+keyboardSub :: (IntSet -> action) -> Sub model action
 keyboardSub f sink = createSub acquire release sink
   where
     release (cb1, cb2, cb3) = do

--- a/src/Miso/Subscription/Mouse.hs
+++ b/src/Miso/Subscription/Mouse.hs
@@ -60,6 +60,6 @@ import Miso.Effect (Sub)
 mouseSub
   :: (PointerEvent -> action)
   -- ^ Callback fired with the full 'PointerEvent' on every @pointermove@
-  -> Sub action
+  -> Sub model action
 mouseSub = windowSub "pointermove" pointerDecoder
 -----------------------------------------------------------------------------

--- a/src/Miso/Subscription/OnLine.hs
+++ b/src/Miso/Subscription/OnLine.hs
@@ -61,7 +61,7 @@ import qualified Miso.FFI.Internal as FFI
 onLineSub
   :: (Bool -> action)
   -- ^ Callback: 'True' when going online, @False@ when going offline
-  -> Sub action
+  -> Sub model action
 onLineSub f sink = createSub acquire release sink
   where
     release (cb1, cb2) = do

--- a/src/Miso/Subscription/RAF.hs
+++ b/src/Miso/Subscription/RAF.hs
@@ -75,7 +75,7 @@ import           Miso.Subscription.Util (createSub)
 rAFSub
   :: (Double -> action)
   -- ^ Callback fired each frame with a @DOMHighResTimeStamp@ in milliseconds
-  -> Sub action
+  -> Sub model action
 rAFSub toAction sink = createSub acquire release sink
   where
     acquire = do
@@ -113,7 +113,7 @@ rAFSubElapsed
   -- ^ Minimum interval between ticks in milliseconds (e.g. @175@ for ~6 fps)
   -> action
   -- ^ Action to dispatch each time the interval elapses
-  -> Sub action
+  -> Sub model action
 rAFSubElapsed interval action sink = createSub acquire release sink
   where
     acquire = do

--- a/src/Miso/Subscription/Util.hs
+++ b/src/Miso/Subscription/Util.hs
@@ -80,8 +80,8 @@ createSub
   -- ^ Acquire resource
   -> (a -> IO b)
   -- ^ Release resource
-  -> Sub action
-createSub acquire release = \_ ->
+  -> Sub model action
+createSub acquire release = \_ _ ->
   bracket acquire release (\_ -> forever (threadDelay (secs 10000)))
     where
       secs :: Int -> Int

--- a/src/Miso/Subscription/Window.hs
+++ b/src/Miso/Subscription/Window.hs
@@ -88,7 +88,7 @@ import           Miso.Canvas (Coord)
 windowCoordsSub
   :: (Coord -> action)
   -- ^ Callback fired with @(clientX, clientY)@ on every @pointermove@ event
-  -> Sub action
+  -> Sub model action
 windowCoordsSub f = windowPointerMoveSub (f . client)
 -----------------------------------------------------------------------------
 -- | @windowSub eventName decoder toAction@ provides a subscription
@@ -100,7 +100,7 @@ windowSub
   -- ^ t'Decoder' for extracting a value from the raw event object
   -> (r -> action)
   -- ^ Callback fired with the decoded value on each event
-  -> Sub action
+  -> Sub model action
 windowSub = windowSubWithOptions defaultOptions
 -----------------------------------------------------------------------------
 -- | @windowSubWithOptions options eventName decoder toAction@ provides a
@@ -114,7 +114,7 @@ windowSubWithOptions
   -- ^ t'Decoder' for extracting a value from the raw event object
   -> (result -> action)
   -- ^ Callback fired with the decoded value on each event
-  -> Sub action
+  -> Sub model action
 windowSubWithOptions Options{..} eventName Decoder {..} toAction sink =
   createSub acquire release sink
     where
@@ -137,6 +137,6 @@ windowSubWithOptions Options{..} eventName Decoder {..} toAction sink =
 windowPointerMoveSub
   :: (PointerEvent -> action)
   -- ^ Callback fired with the full t'PointerEvent' on every @pointermove@
-  -> Sub action
+  -> Sub model action
 windowPointerMoveSub = windowSub "pointermove" pointerDecoder
 -----------------------------------------------------------------------------

--- a/src/Miso/Types.hs
+++ b/src/Miso/Types.hs
@@ -267,7 +267,7 @@ data Component context props model action
   --   Defaults to @False@.
   --
   -- @since 1.9.0.0
-  , subs :: [ Sub action ]
+  , subs :: [ Sub model action ]
   -- ^ Subscriptions to run during application lifetime
   , styles :: [CSS]
   -- ^ CSS styles expressed as either a URL ('Href') or as 'Style' text.


### PR DESCRIPTION
This allows user's read-only access to the current Component `model` during `Sub` lifetime.

- [x] Added `canvasSub` and `Miso.Subscription.Canvas` module
- [x] Parameterize `Sub` by `model` (i.e. `Sub model action`)

The benefit of this is that we get to create the Canvas DSL with the current snapshotted `model`. This will allow us to bypass drawing the virtual DOM to perform canvas drawing.

```haskell
import Miso.Canvas

data Action = InitCanvas DOMRef | StopCanvas

canvasComponent :: Component context props model action
canvasComponent = 'component' m u v
  where
    m = ()
    u = \case
      InitCanvas domRef ->
        startSub "galaxy" (canvasSub domRef "2d" drawScene)
      StopCanvas ->
        stopSub "galaxy"
    v _context _props () =
      canvas_ [ onCreatedWith InitCanvas, onDestroyed StopCanvas ] []

drawScene :: Double -> Model -> Canvas ()
drawScene _timeStamp m = do
  clearRect (0, 0, 800, 480)
  fillStyle (color cornflowerblue)
  fillRect  (0, 0, 800, 480)
  fillStyle (color white)
  font      "24px sans-serif
  fillText  ("Hello, miso!", 32, 48)
```

No AI was used to make this PR. 