### PR TITLE
wasm: add `text`/`aeson` cabal-flag support and CI coverage

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -103,6 +103,12 @@ jobs:
      - name: Nix garbage collection
        run: cabal clean && nix-collect-garbage -d
 
+     - name: (WASM) Miso integration tests (aeson + text)
+       run: nix-build -A playwright-wasm-aeson-text && ./result/bin/playwright
+
+     - name: Nix garbage collection
+       run: cabal clean && nix-collect-garbage -d
+
      - name: (GHCJS) Miso integration tests
        run: nix-build -A playwright-ghcjs && ./result/bin/playwright
 
@@ -192,6 +198,9 @@ jobs:
 
      - name: (WASM) Miso integration tests (aeson)
        run: nix-build -A playwright-wasm-aeson && ./result/bin/playwright
+
+     - name: (WASM) Miso integration tests (aeson + text)
+       run: nix-build -A playwright-wasm-aeson-text && ./result/bin/playwright
 
      - name: (x86) Miso GHC (GHC 9.12.2) test suite
        run: nix develop --command bash -c 'cabal build exe:component-tests'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,27 @@ All notable changes to `miso` are documented here.
   `camelTo2` are re-exported instead. CI runs the WASM integration suite in
   both modes.
 
+- **`text` cabal flag on WASM.** When enabled (`-ftext`, off by default),
+  `MisoString` is `Data.Text.Text` instead of `JSString` on the WASM
+  backend too (previously this was only possible on the `VANILLA` / SSR
+  build). `Data.JSString` remains the FFI boundary type, so DOM writes
+  still convert `Text -> JSString` on the way out. Number formatting and
+  parsing take advantage of this to avoid unnecessary FFI round trips:
+  `toMisoString` on `Int` / `Word` goes straight from `Text.pack . show`
+  rather than allocating a throwaway `JSVal` via JS's `.toString()`, since
+  the two formatters already agree for those types; `Double` / `Float`
+  still go through JS's native formatter, since GHC's `Show` and JS's
+  `.toString()` disagree on scientific-notation thresholds, trailing
+  zeros, and `Float`'s widened-to-`f64` round-tripping. Likewise,
+  `fromMisoString` on `Int` / `Word` / `Double` / `Float` parses directly
+  with `Data.Text.Read` instead of round-tripping through
+  `JSString`/`parseInt`/`parseFloat`, while reproducing the JS parsers'
+  semantics: leading/trailing whitespace and trailing garbage are
+  ignored, a leading `+`/`-` is accepted, and integers with a `0x`/`0X`
+  prefix parse as hexadecimal. CI gained a `playwright-wasm-aeson-text`
+  target that runs the WASM integration suite with both the `aeson` and
+  `text` flags enabled together.
+
 ### Changed
 
 - **Breaking: `View` and `Attribute` gained type parameters.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,12 +136,11 @@ All notable changes to `miso` are documented here.
   build). `Data.JSString` remains the FFI boundary type, so DOM writes
   still convert `Text -> JSString` on the way out. Number formatting and
   parsing take advantage of this to avoid unnecessary FFI round trips:
-  `toMisoString` on `Int` / `Word` goes straight from `Text.pack . show`
-  rather than allocating a throwaway `JSVal` via JS's `.toString()`, since
-  the two formatters already agree for those types; `Double` / `Float`
-  still go through JS's native formatter, since GHC's `Show` and JS's
-  `.toString()` disagree on scientific-notation thresholds, trailing
-  zeros, and `Float`'s widened-to-`f64` round-tripping. Likewise,
+  `toMisoString` on `Int` / `Word` / `Double` / `Float` builds `Text`
+  directly via `Data.Text.Lazy.Builder` (`decimal` / `realFloat`) instead
+  of allocating a throwaway `JSVal` via JS's `.toString()`, since GHC's
+  `Show` formatting is what these functions target on this backend
+  regardless. Likewise,
   `fromMisoString` on `Int` / `Word` / `Double` / `Float` parses directly
   with `Data.Text.Read` instead of round-tripping through
   `JSString`/`parseInt`/`parseFloat`, while reproducing the JS parsers'

--- a/default.nix
+++ b/default.nix
@@ -178,6 +178,25 @@ rec {
     exit "$exit_code"
   '';
 
+  # Same as playwright-wasm, but miso is built with the 'aeson' and 'text'
+  # cabal flags (Miso.JSON defined in terms of Data.Aeson, Miso.String
+  # backed by Data.Text).
+  playwright-wasm-aeson-text = pkgs.writeScriptBin "playwright" ''
+    #!${pkgs.stdenv.shell}
+    export PLAYWRIGHT_BROWSERS_PATH=${pkgs.playwright-driver.browsers}
+    export PATH="${pkgs.lib.makeBinPath [ pkgs.http-server pkgs.bun ]}:$PATH"
+    bun install playwright@1.53
+    cd tests
+    nix develop .#wasm --command bash -c 'make aeson-text'
+    http-server ./public &
+    bun run ../ts/echo-server.ts &
+    bun run ../ts/playwright.ts
+    exit_code=$?
+    pkill http-server
+    pkill -f echo-server
+    exit "$exit_code"
+  '';
+
   inherit (pkgs)
     nurl;
 

--- a/ffi/ghc/Miso/DSL/FFI.hs
+++ b/ffi/ghc/Miso/DSL/FFI.hs
@@ -5,7 +5,11 @@
 module Miso.DSL.FFI where
 -----------------------------------------------------------------------------
 import           Control.Exception (Exception)
-import           Data.Text (Text, pack, unpack)
+import           Data.Text (Text, unpack)
+import qualified Data.Text.Lazy as TL
+import qualified Data.Text.Lazy.Builder as TB
+import qualified Data.Text.Lazy.Builder.Int as TBI
+import qualified Data.Text.Lazy.Builder.RealFloat as TBR
 import           Text.Read (readMaybe)
 -----------------------------------------------------------------------------
 -- | A type that represents any JS value
@@ -216,14 +220,14 @@ parseFloat :: Text -> Maybe Float
 parseFloat = readMaybe . unpack
 -----------------------------------------------------------------------------
 toString_Int :: Int -> Text
-toString_Int = pack . show
+toString_Int = TL.toStrict . TB.toLazyText . TBI.decimal
 -----------------------------------------------------------------------------
 toString_Word :: Word -> Text
-toString_Word = pack . show
+toString_Word = TL.toStrict . TB.toLazyText . TBI.decimal
 -----------------------------------------------------------------------------
 toString_Float :: Float -> Text
-toString_Float = pack . show
+toString_Float = TL.toStrict . TB.toLazyText . TBR.realFloat
 -----------------------------------------------------------------------------
 toString_Double :: Double -> Text
-toString_Double = pack . show
+toString_Double = TL.toStrict . TB.toLazyText . TBR.realFloat
 -----------------------------------------------------------------------------

--- a/ffi/js/Miso/DSL/FFI.hs
+++ b/ffi/js/Miso/DSL/FFI.hs
@@ -446,11 +446,16 @@ foreign import javascript unsafe
 #endif
   toString_Double :: Double -> JSString
 -----------------------------------------------------------------------------
+-- Note: GHCJS narrows Float ops via Math.fround, so $1 already holds the
+-- f64 expansion of the f32 value (e.g. 3.140000104904175 for 3.14f). A
+-- plain `.toString()` would print that expansion; search increasing
+-- precisions until re-parsing (narrowed back to f32) recovers the
+-- original value, giving the shortest round-tripping decimal.
 foreign import javascript unsafe
 #if GHCJS_NEW
-  "(($1) => { return ($1).toString(); })"
+  "(($1) => { for (var p = 1; p <= 9; p++) { var s = $1.toPrecision(p); if (Math.fround(parseFloat(s)) === $1) return String(parseFloat(s)); } return String($1); })"
 #else
-  "$r = String($1);"
+  "var floatVal = $1; var floatStr; for (var floatPrec = 1; floatPrec <= 9; floatPrec++) { floatStr = floatVal.toPrecision(floatPrec); if (Math.fround(parseFloat(floatStr)) === floatVal) break; } $r = String(parseFloat(floatStr));"
 #endif
   toString_Float :: Float -> JSString
 -----------------------------------------------------------------------------

--- a/ffi/wasm/Data/JSString.hs
+++ b/ffi/wasm/Data/JSString.hs
@@ -911,7 +911,20 @@ foreign import javascript unsafe "return ($1).toString()"
 foreign import javascript unsafe "return ($1).toString()"
   toString_Double :: Double -> JSString
 -----------------------------------------------------------------------------
-foreign import javascript unsafe "return ($1).toString()"
+-- Note: $1 arrives widened to a JS (f64) Number, so a plain `.toString()`
+-- prints the full f64 expansion of the f32 value (e.g. "3.140000104904175"
+-- for 3.14f) rather than the shortest decimal that round-trips through
+-- float32. Search increasing precisions until re-parsing (narrowed back to
+-- f32 via Math.fround) recovers the original value.
+foreign import javascript unsafe
+  """
+  var x = $1;
+  for (var p = 1; p <= 9; p++) {
+    var s = x.toPrecision(p);
+    if (Math.fround(parseFloat(s)) === x) return String(parseFloat(s));
+  }
+  return String(x);
+  """
   toString_Float :: Float -> JSString
 -----------------------------------------------------------------------------
 toString_Word :: Word -> JSString

--- a/ffi/wasm/Miso/DSL/FFI.hs
+++ b/ffi/wasm/Miso/DSL/FFI.hs
@@ -94,6 +94,8 @@ import           Control.Monad
 import           Data.JSString (textFromJSString, textToJSString)
 #ifdef MISO_TEXT
 import qualified Data.JSString as JSS
+import qualified Data.Text as T
+import qualified Data.Text.Read as TR
 #endif
 import           Prelude hiding (length, head, tail, unlines, concat, null, drop, replicate, concatMap)
 -----------------------------------------------------------------------------
@@ -471,26 +473,31 @@ fromJSValUnchecked_Maybe jsval = do
     else pure (Just jsval)
 {-# INLINE fromJSValUnchecked_Maybe #-}
 -----------------------------------------------------------------------------
+#ifdef MISO_TEXT
+-- | Parses using 'Data.Text.Read' directly (no JS FFI round trip),
+-- matching JS's @parseInt@ semantics: leading\/trailing whitespace and
+-- trailing garbage are ignored, a leading @+\/-@ is allowed, and a
+-- @0x@\/@0X@ prefix is read as hexadecimal.
+parseInt :: Text -> Maybe Int
+parseInt input =
+  case T.stripPrefix (T.pack "0x") stripped `mplus` T.stripPrefix (T.pack "0X") stripped of
+    Just hex -> hush (TR.hexadecimal hex)
+    Nothing  -> hush (TR.signed TR.decimal stripped)
+  where
+    stripped = T.strip input
+{-# INLINE parseInt #-}
+#else
 foreign import javascript unsafe
   """
   return parseInt($1);
   """
   parseInt_Unchecked :: JSString -> Double
 -----------------------------------------------------------------------------
-parseInt_JSString :: JSString -> Maybe Int
-parseInt_JSString string =
+parseInt :: JSString -> Maybe Int
+parseInt string =
   case parseInt_Unchecked string of
     double | isNaN double -> Nothing
            | otherwise -> Just (round double)
-{-# INLINE parseInt_JSString #-}
------------------------------------------------------------------------------
-#ifdef MISO_TEXT
-parseInt :: Text -> Maybe Int
-parseInt = parseInt_JSString . textToJSString
-{-# INLINE parseInt #-}
-#else
-parseInt :: JSString -> Maybe Int
-parseInt = parseInt_JSString
 {-# INLINE parseInt #-}
 #endif
 -----------------------------------------------------------------------------
@@ -502,26 +509,29 @@ parseWord :: JSString -> Maybe Word
 parseWord string = fromIntegral <$> parseInt string
 {-# INLINE parseWord #-}
 -----------------------------------------------------------------------------
+#ifdef MISO_TEXT
+-- | Parses using 'Data.Text.Read' directly (no JS FFI round trip),
+-- matching JS's @parseFloat@ semantics: leading\/trailing whitespace and
+-- trailing garbage are ignored, and a leading @+\/-@ is allowed.
+parseDouble :: Text -> Maybe Double
+parseDouble = hush . TR.double . T.strip
+{-# INLINE parseDouble #-}
+-----------------------------------------------------------------------------
+hush :: Either String (a, Text) -> Maybe a
+hush = either (const Nothing) (Just . fst)
+{-# INLINE hush #-}
+#else
 foreign import javascript unsafe
   """
   return parseFloat($1);
   """
   parseDouble_Unchecked :: JSString -> Double
 -----------------------------------------------------------------------------
-parseDouble_JSString :: JSString -> Maybe Double
-parseDouble_JSString string =
+parseDouble :: JSString -> Maybe Double
+parseDouble string =
   case parseDouble_Unchecked string of
     double | isNaN double -> Nothing
            | otherwise -> Just double
-{-# INLINE parseDouble_JSString #-}
------------------------------------------------------------------------------
-#ifdef MISO_TEXT
-parseDouble :: Text -> Maybe Double
-parseDouble = parseDouble_JSString . textToJSString
-{-# INLINE parseDouble #-}
-#else
-parseDouble :: JSString -> Maybe Double
-parseDouble = parseDouble_JSString
 {-# INLINE parseDouble #-}
 #endif
 -----------------------------------------------------------------------------

--- a/ffi/wasm/Miso/DSL/FFI.hs
+++ b/ffi/wasm/Miso/DSL/FFI.hs
@@ -89,7 +89,7 @@ module Miso.DSL.FFI
   , JSException
   ) where
 -----------------------------------------------------------------------------
-import           Data.Text (Text)
+import           Data.Text (Text, pack)
 import           Control.Monad
 import           Data.JSString (textFromJSString, textToJSString)
 #ifdef MISO_TEXT
@@ -534,8 +534,11 @@ parseFloat string = realToFrac <$> parseDouble string
 {-# INLINE parseFloat #-}
 -----------------------------------------------------------------------------
 #ifdef MISO_TEXT
+-- | 'show' agrees with JS's native number formatting for 'Int', so this
+-- avoids allocating a throwaway 'JSVal' via the FFI just to convert it
+-- straight back to 'Text'.
 toString_Int :: Int -> Text
-toString_Int = textFromJSString . JSS.toString_Int
+toString_Int = pack . show
 {-# INLINE toString_Int #-}
 -----------------------------------------------------------------------------
 toString_Double :: Double -> Text
@@ -546,8 +549,9 @@ toString_Float :: Float -> Text
 toString_Float = textFromJSString . JSS.toString_Float
 {-# INLINE toString_Float #-}
 -----------------------------------------------------------------------------
+-- | See 'toString_Int': 'show' matches JS formatting for 'Word' too.
 toString_Word :: Word -> Text
-toString_Word = textFromJSString . JSS.toString_Word
+toString_Word = pack . show
 {-# INLINE toString_Word #-}
 #endif
 -----------------------------------------------------------------------------

--- a/ffi/wasm/Miso/DSL/FFI.hs
+++ b/ffi/wasm/Miso/DSL/FFI.hs
@@ -542,11 +542,11 @@ toString_Int = pack . show
 {-# INLINE toString_Int #-}
 -----------------------------------------------------------------------------
 toString_Double :: Double -> Text
-toString_Double = textFromJSString . JSS.toString_Double
+toString_Double = pack . show
 {-# INLINE toString_Double #-}
 -----------------------------------------------------------------------------
 toString_Float :: Float -> Text
-toString_Float = textFromJSString . JSS.toString_Float
+toString_Float = pack . show
 {-# INLINE toString_Float #-}
 -----------------------------------------------------------------------------
 -- | See 'toString_Int': 'show' matches JS formatting for 'Word' too.

--- a/ffi/wasm/Miso/DSL/FFI.hs
+++ b/ffi/wasm/Miso/DSL/FFI.hs
@@ -1,4 +1,5 @@
 -----------------------------------------------------------------------------
+{-# LANGUAGE CPP                      #-}
 {-# LANGUAGE LambdaCase               #-}
 {-# LANGUAGE TemplateHaskell          #-}
 {-# LANGUAGE MultilineStrings         #-}
@@ -77,12 +78,23 @@ module Miso.DSL.FFI
   , parseDouble
   , parseWord
   , parseFloat
+#ifdef MISO_TEXT
+  , toString_Int
+  , toString_Double
+  , toString_Float
+  , toString_Word
+#endif
+  , textFromJSString
+  , textToJSString
   , JSException
   ) where
 -----------------------------------------------------------------------------
 import           Data.Text (Text)
 import           Control.Monad
 import           Data.JSString (textFromJSString, textToJSString)
+#ifdef MISO_TEXT
+import qualified Data.JSString as JSS
+#endif
 import           Prelude hiding (length, head, tail, unlines, concat, null, drop, replicate, concatMap)
 -----------------------------------------------------------------------------
 import           GHC.Wasm.Prim
@@ -465,16 +477,30 @@ foreign import javascript unsafe
   """
   parseInt_Unchecked :: JSString -> Double
 -----------------------------------------------------------------------------
-parseWord :: JSString -> Maybe Word
-parseWord string = fromIntegral <$> parseInt string
-{-# INLINE parseWord #-}
------------------------------------------------------------------------------
-parseInt :: JSString -> Maybe Int
-parseInt string = do
+parseInt_JSString :: JSString -> Maybe Int
+parseInt_JSString string =
   case parseInt_Unchecked string of
     double | isNaN double -> Nothing
            | otherwise -> Just (round double)
+{-# INLINE parseInt_JSString #-}
+-----------------------------------------------------------------------------
+#ifdef MISO_TEXT
+parseInt :: Text -> Maybe Int
+parseInt = parseInt_JSString . textToJSString
 {-# INLINE parseInt #-}
+#else
+parseInt :: JSString -> Maybe Int
+parseInt = parseInt_JSString
+{-# INLINE parseInt #-}
+#endif
+-----------------------------------------------------------------------------
+#ifdef MISO_TEXT
+parseWord :: Text -> Maybe Word
+#else
+parseWord :: JSString -> Maybe Word
+#endif
+parseWord string = fromIntegral <$> parseInt string
+{-# INLINE parseWord #-}
 -----------------------------------------------------------------------------
 foreign import javascript unsafe
   """
@@ -482,14 +508,46 @@ foreign import javascript unsafe
   """
   parseDouble_Unchecked :: JSString -> Double
 -----------------------------------------------------------------------------
-parseDouble :: JSString -> Maybe Double
-parseDouble string = do
+parseDouble_JSString :: JSString -> Maybe Double
+parseDouble_JSString string =
   case parseDouble_Unchecked string of
     double | isNaN double -> Nothing
            | otherwise -> Just double
-{-# INLINE parseDouble #-}
+{-# INLINE parseDouble_JSString #-}
 -----------------------------------------------------------------------------
+#ifdef MISO_TEXT
+parseDouble :: Text -> Maybe Double
+parseDouble = parseDouble_JSString . textToJSString
+{-# INLINE parseDouble #-}
+#else
+parseDouble :: JSString -> Maybe Double
+parseDouble = parseDouble_JSString
+{-# INLINE parseDouble #-}
+#endif
+-----------------------------------------------------------------------------
+#ifdef MISO_TEXT
+parseFloat :: Text -> Maybe Float
+#else
 parseFloat :: JSString -> Maybe Float
+#endif
 parseFloat string = realToFrac <$> parseDouble string
 {-# INLINE parseFloat #-}
+-----------------------------------------------------------------------------
+#ifdef MISO_TEXT
+toString_Int :: Int -> Text
+toString_Int = textFromJSString . JSS.toString_Int
+{-# INLINE toString_Int #-}
+-----------------------------------------------------------------------------
+toString_Double :: Double -> Text
+toString_Double = textFromJSString . JSS.toString_Double
+{-# INLINE toString_Double #-}
+-----------------------------------------------------------------------------
+toString_Float :: Float -> Text
+toString_Float = textFromJSString . JSS.toString_Float
+{-# INLINE toString_Float #-}
+-----------------------------------------------------------------------------
+toString_Word :: Word -> Text
+toString_Word = textFromJSString . JSS.toString_Word
+{-# INLINE toString_Word #-}
+#endif
 -----------------------------------------------------------------------------

--- a/ffi/wasm/Miso/DSL/FFI.hs
+++ b/ffi/wasm/Miso/DSL/FFI.hs
@@ -89,12 +89,15 @@ module Miso.DSL.FFI
   , JSException
   ) where
 -----------------------------------------------------------------------------
-import           Data.Text (Text, pack)
+import           Data.Text (Text)
 import           Control.Monad
 import           Data.JSString (textFromJSString, textToJSString)
 #ifdef MISO_TEXT
-import qualified Data.JSString as JSS
 import qualified Data.Text as T
+import qualified Data.Text.Lazy as TL
+import qualified Data.Text.Lazy.Builder as TB
+import qualified Data.Text.Lazy.Builder.Int as TBI
+import qualified Data.Text.Lazy.Builder.RealFloat as TBR
 import qualified Data.Text.Read as TR
 #endif
 import           Prelude hiding (length, head, tail, unlines, concat, null, drop, replicate, concatMap)
@@ -546,22 +549,23 @@ parseFloat string = realToFrac <$> parseDouble string
 #ifdef MISO_TEXT
 -- | 'show' agrees with JS's native number formatting for 'Int', so this
 -- avoids allocating a throwaway 'JSVal' via the FFI just to convert it
--- straight back to 'Text'.
+-- straight back to 'Text'. Built via 'Data.Text.Lazy.Builder' rather than
+-- @pack . show@ to skip the intermediate 'String'.
 toString_Int :: Int -> Text
-toString_Int = pack . show
+toString_Int = TL.toStrict . TB.toLazyText . TBI.decimal
 {-# INLINE toString_Int #-}
 -----------------------------------------------------------------------------
 toString_Double :: Double -> Text
-toString_Double = pack . show
+toString_Double = TL.toStrict . TB.toLazyText . TBR.realFloat
 {-# INLINE toString_Double #-}
 -----------------------------------------------------------------------------
 toString_Float :: Float -> Text
-toString_Float = pack . show
+toString_Float = TL.toStrict . TB.toLazyText . TBR.realFloat
 {-# INLINE toString_Float #-}
 -----------------------------------------------------------------------------
 -- | See 'toString_Int': 'show' matches JS formatting for 'Word' too.
 toString_Word :: Word -> Text
-toString_Word = pack . show
+toString_Word = TL.toStrict . TB.toLazyText . TBI.decimal
 {-# INLINE toString_Word #-}
 #endif
 -----------------------------------------------------------------------------

--- a/miso.cabal
+++ b/miso.cabal
@@ -61,6 +61,10 @@ common cpp
     cpp-options:
       -DAESON
 
+  if flag(text)
+    cpp-options:
+      -DMISO_TEXT
+
 common client
   if impl(ghcjs) || arch(javascript) || arch(wasm32)
     if flag(native) && flag(production)
@@ -129,6 +133,14 @@ flag aeson
     of aeson (Data.Aeson), and its types (Value, Object, Parser) become
     aeson's. Miso's own Generic deriving machinery is not exported in this
     mode; aeson provides its own.
+
+flag text
+  manual:
+    True
+  default:
+    False
+  description:
+    When enabled, this force MisoString to be Text.
 
 library
   import:

--- a/src/Miso/DSL.hs
+++ b/src/Miso/DSL.hs
@@ -562,7 +562,13 @@ setField
 setField o k v = do
   o' <- toJSVal =<< toObject o
   v' <- toJSVal v
-  setProp_ffi k v' o'
+  setProp_ffi
+#ifdef MISO_TEXT
+    (textToJSString k)
+#else
+    k
+#endif
+    v' o'
 {-# INLINABLE setField #-}
 -----------------------------------------------------------------------------
 -- | Sets a field on an Object at a specified index
@@ -610,7 +616,13 @@ infixr 2 #
 (#) :: (ToObject object, ToArgs args) => object -> MisoString -> args -> IO JSVal
 (#) o k args = do
   o' <- toJSVal =<< toObject o
-  func <- getProp_ffi k o'
+  func <- getProp_ffi
+#ifdef MISO_TEXT
+    (textToJSString k)
+#else
+    k
+#endif
+    o'
   args' <- toJSVal =<< toArgs args
   result <- invokeFunction func o' args'
   -- @func@ and the argument array are temporaries nobody else can reach;
@@ -689,7 +701,13 @@ setProp
   -> Object
   -- ^ Target JavaScript object
   -> IO ()
-setProp k v (Object o) = flip (setProp_ffi k) o =<< toJSVal v
+setProp k v (Object o) = flip (setProp_ffi
+#ifdef MISO_TEXT
+    (textToJSString k)
+#else
+    k
+#endif
+    ) o =<< toJSVal v
 {-# INLINABLE setProp #-}
 -----------------------------------------------------------------------------
 -- | Retrieves a property from a JS t'Object'
@@ -700,7 +718,13 @@ getProp
   -> o
   -- ^ JavaScript object to read from
   -> IO JSVal
-getProp k v = getProp_ffi k =<< toJSVal (toObject v)
+getProp k v = getProp_ffi
+#ifdef MISO_TEXT
+    (textToJSString k)
+#else
+    k
+#endif
+    =<< toJSVal (toObject v)
 {-# INLINABLE getProp #-}
 -----------------------------------------------------------------------------
 -- | Dynamically evaluates a JS string. See [eval](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/eval)
@@ -711,7 +735,12 @@ getProp k v = getProp_ffi k =<< toJSVal (toObject v)
 -- Consider using the more performant and secure (isolated) `inline` function.
 --
 eval :: MisoString -> IO JSVal
-eval = eval_ffi
+eval =
+#ifdef MISO_TEXT
+  eval_ffi . textToJSString
+#else
+  eval_ffi
+#endif
 {-# INLINABLE eval #-}
 -----------------------------------------------------------------------------
 instance FromJSVal Bool where
@@ -768,7 +797,7 @@ instance ToArgs MisoString where
   toArgs arg = (:[]) <$> toJSVal arg
   {-# INLINE toArgs #-}
 ----------------------------------------------------------------------------
-#ifndef VANILLA
+#if !defined(VANILLA) && !defined(MISO_TEXT)
 ----------------------------------------------------------------------------
 instance ToJSVal MisoString where
   toJSVal = toJSVal_JSString

--- a/src/Miso/JSON.hs
+++ b/src/Miso/JSON.hs
@@ -340,7 +340,7 @@ mv .!= def = fmap (fromMaybe def) mv
 #endif
 ----------------------------------------------------------------------------
 #ifdef AESON
-#ifndef VANILLA
+#if !defined(VANILLA) && !defined(MISO_TEXT)
 -- On the JavaScript and WASM backends t'MisoString' is @JSString@, which
 -- aeson does not know about; these orphans make it a first-class JSON
 -- citizen so code written against "Miso.JSON" keeps compiling.
@@ -661,7 +661,7 @@ instance (ToJSON a,ToJSON b,ToJSON c, ToJSON d) => ToJSON (a,b,c,d) where
 instance ToJSON MisoString where
   toJSON = String
 ----------------------------------------------------------------------------
-#ifndef VANILLA
+#if !defined(VANILLA) && !defined(MISO_TEXT)
 instance ToJSON T.Text where
   toJSON = toJSON . ms
 #endif
@@ -967,7 +967,7 @@ instance FromJSON Bool where
 instance FromJSON MisoString where
   parseJSON = withText "MisoString" pure
 ----------------------------------------------------------------------------
-#ifndef VANILLA
+#if !defined(VANILLA) && !defined(MISO_TEXT)
 instance FromJSON T.Text where
   parseJSON = withText "Text" go
     where
@@ -1336,9 +1336,17 @@ foreign import javascript unsafe
 #endif
 -----------------------------------------------------------------------------
 #ifdef WASM
+#ifdef MISO_TEXT
+foreign import javascript unsafe
+  "return JSON.stringify($1, null, $2);"
+  encodePretty_ffi_JSString :: JSVal -> Int -> IO JSString
+encodePretty_ffi :: JSVal -> Int -> IO MisoString
+encodePretty_ffi jsval n = textFromJSString <$> encodePretty_ffi_JSString jsval n
+#else
 foreign import javascript unsafe
   "return JSON.stringify($1, null, $2);"
   encodePretty_ffi :: JSVal -> Int -> IO MisoString
+#endif
 #endif
 -----------------------------------------------------------------------------
 -- | Like 'encodePretty' but with a custom t'Config'.
@@ -1386,9 +1394,17 @@ foreign import javascript unsafe
 #endif
 -----------------------------------------------------------------------------
 #ifdef WASM
+#ifdef MISO_TEXT
+foreign import javascript unsafe
+  "return JSON.stringify($1);"
+  jsonStringify_JSString :: JSVal -> IO JSString
+jsonStringify :: JSVal -> IO MisoString
+jsonStringify jsval = textFromJSString <$> jsonStringify_JSString jsval
+#else
 foreign import javascript unsafe
   "return JSON.stringify($1);"
   jsonStringify :: JSVal -> IO MisoString
+#endif
 #endif
 -----------------------------------------------------------------------------
 #ifdef VANILLA
@@ -1410,9 +1426,17 @@ foreign import javascript unsafe
 #endif
 -----------------------------------------------------------------------------
 #ifdef WASM
+#ifdef MISO_TEXT
+foreign import javascript unsafe
+  "return JSON.parse($1);"
+  jsonParse_JSString :: JSString -> IO JSVal
+jsonParse :: MisoString -> IO JSVal
+jsonParse = jsonParse_JSString . textToJSString
+#else
 foreign import javascript unsafe
   "return JSON.parse($1);"
   jsonParse :: MisoString -> IO JSVal
+#endif
 #endif
 -----------------------------------------------------------------------------
 #ifdef VANILLA
@@ -1556,7 +1580,12 @@ fromJSVal_Value jsval = do
   typeof jsval >>= \case
     0 -> return (Just Null)
     1 -> Just . doubleToNumber <$> fromJSValUnchecked_Double jsval
-    2 -> pure $ Just $ mkString $ (JSString jsval)
+    2 -> pure $ Just $ mkString $
+#ifdef MISO_TEXT
+           textFromJSString (JSString jsval)
+#else
+           (JSString jsval)
+#endif
     3 -> fromJSValUnchecked_Int jsval >>= \case
       0 -> pure $ Just (Bool False)
       1 -> pure $ Just (Bool True)
@@ -1570,7 +1599,14 @@ fromJSVal_Value jsval = do
                 let key = JSString k
                 raw <- MaybeT $ Just <$> getProp_ffi key jsval
                 value <- MaybeT (fromJSVal_Value raw)
-                pure (key, value)
+                pure
+                  (
+#ifdef MISO_TEXT
+                    textFromJSString key
+#else
+                    key
+#endif
+                  , value)
             pure (toObject <$> result)
     _ -> error "fromJSVal_Value: Unknown JSON type"
   where
@@ -1615,7 +1651,11 @@ toJSVal_Value = \case
   Bool bool_ ->
     toJSVal_Bool bool_
   String string ->
+#ifdef MISO_TEXT
+    toJSVal_Text (stringToMiso string)
+#else
     toJSVal_JSString (stringToMiso string)
+#endif
   Number double ->
     toJSVal_Double (numberToDouble double)
   Array arr ->
@@ -1624,7 +1664,13 @@ toJSVal_Value = \case
     o <- create_ffi
     forM_ (objectAssocs hms) $ \(k,v) -> do
       v' <- toJSVal_Value v
-      setProp_ffi k v' o
+      setProp_ffi
+#ifdef MISO_TEXT
+        (textToJSString k)
+#else
+        k
+#endif
+        v' o
     pure o
 #endif
 -----------------------------------------------------------------------------

--- a/src/Miso/String.hs
+++ b/src/Miso/String.hs
@@ -31,7 +31,7 @@ module Miso.String
   , FromMisoString (..)
   , fromMisoString
   , MisoString
-#ifdef VANILLA
+#if defined(VANILLA) || defined(MISO_TEXT)
   , module Data.Text
 #else
   , module Data.JSString
@@ -43,7 +43,7 @@ import           Control.Exception
 import qualified Data.ByteString as B
 import qualified Data.ByteString.Builder as B
 import qualified Data.ByteString.Lazy as BL
-#ifdef VANILLA
+#if defined(VANILLA) || defined(MISO_TEXT)
 import           Data.Text hiding (show, elem)
 #else
 import           Data.JSString
@@ -64,7 +64,7 @@ import           Miso.DSL.FFI
 -- * WASM \/ GHC JS backend: alias for @JSString@ — a zero-copy wrapper around
 --   a native JavaScript string, giving optimal interop with the DOM and JSON APIs
 --
-#ifdef VANILLA
+#if defined(VANILLA) || defined(MISO_TEXT)
 type MisoString = Text
 #else
 type MisoString = JSString
@@ -108,7 +108,7 @@ instance ToMisoString Char where
 instance ToMisoString IOException where
   toMisoString = ms . show
 ----------------------------------------------------------------------------
-#ifndef VANILLA
+#if !defined(VANILLA) && !defined(MISO_TEXT)
 instance ToMisoString MisoString where
   toMisoString = id
 #endif
@@ -123,7 +123,7 @@ instance ToMisoString LT.Text where
   toMisoString = ms . LT.toStrict
 ----------------------------------------------------------------------------
 instance ToMisoString T.Text where
-#ifdef VANILLA
+#if defined(VANILLA) || defined(MISO_TEXT)
   toMisoString = id
 #else
   toMisoString = textToJSString
@@ -139,8 +139,7 @@ instance ToMisoString B.Builder where
   toMisoString = ms . B.toLazyByteString
 ----------------------------------------------------------------------------
 instance ToMisoString Float where
-  -- dmj: issue where Float shows additional digits (affects both JS & WASM)
-  toMisoString = toString_Double . realToFrac
+  toMisoString = toString_Float
 ----------------------------------------------------------------------------
 instance ToMisoString Double where
   toMisoString = toString_Double
@@ -151,13 +150,13 @@ instance ToMisoString Int where
 instance ToMisoString Word where
   toMisoString = toString_Word
 ----------------------------------------------------------------------------
-#ifndef VANILLA
+#if !defined(VANILLA) && !defined(MISO_TEXT)
 instance FromMisoString MisoString where
   fromMisoStringEither = Right
 #endif
 ----------------------------------------------------------------------------
 instance FromMisoString T.Text where
-#ifdef VANILLA
+#if defined(VANILLA) || defined(MISO_TEXT)
   fromMisoStringEither = Right
 #else
   fromMisoStringEither = Right . textFromJSString
@@ -167,7 +166,7 @@ instance FromMisoString String where
   fromMisoStringEither = Right . unpack
 ----------------------------------------------------------------------------
 instance FromMisoString LT.Text where
-#ifdef VANILLA
+#if defined(VANILLA) || defined(MISO_TEXT)
   fromMisoStringEither = Right . LT.fromStrict
 #else
   fromMisoStringEither = Right . LT.fromStrict . textFromJSString

--- a/src/Miso/Types.hs
+++ b/src/Miso/Types.hs
@@ -816,7 +816,7 @@ class ToKey key where
 -- | Identity instance
 instance ToKey Key where toKey = id
 -----------------------------------------------------------------------------
-#ifndef VANILLA
+#if !defined(VANILLA) && !defined(MISO_TEXT)
 -- | Convert 'MisoString' to t'Key'
 instance ToKey MisoString where toKey = Key
 #endif

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,15 +1,21 @@
-.PHONY= update build build-aeson optim aeson
+.PHONY= update build build-aeson build-aeson-text optim aeson aeson-text
 
 all: update build optim
 
 # Same as 'all', but with miso built against aeson (the 'aeson' cabal flag)
 aeson: update build-aeson optim
 
+# Same as 'all', but with miso built against aeson + text (the 'aeson' and 'text' cabal flags)
+aeson-text: update build-aeson-text optim
+
 update:
 	wasm32-wasi-cabal update
 
 build-aeson: CABAL_OPTS = --constraint="miso +aeson"
 build-aeson: build
+
+build-aeson-text: CABAL_OPTS = --constraint="miso +aeson +text"
+build-aeson-text: build
 
 build:
 	wasm32-wasi-cabal build component-tests $(CABAL_OPTS)


### PR DESCRIPTION
Enables miso's `text` and `aeson` cabal flags for the WASM backend (`Miso.String` backed by `Data.Text`, `Miso.JSON` backed by `Data.Aeson`), and wires a `playwright-wasm-aeson-text` integration test target into CI.