### PR TITLE
fix: `parseInt` (`-ftext`) mis-parses negative hex, e.g. "-0x1A" as 0

### DIFF
--- a/ffi/wasm/Miso/DSL/FFI.hs
+++ b/ffi/wasm/Miso/DSL/FFI.hs
@@ -483,11 +483,17 @@ fromJSValUnchecked_Maybe jsval = do
 -- @0x@\/@0X@ prefix is read as hexadecimal.
 parseInt :: Text -> Maybe Int
 parseInt input =
-  case T.stripPrefix (T.pack "0x") stripped `mplus` T.stripPrefix (T.pack "0X") stripped of
-    Just hex -> hush (TR.hexadecimal hex)
-    Nothing  -> hush (TR.signed TR.decimal stripped)
+  applySign <$>
+    case T.stripPrefix (T.pack "0x") unsigned `mplus` T.stripPrefix (T.pack "0X") unsigned of
+      Just hex -> hush (TR.hexadecimal hex)
+      Nothing  -> hush (TR.decimal unsigned)
   where
     stripped = T.strip input
+    (isNegative, unsigned) = case T.uncons stripped of
+      Just ('-', rest) -> (True, rest)
+      Just ('+', rest) -> (False, rest)
+      _                -> (False, stripped)
+    applySign = if isNegative then negate else id
 {-# INLINE parseInt #-}
 #else
 foreign import javascript unsafe

--- a/tests/app/Main.hs
+++ b/tests/app/Main.hs
@@ -1557,6 +1557,16 @@ main = withJS $ do
         S.fromMisoStringEither "3" `shouldBe` Right (3 :: Word)
         S.fromMisoStringEither @Word "foo" `shouldSatisfy` isLeft
 
+      -- Regression test: parseInt used to check for a "0x"/"0X" prefix
+      -- before stripping a leading sign, so a negative hex literal never
+      -- matched the hex branch and fell through to decimal parsing, which
+      -- read only the leading "0" and silently returned 0 instead of -26.
+      it "Should parse signed hexadecimal integers via parseInt" $ do
+        S.fromMisoStringEither "-0x1A" `shouldBe` Right (-26 :: Int)
+        S.fromMisoStringEither "+0x1A" `shouldBe` Right (26 :: Int)
+        S.fromMisoStringEither "0x1A"  `shouldBe` Right (26 :: Int)
+        S.fromMisoStringEither "-0X1A" `shouldBe` Right (-26 :: Int)
+
     describe "JS DSL tests" $ do
       it "Should get an set a property on an Object" $ do
         c <- liftIO create


### PR DESCRIPTION
The old code checked for a "0x"/"0X" prefix before stripping a sign, so a negative hex literal never matched the prefix check and fell through to TR.signed TR.decimal, which read only the leading "0" before stopping at 'x' and silently returned 0 instead of -26.

parseInt now strips an optional leading +/- first, then checks the remainder for a hex prefix and applies the sign to the parsed magnitude, matching JS's parseInt semantics. Verified against Data.Text.Read directly for a range of signed/hex/decimal inputs.