### PR TITLE
fix: make `MisoString` drop code-point-aware on WASM, matching `take`/`length`

### DIFF
--- a/ffi/wasm/Data/JSString.hs
+++ b/ffi/wasm/Data/JSString.hs
@@ -777,7 +777,7 @@ foreign import javascript unsafe
 foreign import javascript unsafe
   """
   if ($1 < 1 || $2.length === 0) return $2;
-  return $2.slice($1, $2.length);
+  return Array.from($2).slice($1).join('');
   """ drop :: Int -> JSString -> JSString
 -----------------------------------------------------------------------------
 foldl' :: (a -> Char -> a) -> a -> JSString -> a


### PR DESCRIPTION
`take` and `length` were made code-point-based to fix astral-character (emoji) miscounting, but drop was left on raw UTF-16 slicing. Since `splitAt` is defined as (`take` n xs, `drop` n xs), the two disagreed on where position n falls for any string containing an astral character before it, corrupting the split. drop now uses the same `Array.from(...).slice(...).join('')` approach as take.