### PR TITLE
fix: native decoder/method wire-shape and default-value bugs

### DIFF
--- a/src/Miso/Native/Element/List/Method.hs
+++ b/src/Miso/Native/Element/List/Method.hs
@@ -57,13 +57,13 @@ defaultScrollToPosition
   { stpPosition = 10
   , stpOffset = 100
   , stpAlignTo = "top"
-  , stpSmooth = True
+  , stpSmooth = False
   }
 -----------------------------------------------------------------------------
 instance ToJSVal ScrollToPosition where
   toJSVal ScrollToPosition {..} = do
     object <- create
-    set "position" stpPosition object
+    set "index" stpPosition object
     set "offset" stpOffset object
     set "alignTo" stpAlignTo object
     set "smooth" stpSmooth object
@@ -125,7 +125,7 @@ instance ToJSVal AutoScroll where
 defaultAutoScroll :: AutoScroll
 defaultAutoScroll = AutoScroll
   { rate = "60"
-  , start = True
+  , start = False
   , autoStop = True
   }
 --------------------------------------------------------------------

--- a/src/Miso/Native/Element/ScrollView/Method.hs
+++ b/src/Miso/Native/Element/ScrollView/Method.hs
@@ -99,7 +99,7 @@ instance ToJSVal AutoScroll where
 --
 -- @since 1.13.0.0
 defaultAutoScroll :: AutoScroll
-defaultAutoScroll = AutoScroll 120 True
+defaultAutoScroll = AutoScroll 120 False
 -----------------------------------------------------------------------------
 -- | Invokes the Lynx @autoScroll@ method on a @<scroll-view>@ element.
 --

--- a/src/Miso/Native/Element/View/Event.hs
+++ b/src/Miso/Native/Element/View/Event.hs
@@ -106,7 +106,7 @@ import Control.Applicative (liftA2)
 import qualified Data.Map as M
 import           Miso.Event (on, onMain, Decoder(..), DecodeTarget(..), Events, emptyDecoder, Phase(BUBBLE))
 import           Miso.JSON
-import           Miso.String (MisoString)
+import           Miso.String (MisoString, isPrefixOf)
 import           Miso.Types (Attribute, EventHandler, DOMRef)
 ----------------------------------------------------------------------------
 -- | The 'Events' map for the Lynx @<view>@ element.
@@ -176,12 +176,18 @@ data AnimationEvent
     -- ^ The type of the animation. If it is a keyframe animation,
     -- this value is `keyframe-animation`; if it is a transition animation,
     -- this value is `transition-animation`.
-  , animationName :: MisoString
+  , animationName :: Maybe MisoString
     -- ^ The name of the animation. If it is a keyframe animation, it
     -- is the name of `@keyframes` in CSS; if it is a transition animation,
-    -- it is the name of `transition-property` in CSS.
+    -- it is the name of `transition-property` in CSS. 'Nothing' for
+    -- 'LegacyTransitionAnimation', whose property name is folded into
+    -- 'animationType' instead.
   , newAnimator :: Bool
-    -- ^ Default value 'True'
+    -- ^ 'True' only when the engine's new animator explicitly reports it
+    -- (always @true@ when present, on both keyframe and transition events);
+    -- pre-"new animator" engines never send this field at all, for
+    -- keyframe animations as well as 'LegacyTransitionAnimation', so
+    -- 'False' whenever the field is absent.
   } deriving (Show, Eq)
 ----------------------------------------------------------------------------
 -- | Which animation kind raised the event: a @\@keyframes@ animation or a
@@ -191,13 +197,19 @@ data AnimationEvent
 data AnimationType
   = KeyFrameAnimation
   | TransitionAnimation
+  | LegacyTransitionAnimation MisoString
+    -- ^ Pre-"new animator" engines report a CSS transition as
+    -- @transition-\<property\>@ (e.g. @transition-width@) instead of
+    -- @transition-animation@, and send no @animation_name@\/@new_animator@
+    -- alongside it. This carries the raw wire value (e.g. @transition-width@).
   deriving (Show, Eq)
 ----------------------------------------------------------------------------
 instance FromJSON AnimationType where
   parseJSON = withText "animation-type" $ \case
     "keyframe-animation" -> pure KeyFrameAnimation
     "transition-animation" -> pure TransitionAnimation
-    x -> typeMismatch "animation-type" (toJSON x)
+    x | "transition-" `isPrefixOf` x -> pure (LegacyTransitionAnimation x)
+      | otherwise -> typeMismatch "animation-type" (toJSON x)
 ----------------------------------------------------------------------------
 -- | Animation decoder for use with events like 'onAnimationStart'
 animationDecoder :: Decoder AnimationEvent
@@ -205,11 +217,13 @@ animationDecoder = Decoder {..}
   where
     decodeAt = DecodeTarget mempty
     decoder = withObject "animationDecoder" $ \o -> do
-      d <- o .: "detail"
-      AnimationEvent
-        <$> d .: "animation_type"
-        <*> d .: "animation_name"
-        <*> d .: "new_animator"
+      d <- o .: "params"
+      aType <- d .: "animation_type"
+      name <- case aType of
+        LegacyTransitionAnimation _ -> pure Nothing
+        _ -> Just <$> d .: "animation_name"
+      newAnim <- d .:? "new_animator" .!= False
+      pure (AnimationEvent aType name newAnim)
 -----------------------------------------------------------------------------
 -- | Payload of a @<view>@ layout-change event: the target's id, its new
 -- box, and its @dataset@.

--- a/src/Miso/Native/Element/View/Method.hs
+++ b/src/Miso/Native/Element/View/Method.hs
@@ -79,7 +79,7 @@ instance ToJSVal BoundingClientRect where
 defaultBoundingClientRect :: BoundingClientRect
 defaultBoundingClientRect
   = BoundingClientRect
-  { androidEnableTransformProps = True
+  { androidEnableTransformProps = False
   , relativeTo = Nothing
   }
 -----------------------------------------------------------------------------
@@ -168,8 +168,8 @@ takeScreenshot = invokeExec "takeScreenshot"
 defaultTakeScreenshot :: TakeScreenshot
 defaultTakeScreenshot
   = TakeScreenshot
-  { scale = 0.5
-  , format = ".png"
+  { scale = 1
+  , format = "jpeg"
   }
 -----------------------------------------------------------------------------
 -- | https://lynxjs.org/api/elements/built-in/view.html#requestaccessibilityfocus

--- a/src/Miso/Native/Element/View/Property.hs
+++ b/src/Miso/Native/Element/View/Property.hs
@@ -316,9 +316,9 @@ accessibilityElementsA11y_ = textProp "accessibility-elements-a11y"
 --
 -- Marks the current node and all its child nodes as non-accessible nodes.
 --
--- > accessibilityExclusiveHidden_ True
+-- > accessibilityElementsHidden_ True
 --
--- Default Value: 'True'
+-- Default Value: 'False'
 --
 accessibilityElementsHidden_ :: Bool -> Attribute model action
 accessibilityElementsHidden_ = boolProp "accessibility-elements-hidden"
@@ -329,7 +329,7 @@ accessibilityElementsHidden_ = boolProp "accessibility-elements-hidden"
 --
 -- > accessibilityExclusiveFocus_ True
 --
--- Default Value: 'True'
+-- Default Value: 'False'
 --
 accessibilityExclusiveFocus_ :: Bool -> Attribute model action
 accessibilityExclusiveFocus_ = boolProp "accessibility-exclusive-focus"
@@ -511,8 +511,8 @@ hitSlop_ = textProp "hit-slop"
 --
 -- Default Value: 'False
 --
-ignoreFocus_ :: MisoString -> Attribute model action
-ignoreFocus_ = textProp "ignore-focus"
+ignoreFocus_ :: Bool -> Attribute model action
+ignoreFocus_ = boolProp "ignore-focus"
 -----------------------------------------------------------------------------
 -- | https://lynxjs.org/api/elements/built-in/view.html#ios-enable-simultaneous-touch
 --

--- a/src/Miso/Native/X/Element/Overlay/Event.hs
+++ b/src/Miso/Native/X/Element/Overlay/Event.hs
@@ -1,4 +1,5 @@
 -----------------------------------------------------------------------------
+{-# LANGUAGE LambdaCase        #-}
 {-# LANGUAGE OverloadedStrings #-}
 -----------------------------------------------------------------------------
 -- |
@@ -36,6 +37,7 @@ module Miso.Native.X.Element.Overlay.Event
     -- *** Types
   , OverlayErrorEvent (..)
   , OverlayTouchEvent (..)
+  , OverlayTouchState (..)
     -- *** Decoders
   , overlayErrorDecoder
   , overlayTouchDecoder
@@ -69,16 +71,37 @@ overlayEvents
 -- | Payload of the @binderror@ event.
 data OverlayErrorEvent
   = OverlayErrorEvent
-  { errorCode :: MisoString
+  { errorCode :: Int
     -- ^ The error code
   , errorMsg :: MisoString
     -- ^ The error message
   } deriving (Show, Eq)
 -----------------------------------------------------------------------------
+-- | Touch phase of a @bindoverlaytouch@ event, mirrored from Lynx's
+-- @OverlayTouchState@ enum.
+--
+-- @since 1.13.0.0
+data OverlayTouchState
+  = OverlayTouchDown
+  | OverlayTouchMove
+  | OverlayTouchUp
+  | OverlayTouchCancel
+  deriving (Show, Eq)
+-----------------------------------------------------------------------------
+-- | Numbering matches Lynx's @OverlayTouchState@ enum (@OverlayTouchStateDown
+-- = 0@ … @OverlayTouchStateCancel = 3@), the shape the wire actually sends.
+instance FromJSON OverlayTouchState where
+  parseJSON = withNumber "OverlayTouchState" $ \case
+    0 -> pure OverlayTouchDown
+    1 -> pure OverlayTouchMove
+    2 -> pure OverlayTouchUp
+    3 -> pure OverlayTouchCancel
+    x -> typeMismatch "OverlayTouchState" (toJSON x)
+-----------------------------------------------------------------------------
 -- | Payload of the @bindoverlaytouch@ event.
 data OverlayTouchEvent
   = OverlayTouchEvent
-  { touchState :: MisoString
+  { touchState :: OverlayTouchState
     -- ^ The @OverlayTouchState@
   , touchX :: Double
     -- ^ The horizontal position of the touch

--- a/src/Miso/Native/X/Element/Refresh/Event.hs
+++ b/src/Miso/Native/X/Element/Refresh/Event.hs
@@ -1,4 +1,5 @@
 -----------------------------------------------------------------------------
+{-# LANGUAGE LambdaCase        #-}
 {-# LANGUAGE OverloadedStrings #-}
 -----------------------------------------------------------------------------
 -- |
@@ -28,6 +29,7 @@ module Miso.Native.X.Element.Refresh.Event
     -- *** Types
   , HeaderOffsetEvent (..)
   , RefreshStateChangeEvent (..)
+  , RefreshState (..)
   , StartRefreshEvent (..)
     -- *** Decoders
   , headerOffsetDecoder
@@ -41,7 +43,6 @@ import qualified Data.Map as M
 -----------------------------------------------------------------------------
 import           Miso.Event
 import           Miso.JSON
-import           Miso.String (MisoString)
 import           Miso.Types (Attribute, EventHandler, DOMRef)
 -----------------------------------------------------------------------------
 -- | The 'Events' map for the Lynx @<refresh>@ element.
@@ -67,10 +68,28 @@ data HeaderOffsetEvent
     -- ^ Ratio of the pull-down distance to the header's own height
   } deriving (Show, Eq)
 -----------------------------------------------------------------------------
+-- | The state of a \<refresh-header\>, mirrored from Lynx's @RefreshState@ enum.
+--
+-- @since 1.13.0.0
+data RefreshState
+  = Idle
+  | OverDragRelease
+  | Refreshing
+  deriving (Show, Eq)
+-----------------------------------------------------------------------------
+-- | Numbering matches Lynx's @RefreshState@ enum (@IDLE = 0@ … @REFRESHING
+-- = 2@), the shape the wire actually sends.
+instance FromJSON RefreshState where
+  parseJSON = withNumber "RefreshState" $ \case
+    0 -> pure Idle
+    1 -> pure OverDragRelease
+    2 -> pure Refreshing
+    x -> typeMismatch "RefreshState" (toJSON x)
+-----------------------------------------------------------------------------
 -- | Payload of the @bindrefreshstatechange@ event.
 newtype RefreshStateChangeEvent
   = RefreshStateChangeEvent
-  { state :: MisoString
+  { state :: RefreshState
     -- ^ The @RefreshState@ of the \<refresh-header\>
   } deriving (Show, Eq)
 -----------------------------------------------------------------------------


### PR DESCRIPTION
Cross-referenced against the current Lynx engine source (`lynx`, `lynx-stack`). Nine bugs found and fixed:

- `View.Event`: animationDecoder read the animation/transition payload from "detail", but real Lynx events carry it under "params" (events.d.ts's BaseAnimationEvent/BaseTransitionEvent). Broke all on(Animation|Transition)(Start|End|Cancel)[Main][With] combinators on native. new_animator is also optional on the wire, not required.

- `Refresh.Event`: RefreshStateChangeEvent.state was decoded as MisoString, but the wire sends Lynx's RefreshState enum as a number (0=Idle, 1=OverDragRelease, 2=Refreshing per refresh.d.ts). Broke onRefreshStateChange* on native.

- `Overlay.Event`: touchState was decoded as MisoString, but the wire sends Lynx's OverlayTouchState enum as a number (overlay.d.ts). errorCode was decoded as MisoString, but Android (the only platform implementing binderror) sends a raw Int (LynxOverlayView.kt), contrary to overlay.d.ts's own incorrect `errorCode: string` declaration. Broke onOverlayTouch*/onError* on native.

- `List.Method`: scrollToPosition sent the target index under the key "position", but the engine's real parameter name is "index" (list.d.ts, list_element.cc). defaultScrollToPosition and defaultAutoScroll also set stpSmooth/start to True against the engine's documented/actual defaults of false.

- `View.Property`: ignoreFocus_ took a MisoString, but the property is boolean on the wire (props.d.ts) and every sibling boolean property in the file uses Bool/boolProp; its own doc example (ignoreFocus_ True) didn't even typecheck.

- `View.Method`: defaultTakeScreenshot set format = ".png" (the engine only accepts the literal strings "jpeg"/"png") and scale = 0.5 against the documented/engine default of 1. defaultBoundingClientRect set androidEnableTransformProps = True against the documented/engine default of False (methods.d.ts).