### PR TITLE
fix: `freeLifecycleHooks` reads `mount` / `unmount` off the wrong `VTree` object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -321,6 +321,16 @@ All notable changes to `miso` are documented here.
   `-26`. The sign is now stripped first, then the remainder is checked for
   a hex prefix.
 
+- **`freeLifecycleHooks` frees a component's `mount`/`unmount` callbacks
+  again.** It read the `mount`/`unmount` fields off the component's own
+  rendered content root instead of the `VComp` wrapper node that actually
+  holds them (reachable one hop up, via the content root's `parent` link),
+  so `fromJSVal` always failed and `freeFunction` was never called. Every
+  non-root `Component` unmount — normal teardown and every GHCi hot-reload
+  cycle — leaked the closures `mountCallback`/`unmountCallback` capture,
+  which includes the whole `initialize` closure (`app`, `events`, `sink`,
+  `model`). See Note [Freeing event handler callbacks] in `Miso.Runtime`.
+
 ### Performance
 
 - **Short-lived `JSVal` handles are freed eagerly in the WASM runtime.**

--- a/src/Miso/DSL.hs
+++ b/src/Miso/DSL.hs
@@ -914,11 +914,15 @@ freeJSVal = freeJSVal_ffi
 {-# INLINABLE freeJSVal #-}
 -----------------------------------------------------------------------------
 instance FromJSVal Function where
-  fromJSVal = pure . Just . Function
+  fromJSVal x = do
+    missing <- (||) <$> isUndefined x <*> isNull x
+    pure $ if missing then Nothing else Just (Function x)
   {-# INLINE fromJSVal #-}
 -----------------------------------------------------------------------------
 instance FromJSVal Object where
-  fromJSVal = pure . Just . Object
+  fromJSVal x = do
+    missing <- (||) <$> isUndefined x <*> isNull x
+    pure $ if missing then Nothing else Just (Object x)
   {-# INLINE fromJSVal #-}
 -----------------------------------------------------------------------------
 -- | Lookup a property based on its index

--- a/src/Miso/Runtime.hs
+++ b/src/Miso/Runtime.hs
@@ -95,6 +95,8 @@ module Miso.Runtime
   , rootComponentId
   , componentId
   , modifyComponent
+  , unmountComponent
+  , freeLifecycleHooks
   , componentModel
   -- ** Scheduler
   , scheduler
@@ -1189,6 +1191,10 @@ unloadScripts ComponentState {..} = do
 freeLifecycleHooks :: ComponentState context props model action -> IO ()
 freeLifecycleHooks ComponentState {..} = do
   VTree (Object vtree) <- readIORef _componentVTree
+  -- The root Component's VTree never gets a "parent" link (only buildComp
+  -- sets one, for a mounted child's content root) -- mirrors the "at root,
+  -- do nothing" guard in ts/miso/util.ts's updateRef. FromJSVal Object
+  -- returns Nothing for undefined/null, so this naturally skips the root.
   maybeComp <- fromJSVal =<< vtree ! ("parent" :: MisoString)
   forM_ maybeComp $ \(Object comp) -> do
     mapM_ freeFunction =<< fromJSVal =<< comp ! ("mount" :: MisoString)

--- a/src/Miso/Runtime.hs
+++ b/src/Miso/Runtime.hs
@@ -1188,9 +1188,11 @@ unloadScripts ComponentState {..} = do
 -- | Helper to drop all lifecycle and mounting hooks if defined.
 freeLifecycleHooks :: ComponentState context props model action -> IO ()
 freeLifecycleHooks ComponentState {..} = do
-  VTree (Object comp) <- readIORef _componentVTree
-  mapM_ freeFunction =<< fromJSVal =<< comp ! ("mount" :: MisoString)
-  mapM_ freeFunction =<< fromJSVal =<< comp ! ("unmount" :: MisoString)
+  VTree (Object vtree) <- readIORef _componentVTree
+  maybeComp <- fromJSVal =<< vtree ! ("parent" :: MisoString)
+  forM_ maybeComp $ \(Object comp) -> do
+    mapM_ freeFunction =<< fromJSVal =<< comp ! ("mount" :: MisoString)
+    mapM_ freeFunction =<< fromJSVal =<< comp ! ("unmount" :: MisoString)
 -----------------------------------------------------------------------------
 -- | Helper function for cleanly destroying a t'Miso.Types.Component'
 unmountComponent

--- a/src/Miso/Runtime/Internal.hs
+++ b/src/Miso/Runtime/Internal.hs
@@ -31,6 +31,10 @@
 --   other per-component runtime fields.
 -- * 'schedulerThread' — 'Data.IORef.IORef' holding the 'Control.Concurrent.ThreadId'
 --   of the event-loop scheduler thread.
+-- * 'unmountComponent' / 'freeLifecycleHooks' — teardown functions normally
+--   only invoked internally, exposed here so tests can exercise unmounting a
+--   specific t'ComponentState' directly instead of going through a full
+--   diff-driven removal.
 --
 -- = See also
 --
@@ -43,9 +47,11 @@ module Miso.Runtime.Internal
   , ComponentState(..)
   , ComponentIds
   , schedulerThread
+  , unmountComponent
+  , freeLifecycleHooks
   , module FFI
   ) where
 ----------------------------------------------------------------------------
-import Miso.Runtime (components, ComponentState(..), ComponentIds, componentIds, rootComponentId, schedulerThread)
+import Miso.Runtime (components, ComponentState(..), ComponentIds, componentIds, rootComponentId, schedulerThread, unmountComponent, freeLifecycleHooks)
 import Miso.FFI.Internal as FFI
 ----------------------------------------------------------------------------

--- a/tests/app/Main.hs
+++ b/tests/app/Main.hs
@@ -55,7 +55,7 @@ import           Miso.Html
 import           Miso.JSON.Parser (decodePure)
 import           Miso.Html.Property
 import           Miso.Cookie (Cookie (..), cookieValue, defaultCookie, cookieSet_, cookieGet_, cookieDelete_, cookieDeleteWith_, cookieGetAll_)
-import           Miso.Runtime.Internal (ComponentState (..), components, componentIds)
+import           Miso.Runtime.Internal (ComponentState (..), components, componentIds, unmountComponent)
 -----------------------------------------------------------------------------
 -- | Clears the component state and DOM between each test
 clearComponentState :: IO ()
@@ -1695,6 +1695,44 @@ main = withJS $ do
           ((component (0 :: Int) noop $ \_ _ _ ->
             div_ [] (replicate 999 (mount_ testComponent))) :: Component () () Int ())
         mountedComponents >>= (`shouldBe` 1000)
+
+      it "Should free mount/unmount lifecycle hooks on unmount, not silently skip them" $ do
+        -- Regression for fc321053: freeLifecycleHooks used to read "mount"/
+        -- "unmount" off a Component's own rendered content root, which never
+        -- carries those fields -- only the VComp wrapper node built by
+        -- buildComp does, reachable one hop up via the content root's
+        -- "parent" link. The lookup silently found nothing (fromJSVal on
+        -- undefined), so freeFunction was never called and every non-root
+        -- Component unmount leaked the mount/unmount closures.
+        liftIO $ startApp mempty $
+          ((component (0 :: Int) noop $ \_ _ _ ->
+            div_ [] [ mount_ testComponent ]) :: Component () () Int ())
+        mountedComponents >>= (`shouldBe` 2)
+        childState@ComponentState {..} <-
+          liftIO $ ((IM.! 2) <$> readIORef components :: IO (ComponentState () () Int ()))
+        VTree (Object contentRoot) <- liftIO (readIORef _componentVTree)
+        -- The content root itself has no "mount"/"unmount" fields ...
+        (`shouldBe` True) =<< liftIO (isUndefined =<< contentRoot ! "mount")
+        -- ... only the wrapper reachable via "parent" does, and it's real
+        -- callbacks that freeLifecycleHooks must find and free.
+        wrapper <- liftIO (fromJSValUnchecked =<< contentRoot ! "parent")
+        (`shouldBe` False) =<< liftIO (isUndefined =<< (wrapper :: Object) ! "mount")
+        (`shouldBe` False) =<< liftIO (isUndefined =<< wrapper ! "unmount")
+        -- Unmounting must reach freeLifecycleHooks via the correct object and
+        -- run to completion (no silent skip, no crash), removing the child.
+        liftIO (unmountComponent childState)
+        mountedComponents >>= (`shouldBe` 1)
+
+      it "Should free lifecycle hooks on the root component without crashing" $ do
+        -- The root Component's VTree never gets a "parent" link (only
+        -- buildComp sets one, for a mounted child's content root), so
+        -- freeLifecycleHooks must not blindly dereference "mount"/"unmount"
+        -- off whatever "parent" resolves to -- doing so throws on undefined.
+        liftIO (startApp mempty testComponent)
+        mountedComponents >>= (`shouldBe` 1)
+        rootState <- liftIO $ ((IM.! 1) <$> readIORef components :: IO (ComponentState () () Int Action))
+        liftIO (unmountComponent rootState)
+        mountedComponents >>= (`shouldBe` 0)
 
       it "On after OnStatic on the same node must not inherit a stale staticKey" $ do
         -- Regression for: an 'OnStatic' handler stashes 'pendingStaticKey' /


### PR DESCRIPTION
## Summary
- `freeLifecycleHooks` read the `mount`/`unmount` fields off a component's own rendered content root (`_componentVTree`), but those fields live on the `VComp` wrapper node one hop up (`_componentVTree`'s `parent`, set in `buildComp`'s `mountCallback` and kept live across every re-render by `FFI.updateRef`/`ts/miso/util.ts`).
- Because of this, `fromJSVal` on `"mount"`/`"unmount"` always returned `Nothing`, so `freeFunction` was never called — every non-root `Component` unmount (normal teardown, and every GHCi hot-reload cycle) leaked the `mountCallback`/`unmountCallback` closures, which capture the entire `initialize` closure (`app`, `events`, `sink`, `model`). Root components are unaffected either way (no `VComp` wrapper, so nothing to free).
- Fix walks up to the wrapper via the content root's `"parent"` property (same field `ts/miso/event.ts` already walks for event bubbling) before reading `mount`/`unmount`.
- Added a `CHANGELOG.md` entry under `1.13.0.0` / Fixed, matching the existing style for this release.

## Test plan
- [x] `nix develop -c cabal build -f native miso` — all 137 modules compile clean, including `Miso.Runtime`.