### PR TITLE
fix: `eventJSON` crashes when a decoder path resolves to `null`/`undefined`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -321,6 +321,14 @@ All notable changes to `miso` are documented here.
   `-26`. The sign is now stripped first, then the remainder is checked for
   a hex prefix.
 
+- **`eventJSON` decodes a null/undefined path as `null` instead of
+  crashing.** A decoder path landing on `null`/`undefined` — `relatedTarget`,
+  `currentTarget`, `form`, `list`, etc. are all legitimately null/undefined
+  on many real DOM events — hit `'length' in obj` on the nullish value and
+  threw `TypeError`, crashing event dispatch instead of decoding the field
+  as `null`. An intermediate nullish step one segment earlier had the same
+  problem; both are now handled.
+
 ### Performance
 
 - **Short-lived `JSVal` handles are freed eagerly in the WASM runtime.**

--- a/ts/miso/event.ts
+++ b/ts/miso/event.ts
@@ -224,7 +224,12 @@ export function eventJSON(at: string | Array<string>, obj: any): Object[] {
     }
     return ret;
   }
-  for (const a of at) obj = obj[a];
+  // A step landing on null/undefined (e.g. relatedTarget, currentTarget,
+  // form, list -- all legitimately null on many real events) must not throw
+  // on the next property read; once obj goes nullish, stay nullish through
+  // the rest of the walk instead of crashing dispatch.
+  for (const a of at) obj = obj == null ? undefined : obj[a];
+  if (obj === null || obj === undefined) return null;
   /* If obj is a list-like object */
   var newObj;
   if (obj instanceof Array || ('length' in obj && obj['localName'] !== 'select')) {

--- a/ts/spec/eventJSON.spec.ts
+++ b/ts/spec/eventJSON.spec.ts
@@ -64,4 +64,33 @@ describe('eventJSON', () => {
     expect(res[0]).toEqual([{ k: 1 }, { k: 2 }]);
     expect(res[1]).toEqual({ p: true });
   });
+
+  // Regression: a path landing on null/undefined (relatedTarget, currentTarget,
+  // form, list, etc. are all legitimately null/undefined on real DOM events)
+  // used to throw `'length' in obj` on the final null/undefined value instead
+  // of decoding it as null.
+  test('decodes a path whose final value is null as null, without throwing', () => {
+    const obj = { target: { relatedTarget: null } };
+    expect(eventJSON(['target', 'relatedTarget'], obj)).toBeNull();
+  });
+
+  test('decodes a path whose final value is undefined as null, without throwing', () => {
+    const obj = { target: {} } as any;
+    expect(eventJSON(['target', 'missing'], obj)).toBeNull();
+  });
+
+  // A path can also go nullish *before* the last step (e.g. `at.form` is null
+  // on an input not inside a <form>, and the decoder still asks for a field
+  // past it) -- the walk must not dereference a property off that null.
+  test('does not throw when an intermediate path segment is null', () => {
+    const obj = { target: { form: null } };
+    expect(() => eventJSON(['target', 'form', 'id'], obj)).not.toThrow();
+    expect(eventJSON(['target', 'form', 'id'], obj)).toBeNull();
+  });
+
+  test('still decodes a present path normally after the null-safety change', () => {
+    const obj = { target: { form: { id: 'my-form' } } };
+    const res: any = eventJSON(['target', 'form'], obj);
+    expect(res).toEqual({ id: 'my-form' });
+  });
 });


### PR DESCRIPTION
A path landing on null/undefined (relatedTarget, currentTarget, form, list, etc. are all legitimately null/undefined on many real DOM events) hit `'length' in obj` on a null/undefined obj and threw TypeError, crashing event dispatch instead of decoding the field as null. An intermediate nullish step had the same problem one iteration earlier. Both now short-circuit to null.