### PR TITLE
fix: native <list> virtualization state leaked on nested removal

### DIFF
--- a/ts/miso/native/mts.ts
+++ b/ts/miso/native/mts.ts
@@ -25,6 +25,7 @@ import type { ElementRef } from "@lynx-js/type-element-api";
 import
   { drawingContext
   , destroyNodeEvents
+  , destroyListState
   } from './mts/context';
 
 export function mts () {
@@ -145,7 +146,7 @@ function processMessage (m : PATCH, runtime) {
    native handle (no `.children`/`.nodeId` JS properties), so read the id from
    Config and walk children via the element PAPI. `node` is captured before
    detachment, so its subtree is still intact here. */
-function dropChildren (nodeMap: Record<number, ElementRef>, node: ElementRef) {
+export function dropChildren (nodeMap: Record<number, ElementRef>, node: ElementRef) {
    const nodeId = __GetConfig(node)?.nodeId as number | undefined;
    if (nodeId !== undefined) {
       delete nodeMap[nodeId];
@@ -153,6 +154,11 @@ function dropChildren (nodeMap: Record<number, ElementRef>, node: ElementRef) {
       // direct-bind listeners), else each destroyed node leaks its entries.
       destroyNodeEvents(node, nodeId);
    }
+   // Keyed by __GetElementUniqueID rather than nodeId, so this runs
+   // unconditionally (not gated on nodeId being set) -- a removed <list>,
+   // wherever it sits in this subtree, must not keep its virtualization
+   // state (and every ElementRef it holds) alive forever.
+   destroyListState(node);
    for (let child = __FirstElement(node) as ElementRef; child; child = __NextElement(child) as ElementRef) {
       dropChildren(nodeMap, child);
    }

--- a/ts/miso/native/mts/context.ts
+++ b/ts/miso/native/mts/context.ts
@@ -36,7 +36,9 @@ function nextNodeId () : number {
 // hold each list's item elements and serve them back by index — one element per
 // cell, with no reuse pool (that's the "full recycler" upgrade path).
 type ListState = { node: ElementRef; items: Array<ElementRef>; known: number };
-const listStates = new Map<number, ListState>();
+// Exported (read/write) for test introspection only -- production code should
+// go through listStateOf/destroyListState, not touch this Map directly.
+export const listStates = new Map<number, ListState>();
 
 // Main-thread event routing registry, keyed by the element's `nodeId`.
 // NOT stored in element config directly: Lynx __SetConfig/__GetConfig round-trips
@@ -73,6 +75,17 @@ export function destroyNodeEvents(node : ElementRef, nodeId : number) : void {
     directBindings.delete(nodeId);
   }
   mainThreadKeys.delete(nodeId);
+}
+
+// Drop a node's <list> virtualization state, if it has any. Keyed by
+// __GetElementUniqueID (not nodeId, unlike destroyNodeEvents -- see
+// listStateOf) so this must be called independently, not folded into
+// destroyNodeEvents. Called from `dropChildren` (ts/miso/native/mts.ts) for
+// every node in a removed subtree -- without this, a <list> removed via an
+// ancestor wrapper (rather than directly) keeps its {node, items, known}
+// entry, and every ElementRef in it, in this Map forever.
+export function destroyListState(node : ElementRef) : void {
+  listStates.delete(__GetElementUniqueID(node));
 }
 
 function nodeIdOf(node : ElementRef) : number | undefined {

--- a/ts/spec/native-mts.spec.ts
+++ b/ts/spec/native-mts.spec.ts
@@ -4,8 +4,9 @@
    and per-node event-registry teardown. The Lynx PAPI globals (`__GetConfig`,
    `__AddEvent`) and the `runtime`/`lynx` host objects are stubbed here — in a web
    build they don't exist, which is exactly why this code has no other coverage. */
-import { test, expect, describe, beforeEach, afterAll, beforeAll } from 'bun:test';
-import { routeEvent, destroyNodeEvents, drawingContext } from '../miso/native/mts/context';
+import { test, expect, describe, beforeEach, afterEach, afterAll, beforeAll } from 'bun:test';
+import { routeEvent, destroyNodeEvents, drawingContext, listStates, destroyListState } from '../miso/native/mts/context';
+import { dropChildren } from '../miso/native/mts';
 import { vnode, vfrag, vcomp, vtext } from '../miso/smart';
 import type { EventContext, NodeId } from '../miso/types';
 
@@ -240,5 +241,65 @@ describe('drawingContext.removeAttribute — MTS', () => {
     expect(setAttributeCalls[0][2]).toBeNull();
 
     delete (globalThis as any).__SetAttribute;
+  });
+});
+
+// Regression: dropChildren (ts/miso/native/mts.ts) recursively tears down a
+// removed subtree's event state via destroyNodeEvents, but previously never
+// touched listStates (ts/miso/native/mts/context.ts) -- so a <list> removed
+// via an ancestor wrapper (rather than directly) kept its {node, items,
+// known} entry, and every ElementRef in it, in that Map forever.
+describe('destroyListState / dropChildren — <list> virtualization teardown', () => {
+
+  afterEach(() => {
+    for (const g of ['__GetElementUniqueID', '__FirstElement', '__NextElement'])
+      delete (globalThis as any)[g];
+  });
+
+  test('destroyListState clears a node\'s own list state', () => {
+    const node: El = { nodeId: 72 };
+    (globalThis as any).__GetElementUniqueID = (n: El) => n.nodeId;
+
+    listStates.set(72, { node: node as any, items: [{} as any], known: 1 });
+    expect(listStates.has(72)).toBeTrue();
+
+    destroyListState(node as any);
+    expect(listStates.has(72)).toBeFalse();
+  });
+
+  test('destroyListState on a node with no list state is a harmless no-op', () => {
+    const node: El = { nodeId: 73 };
+    (globalThis as any).__GetElementUniqueID = (n: El) => n.nodeId;
+    expect(() => destroyListState(node as any)).not.toThrow();
+  });
+
+  test('dropChildren clears the listStates entry of a <list> nested under a removed wrapper', () => {
+    // tree: wrapper(70) -> list(71), removed as a unit via the wrapper --
+    // the list itself is never the direct argument to removeChild/replaceChild.
+    const wrapper: El = { nodeId: 70 };
+    const list: El = { nodeId: 71 };
+
+    (globalThis as any).__GetElementUniqueID = (n: El) => n.nodeId;
+    const childrenOf = new Map<number, El[]>([[70, [list]], [71, []]]);
+    (globalThis as any).__FirstElement = (n: El) => childrenOf.get(n.nodeId)?.[0] ?? null;
+    (globalThis as any).__NextElement = (n: El) => {
+      for (const kids of childrenOf.values()) {
+        const i = kids.indexOf(n);
+        if (i >= 0 && i + 1 < kids.length) return kids[i + 1];
+      }
+      return null;
+    };
+
+    listStates.set(71, { node: list as any, items: [{} as any, {} as any], known: 2 });
+    expect(listStates.has(71)).toBeTrue();
+
+    const nodeMap: Record<number, El> = { 70: wrapper, 71: list };
+    dropChildren(nodeMap as any, wrapper as any);
+
+    // the list's virtualization state (and every ElementRef it held) is gone,
+    // not just its runtime.nodes entry
+    expect(listStates.has(71)).toBeFalse();
+    expect(nodeMap[70]).toBeUndefined();
+    expect(nodeMap[71]).toBeUndefined();
   });
 });


### PR DESCRIPTION
listStates (ts/miso/native/mts/context.ts) is keyed by __GetElementUniqueID, separately from the nodeId-keyed event registries that dropChildren (ts/miso/native/mts.ts) already tore down per node in a removed subtree. A <list> removed via an ancestor wrapper -- not as the direct argument to removeChild/replaceChild -- never had its entry cleared, leaking its {node, items, known} state and every ElementRef in it for the rest of the session.

destroyListState clears a node's list state and is now called alongside destroyNodeEvents for every node dropChildren visits, covering both direct and nested removal.