### PR TITLE
fix: `Prism` `preview`/`preuse` infinite loop, `_Nothing` match

### DIFF
--- a/src/Miso/Lens.hs
+++ b/src/Miso/Lens.hs
@@ -795,11 +795,11 @@ review = _up
 ----------------------------------------------------------------------------
 -- | Try to extract a value from a sum type using a t'Prism' inside 'MonadReader'.
 preview :: MonadReader r m => Prism r a -> m (Maybe a)
-preview = asks . preview
+preview = asks . _down
 ----------------------------------------------------------------------------
 -- | Try to extract a value from a sum type using a t'Prism' inside 'MonadState'.
 preuse :: MonadState s m => Prism s a -> m (Maybe a)
-preuse = gets . preview
+preuse = gets . _down
 ----------------------------------------------------------------------------
 -- | t'Prism' for the 'Left' constructor of 'Either'.
 _Left :: Prism (Either a b) a
@@ -814,8 +814,10 @@ _Just :: Prism (Maybe a) a
 _Just = prism Just Prelude.id
 ----------------------------------------------------------------------------
 -- | t'Prism' that matches a 'Nothing' value.
-_Nothing :: Prism (Maybe a) a
-_Nothing = prism (const Nothing) Prelude.id
+_Nothing :: Prism (Maybe a) ()
+_Nothing = prism (const Nothing) $ \case
+  Nothing -> Just ()
+  Just _  -> Nothing
 ----------------------------------------------------------------------------
 -- | Infix alias for 'preview'. Try to extract a value using a t'Prism'.
 --

--- a/tests/app/Main.hs
+++ b/tests/app/Main.hs
@@ -1071,6 +1071,26 @@ main = withJS $ do
           ([0..10::Int] & Miso.Lens.at (-100) .~ Just 5) `shouldBe` [0..10]
           ([0..10::Int] & Miso.Lens.at 100 .~ Nothing) `shouldBe` [0..10]
           ([0..10::Int] & Miso.Lens.at (-100) .~ Nothing) `shouldBe` [0..10]
+      it "Should review" $ do
+        (review _Left 5 :: Either Int String) `shouldBe` Left 5
+        (review _Right "x" :: Either Int String) `shouldBe` Right "x"
+        (review _Just 5 :: Maybe Int) `shouldBe` Just 5
+      it "Should ^?" $ do
+        ((Left 5 :: Either Int String) ^? _Left) `shouldBe` Just 5
+        ((Right "x" :: Either Int String) ^? _Left) `shouldBe` Nothing
+        ((Right "x" :: Either Int String) ^? _Right) `shouldBe` Just "x"
+        ((Left 5 :: Either Int String) ^? _Right) `shouldBe` Nothing
+        ((Just 5 :: Maybe Int) ^? _Just) `shouldBe` Just 5
+        ((Nothing :: Maybe Int) ^? _Nothing) `shouldBe` Just ()
+        ((Just 5 :: Maybe Int) ^? _Nothing) `shouldBe` Nothing
+      it "Should preview" $ do
+        (runReader (preview _Left) (Left 5 :: Either Int String)) `shouldBe` Just 5
+        (runReader (preview _Left) (Right "x" :: Either Int String)) `shouldBe` Nothing
+        (runReader (preview _Right) (Right "x" :: Either Int String)) `shouldBe` Just "x"
+      it "Should preuse" $ do
+        (evalState (preuse _Left) (Left 5 :: Either Int String)) `shouldBe` Just 5
+        (evalState (preuse _Left) (Right "x" :: Either Int String)) `shouldBe` Nothing
+        (evalState (preuse _Right) (Right "x" :: Either Int String)) `shouldBe` Just "x"
     describe "Inline JS tests" $ do
      it "Should use inline js" $ do
        (`shouldBe` 42) =<< liftIO (getAge (Person "larry" 42))


### PR DESCRIPTION
`preview`/`preuse` in `Miso.Lens` were self-referential (`asks` . `preview` / `gets` . `preview`) instead of calling the Prism's `_down` field, causing a `<<loop>>` the moment either was invoked; `(^?)` inherited the same bug.

`_Nothing`'s match function was copy-pasted from _Just (id), so it behaved identically to `_Just` instead of matching the `Nothing` case. Retyped to `Prism (Maybe a) ()` to match conventional prism-library semantics.

Added tests alongside the existing `Miso.Lens` tests covering review, `(^?)`, `preview`, `preuse`, and `_Nothing`.