### PR TITLE
feat: `VProps`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,9 @@ All notable changes to `miso` are documented here.
   component's current `props` whenever the enclosing `View` is built or
   rendered (`toHtml` on a bare `View` uses `()`). `withProps` is a synonym
   for `vprops`.
-- **`toHtmlWith` / `contentWith_`.** `toHtmlWith :: props -> View context
-  props model action -> ByteString` renders a `View` whose `props` type is
-  not `()`, supplying the value a `VProps` node resolves against. The Lynx
-  SVG `contentWith_` is the same for the `content` attribute; `content_` is
-  `contentWith_ ()`.
+- **`toHtmlWith`.** `toHtmlWith :: props -> View context props model action
+  -> ByteString` renders a `View` whose `props` type is not `()`, supplying
+  the value a `VProps` node resolves against.
 - **`VContext` / `vcontext` / `withContext`.** A `View` constructor that
   embeds a subtree built from a `context -> View context props model action`
   function, so a helper deep in a view tree can read the app-global
@@ -45,7 +43,8 @@ All notable changes to `miso` are documented here.
   that leaves it polymorphic needs no other change. `ToHtml (View …)` now
   requires `props ~ ()` (use `toHtmlWith` otherwise). `content_` in
   `Miso.Native.X.Element.Svg.Property` now takes a
-  `View context () model action` (use `contentWith_` otherwise).
+  `View context () model action`; lift `withProps` above the element to
+  draw from the component's `props`.
 
 ## 1.13.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,29 @@ All notable changes to `miso` are documented here.
 
 ### Added
 
+- **`VProps` / `vprops` / `withProps`.** The `props` counterpart of
+  `VContext`: a `View` constructor that embeds a subtree built from a
+  `props -> View context props model action` function, so a helper deep in a
+  view tree can read the enclosing component's `props` without needing it
+  threaded through as an explicit argument. Resolved against the mounting
+  component's current `props` whenever the enclosing `View` is built or
+  rendered (`toHtml` on a bare `View` uses `()`). `withProps` is a synonym
+  for `vprops`.
+
+### Changed
+
+- **Breaking: `View` gained a `props` type parameter.** `View context model
+  action` is now `View context props model action`, matching the order of
+  `Component context props model action`. Unlike `context`, `props` are
+  per-component, so `VProps` is resolved through the type system the same
+  way `model` is, rather than through a global cell. Mount combinators
+  (`mount_`, `mountWithProps`, `(+>)`, `vcomp`, …) forget the child's
+  `props` at the boundary exactly as they forget its `model` and `action`.
+  Update signatures by inserting a `props` variable after `context`; code
+  that leaves it polymorphic needs no other change. `ToHtml (View …)` now
+  requires `props ~ ()`. `content_` in `Miso.Native.X.Element.Svg.Property`
+  now takes a `View context () model action`.
+
 - **`VContext` / `vcontext` / `withContext`.** A `View` constructor that
   embeds a subtree built from a `context -> View context model action`
   function, so a helper deep in a view tree can read the app-global

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,13 @@ All notable changes to `miso` are documented here.
 
 ### Changed
 
+- **`vcontext` / `vprops` children are resolved before being built.** The
+  runtime now looks through these wrappers before deciding what to do with
+  a child, so one that resolves to an empty fragment is skipped like an
+  inline `fragment []`, and one that resolves to a plain node has its JS
+  handle freed after linking like any other node. `toHtml` likewise
+  resolves them before collapsing adjacent text nodes, matching the
+  client's hydration-time tree.
 - **`VCompStatic` now carries a `StaticMount context`.** The
   `StaticPtr (SomeStaticComponent props context)` / `props` pair that
   `VCompStatic` held inline is now the `StaticMount` existential, mirroring

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,11 +34,6 @@ All notable changes to `miso` are documented here.
   handle freed after linking like any other node. `toHtml` likewise
   resolves them before collapsing adjacent text nodes, matching the
   client's hydration-time tree.
-- **`VCompStatic` now carries a `StaticMount context`.** The
-  `StaticPtr (SomeStaticComponent props context)` / `props` pair that
-  `VCompStatic` held inline is now the `StaticMount` existential, mirroring
-  `VComp (SomeComponent context)`. `vcomp` / `vcomp_` are unchanged; only
-  code pattern-matching on `VCompStatic` directly needs updating.
 - **Breaking: `View` gained a `props` type parameter.** `View context model
   action` is now `View context props model action`, matching the order of
   `Component context props model action`. Unlike `context`, `props` are

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,19 +7,20 @@ All notable changes to `miso` are documented here.
 ### Added
 
 - **`VProps` / `vprops` / `withProps`.** The `props` counterpart of
-  `VContext`: a `View` constructor that embeds a subtree built from a
+  `VContext`: an ambient accessor (not a node) wrapping a
   `props -> View context props model action` function, so a helper deep in a
   view tree can read the enclosing component's `props` without needing it
-  threaded through as an explicit argument. Resolved against the mounting
+  threaded through as an explicit argument. `ImplicitParams` or a `Reader`
+  could serve the same purpose, at the cost of a GHC-specific extension or a
+  monadic style for view code. Resolved against the mounting
   component's current `props` whenever the enclosing `View` is built or
   rendered (`toHtml` on a bare `View` uses `()`). `withProps` is a synonym
   for `vprops`.
 - **`toHtmlWith`.** `toHtmlWith :: props -> View context props model action
   -> ByteString` renders a `View` whose `props` type is not `()`, supplying
   the value a `VProps` node resolves against.
-- **`VContext` / `vcontext` / `withContext`.** A `View` constructor that
-  embeds a subtree built from a `context -> View context props model action`
-  function, so a helper deep in a view tree can read the app-global
+- **`VContext` / `vcontext` / `withContext`.** An ambient accessor (not a
+  node) wrapping a `context -> View context props model action` function, so a helper deep in a view tree can read the app-global
   `context` without needing it threaded through as an explicit argument.
   Resolved against the current `context` whenever the enclosing `View` is
   built or rendered; it does not itself trigger a redraw — that is still

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ All notable changes to `miso` are documented here.
 
 ### Changed
 
+- **`VCompStatic` now carries a `StaticMount context`.** The
+  `StaticPtr (SomeStaticComponent props context)` / `props` pair that
+  `VCompStatic` held inline is now the `StaticMount` existential, mirroring
+  `VComp (SomeComponent context)`. `vcomp` / `vcomp_` are unchanged; only
+  code pattern-matching on `VCompStatic` directly needs updating.
 - **Breaking: `View` gained a `props` type parameter.** `View context model
   action` is now `View context props model action`, matching the order of
   `Component context props model action`. Unlike `context`, `props` are

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,18 @@ All notable changes to `miso` are documented here.
   component's current `props` whenever the enclosing `View` is built or
   rendered (`toHtml` on a bare `View` uses `()`). `withProps` is a synonym
   for `vprops`.
+- **`toHtmlWith` / `contentWith_`.** `toHtmlWith :: props -> View context
+  props model action -> ByteString` renders a `View` whose `props` type is
+  not `()`, supplying the value a `VProps` node resolves against. The Lynx
+  SVG `contentWith_` is the same for the `content` attribute; `content_` is
+  `contentWith_ ()`.
+- **`VContext` / `vcontext` / `withContext`.** A `View` constructor that
+  embeds a subtree built from a `context -> View context props model action`
+  function, so a helper deep in a view tree can read the app-global
+  `context` without needing it threaded through as an explicit argument.
+  Resolved against the current `context` whenever the enclosing `View` is
+  built or rendered; it does not itself trigger a redraw — that is still
+  governed solely by `useContext`. `withContext` is a synonym for `vcontext`.
 
 ### Changed
 
@@ -31,16 +43,9 @@ All notable changes to `miso` are documented here.
   `props` at the boundary exactly as they forget its `model` and `action`.
   Update signatures by inserting a `props` variable after `context`; code
   that leaves it polymorphic needs no other change. `ToHtml (View …)` now
-  requires `props ~ ()`. `content_` in `Miso.Native.X.Element.Svg.Property`
-  now takes a `View context () model action`.
-
-- **`VContext` / `vcontext` / `withContext`.** A `View` constructor that
-  embeds a subtree built from a `context -> View context model action`
-  function, so a helper deep in a view tree can read the app-global
-  `context` without needing it threaded through as an explicit argument.
-  Resolved against the current `context` whenever the enclosing `View` is
-  built or rendered; it does not itself trigger a redraw — that is still
-  governed solely by `useContext`. `withContext` is a synonym for `vcontext`.
+  requires `props ~ ()` (use `toHtmlWith` otherwise). `content_` in
+  `Miso.Native.X.Element.Svg.Property` now takes a
+  `View context () model action` (use `contentWith_` otherwise).
 
 ## 1.13.0.0
 

--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ updateModel = \case
     consoleLog "Hello World"
 ----------------------------------------------------------------------------
 -- | Constructs a virtual DOM from a model
-viewModel :: context -> props -> Int -> View context Action
+viewModel :: context -> props -> Int -> View context props Int Action
 viewModel _context _props x = vfrag
     [ H.button_ [ H.onClick AddOne ] [ text "+" ]
     , text (ms x)

--- a/sample-app-native/Conformance.hs
+++ b/sample-app-native/Conformance.hs
@@ -67,7 +67,7 @@ updateModel = \case
   ReadMTS domRef n ->
     io_ (setStyleProperty domRef "opacity" (opacityForCount n))
 
-viewModel :: () -> () -> Model -> View () Model Action
+viewModel :: () -> () -> Model -> View () () Model Action
 viewModel _ _ Model{..} =
   view_
     [ id_ "probe-root"
@@ -128,7 +128,7 @@ panelStyle =
   , CSS.borderRadius "10px"
   ]
 
-btsIncrementButton :: View context Model Action
+btsIncrementButton :: View context props Model Action
 btsIncrementButton =
   view_
     [ id_ "bts-increment"
@@ -137,7 +137,7 @@ btsIncrementButton =
     ]
     [ label "tap: BTS increment + declarative rerender" ]
 
-dynamicSection :: Bool -> View context Model Action
+dynamicSection :: Bool -> View context props Model Action
 dynamicSection visible =
   view_
     [ id_ "dynamic-section"
@@ -166,7 +166,7 @@ dynamicSection visible =
       [ dynamicChild | visible ]
     ]
 
-dynamicChild :: View context Model Action
+dynamicChild :: View context props Model Action
 dynamicChild =
   view_
     [ id_ "dynamic-child"
@@ -182,7 +182,7 @@ dynamicChild =
     ]
     [ label "dynamic child is mounted" ]
 
-mtsPaintSection :: View context Model Action
+mtsPaintSection :: View context props Model Action
 mtsPaintSection =
   view_
     [ id_ "mts-paint-shell"
@@ -203,7 +203,7 @@ mtsPaintSection =
       [ label "tap: MTS-only background-color" ]
     ]
 
-mtsReadSection :: View context Model Action
+mtsReadSection :: View context props Model Action
 mtsReadSection =
   view_
     [ id_ "mts-read-shell"
@@ -225,7 +225,7 @@ mtsReadSection =
       [ label "tap: MTS reads hydrated BTS count" ]
     ]
 
-label :: MisoString -> View context model action
+label :: MisoString -> View context props model action
 label value =
   text_
     [ CSS.style_
@@ -258,7 +258,7 @@ childUpdate :: ChildAction -> Effect () ChildProps ChildModel ChildAction
 childUpdate IncrementChild =
   modify $ \m -> m { childCount = childCount m + 1 }
 
-childView :: () -> ChildProps -> ChildModel -> View () ChildModel ChildAction
+childView :: () -> ChildProps -> ChildModel -> View () ChildProps ChildModel ChildAction
 childView _ ChildProps{..} ChildModel{..} =
   view_
     [ id_ "child-button"
@@ -281,7 +281,7 @@ childView _ ChildProps{..} ChildModel{..} =
       ]
     ]
 
-childSection :: Int -> View () Model Action
+childSection :: Int -> View () () Model Action
 childSection count =
   view_
     [ id_ "child-slot"

--- a/sample-app-native/Main.hs
+++ b/sample-app-native/Main.hs
@@ -177,7 +177,7 @@ updateModel = \case
 animId :: MisoString
 animId = "#anim-gif"
 -----------------------------------------------------------------------------
-viewModel :: Theme -> () -> Model -> View Theme Model Action
+viewModel :: Theme -> () -> Model -> View Theme () Model Action
 viewModel theme _ Model{..} = view_
   [ CSS.style_
     [ CSS.height "100vh"
@@ -228,7 +228,7 @@ txtLine :: CSS.Style
 txtLine = CSS.lineHeight "1.4"
 -----------------------------------------------------------------------------
 -- | Sticky header showing the latest events.
-logView :: [MisoString] -> View context Model Action
+logView :: [MisoString] -> View context props Model Action
 logView msgs = view_
   [ CSS.style_
     [ CSS.height "120px"
@@ -249,7 +249,7 @@ logView msgs = view_
     unlinesTake = foldr (\a b -> a <> "\n" <> b) "" . take 5
 -----------------------------------------------------------------------------
 -- | Wrap a demo in a labelled bordered card.
-section :: MisoString -> [View context Model Action] -> View context Model Action
+section :: MisoString -> [View context props Model Action] -> View context props Model Action
 section label kids = view_
   [ CSS.style_
     [ CSS.width "100%"
@@ -272,7 +272,7 @@ section label kids = view_
 -- @__AddClass@ against the global cssId 0 stylesheet the runtime scopes the
 -- page to. If @.foo@ applies you get a crimson, padded, rounded card; if the
 -- stylesheet wiring is broken you get plain unstyled text.
-classSection :: View context Model Action
+classSection :: View context props Model Action
 classSection = section "className \8212 .foo rule from styles.css"
   -- className is on the text element itself: Lynx does not cascade `color`
   -- from <view> to child <text>, and there is no inline color to override it,
@@ -286,7 +286,7 @@ classSection = section "className \8212 .foo rule from styles.css"
 -- @tap@ — "Lynx Send Tap Event failed, longpress consumed"), which only shows
 -- up on a physical device (a simulator "tap" is instantaneous and never engages
 -- the longpress path). So don't stack tap + longpress on the same node.
-viewSection :: View context Model Action
+viewSection :: View context props Model Action
 viewSection = section "<view> \8212 gestures (each on its own element)"
   [ gestureBox CSS.steelblue "tap me"
       [ VE.onTap (Log "view: tap")
@@ -316,7 +316,7 @@ viewSection = section "<view> \8212 gestures (each on its own element)"
 -- up (a spring cubic-bezier on @transform@). Liking also flips @burst@ on,
 -- which flings a ring of little hearts outward+up from the centre; the update
 -- schedules 'BurstOff' ~0.65s later so they retract — a one-shot pop.
-heartSection :: Bool -> Bool -> View context Model Action
+heartSection :: Bool -> Bool -> View context props Model Action
 heartSection isLiked isBurst = section "animation \8212 tap the heart (Rednote-style like)"
   [ view_
     [ CSS.style_
@@ -367,7 +367,7 @@ heartSection isLiked isBurst = section "animation \8212 tap the heart (Rednote-s
       [ text "\9829" ]
 -----------------------------------------------------------------------------
 -- | <text> — layout + selection, with selectable text.
-textSection :: View context Model Action
+textSection :: View context props Model Action
 textSection = section "<text> \8212 layout / selection"
   [ text_
     [ TP.textMaxLine_ 3
@@ -380,7 +380,7 @@ textSection = section "<text> \8212 layout / selection"
   ]
 -----------------------------------------------------------------------------
 -- | <image> — load / error, with a resize mode.
-imageSection :: View context Model Action
+imageSection :: View context props Model Action
 imageSection = section "<image> \8212 load / error"
   [ image_ "https://picsum.photos/300/120"
     [ IP.mode_ "aspectFill"
@@ -397,7 +397,7 @@ imageSection = section "<image> \8212 load / error"
 -- dispatches its method to the element selected by 'animId' and logs the result.
 -- 'startAnimation' maps to Lynx's deprecated @startAnimate@; the others are the
 -- current API.
-animationSection :: View context Model Action
+animationSection :: View context props Model Action
 animationSection = section "<image> animation \8212 startAnimate / pause / resume / stop (invokeExec)"
   [ image_ "https://upload.wikimedia.org/wikipedia/commons/2/2c/Rotating_earth_%28large%29.gif"
     [ id_ "anim-gif"
@@ -428,7 +428,7 @@ animationSection = section "<image> animation \8212 startAnimate / pause / resum
       [ text_ [ CSS.style_ [ CSS.color CSS.white, txtLine ] ] [ text lbl ] ]
 -----------------------------------------------------------------------------
 -- | <scroll-view> — nested horizontal scroll with edge + size events.
-nestedScrollSection :: View context Model Action
+nestedScrollSection :: View context props Model Action
 nestedScrollSection = section "<scroll-view> \8212 horizontal, scroll edges"
   [ scrollView_
     [ SP.scrollOrientation_ "horizontal"
@@ -457,7 +457,7 @@ nestedScrollSection = section "<scroll-view> \8212 horizontal, scroll edges"
 -- @scroll-coordinator-slot@ as children (a bare view/scroll-view is rejected
 -- with error 990100). The slot holds the scrollable content; scrolling it folds
 -- the header away, and the coordinator emits `offset` as it folds.
-scrollCoordinatorSection :: View context Model Action
+scrollCoordinatorSection :: View context props Model Action
 scrollCoordinatorSection = section "<scroll-coordinator> \8212 collapsing header + nested scroll"
   [ scrollCoordinator_
     [ ScP.enableScroll_ True
@@ -495,7 +495,7 @@ scrollCoordinatorSection = section "<scroll-coordinator> \8212 collapsing header
   ]
 -----------------------------------------------------------------------------
 -- | <list> — recycler with item-keys, snap, layout-complete.
-listSection :: View context Model Action
+listSection :: View context props Model Action
 listSection = section "<list> \8212 recycler, snap, layout-complete"
   [ list_ (ListOptions Single 1 Vertical)
     [ LE.onScroll (\_ -> Log "list: scroll")
@@ -518,7 +518,7 @@ listSection = section "<list> \8212 recycler, snap, layout-complete"
   ]
 -----------------------------------------------------------------------------
 -- | <input> — the full input event set.
-inputSection :: View context Model Action
+inputSection :: View context props Model Action
 inputSection = section "<input> \8212 input / focus / blur / confirm"
   [ input_
     [ placeholder_ "type here\8230"
@@ -534,7 +534,7 @@ inputSection = section "<input> \8212 input / focus / blur / confirm"
   ]
 -----------------------------------------------------------------------------
 -- | <textarea> — multiline input.
-textareaSection :: View context Model Action
+textareaSection :: View context props Model Action
 textareaSection = section "<textarea> \8212 multiline input / focus / blur"
   [ textarea_
     [ placeholder_ "multiline\8230"
@@ -549,7 +549,7 @@ textareaSection = section "<textarea> \8212 multiline input / focus / blur"
   ]
 -----------------------------------------------------------------------------
 -- | <viewpager> — paged container with change / offset events.
-viewpagerSection :: View context Model Action
+viewpagerSection :: View context props Model Action
 viewpagerSection = section "<viewpager> \8212 paged, change / offset"
   [ viewpager_
     [ VpP.bounces_ True
@@ -577,7 +577,7 @@ viewpagerSection = section "<viewpager> \8212 paged, change / offset"
 -- <scroll-view> (the web preview says otherwise, but native needs it). Pull
 -- down past the top to reveal the header and fire `startrefresh`; the update
 -- then adds rows and calls `finishRefresh` (selected by the element `id`).
-refreshSection :: Int -> View context Model Action
+refreshSection :: Int -> View context props Model Action
 refreshSection rows = section "<refresh> \8212 pull down from the top to load rows"
   [ refresh_
     [ id_ "refresh-demo"
@@ -618,7 +618,7 @@ refreshSection rows = section "<refresh> \8212 pull down from the top to load ro
 -- global, polyfilled for the Lynx runtime in @ts/miso-native.ts@. `toHtml`
 -- doesn't emit @xmlns@, so we add it explicitly to keep the content a
 -- well-formed standalone SVG document.
-svgSection :: View context Model Action
+svgSection :: View context props Model Action
 svgSection = section "<svg> \8212 inline content via Miso.Svg DSL / load"
   [ svg_
     [ SvP.content_ svgArt
@@ -628,7 +628,7 @@ svgSection = section "<svg> \8212 inline content via Miso.Svg DSL / load"
     []
   ]
   where
-    svgArt :: View context Model Action
+    svgArt :: View context props Model Action
     svgArt = Svg.svg_
       [ SvgP.viewBox_ "0 0 100 100"
       , textProp "xmlns" "http://www.w3.org/2000/svg"
@@ -638,7 +638,7 @@ svgSection = section "<svg> \8212 inline content via Miso.Svg DSL / load"
       ]
 -----------------------------------------------------------------------------
 -- | <blur-view> — material blur backdrop.
-blurViewSection :: View context Model Action
+blurViewSection :: View context props Model Action
 blurViewSection = section "<blur-view> \8212 material backdrop (blurs the image behind)"
   [ view_
     [ CSS.style_ [ CSS.width "100%", CSS.height "100px", CSS.position "relative" ] ]
@@ -660,7 +660,7 @@ blurViewSection = section "<blur-view> \8212 material backdrop (blurs the image 
   ]
 -----------------------------------------------------------------------------
 -- | <webview> — embedded web page.
-webviewSection :: View context Model Action
+webviewSection :: View context props Model Action
 webviewSection = section "<webview> \8212 embedded page, load / error"
   [ webview_
     [ WP.src_ "https://haskell-miso.org"
@@ -675,7 +675,7 @@ webviewSection = section "<webview> \8212 embedded page, load / error"
 -- | <overlay> — a full-screen layer above the page, toggled by a button.
 -- (An always-visible overlay would cover the whole gallery, so we gate it on
 -- @visible_@ and let the user open/close it.)
-overlaySection :: Bool -> View context Model Action
+overlaySection :: Bool -> View context props Model Action
 overlaySection open = section "<overlay> \8212 independent layer (tap to open)"
   [ view_
     [ VE.onTap ToggleOverlay
@@ -711,7 +711,7 @@ overlaySection open = section "<overlay> \8212 independent layer (tap to open)"
 -- and fades the scroll-view itself based on scroll offset. Each mutates only
 -- a property the declarative 'CSS.style_' below never sets ("transform" /
 -- "opacity"), per the single-owner discipline in "Miso.Native.MainThread".
-mainThreadSection :: View context Model Action
+mainThreadSection :: View context props Model Action
 mainThreadSection = section "main-thread (MTS) events \8212 gesture + scroll, no BTS round-trip"
   [ view_
     [ event (static (VE.onTapMainWith Pulse))
@@ -798,7 +798,7 @@ badgeComponent = (component (BadgeModel 0) badgeUpdate badgeView) { useContext =
 badgeUpdate :: BadgeAction -> Effect Theme BadgeProps BadgeModel BadgeAction
 badgeUpdate BadgeTap = modify $ \m -> m { badgeTaps = badgeTaps m + 1 }
 -----------------------------------------------------------------------------
-badgeView :: Theme -> BadgeProps -> BadgeModel -> View Theme BadgeModel BadgeAction
+badgeView :: Theme -> BadgeProps -> BadgeModel -> View Theme BadgeProps BadgeModel BadgeAction
 badgeView theme BadgeProps{..} BadgeModel{..} = view_
   [ VE.onTap BadgeTap
   , CSS.style_
@@ -815,7 +815,7 @@ badgeView theme BadgeProps{..} BadgeModel{..} = view_
 -- | Mounts 'badgeComponent' statically with props derived from the parent
 -- model, and a "toggle theme" control above it so context propagation into
 -- the child is visible: tapping it flips the badge's own colors.
-mountedComponentSection :: Theme -> Int -> View Theme Model Action
+mountedComponentSection :: Theme -> Int -> View Theme () Model Action
 mountedComponentSection theme eventCount = section "vcomp \8212 statically-mounted child (props / context / model)"
   [ view_
     [ VE.onTap ToggleTheme

--- a/sample-app/Main.hs
+++ b/sample-app/Main.hs
@@ -64,7 +64,7 @@ updateModel = \case
   SayHelloWorld -> io_ (consoleLog "Hello world")
 ----------------------------------------------------------------------------
 -- | Constructs a virtual DOM from a model
-viewModel :: () -> () -> Model -> View () Model Action
+viewModel :: () -> () -> Model -> View () () Model Action
 viewModel _ _ (Model x) =
   vfrag
   [ H.button_ [ H.onClick AddOne ] [ "+" ]

--- a/src/Miso.hs
+++ b/src/Miso.hs
@@ -217,7 +217,7 @@
 --   = 'VNode' 'Namespace' 'Tag' ['Attribute' model action] ['View' context props model action] 'DirectEvents'
 --   | 'VText' (Maybe t'Key') 'MisoString'
 --   | 'VComp' ('SomeComponent' context)
---   | 'VCompStatic' ('StaticMount' context)
+--   | forall childProps . 'VCompStatic' (StaticPtr ('SomeStaticComponent' childProps context)) childProps
 --   | 'VFrag' (Maybe t'Key') ['View' context props model action]
 --   | 'VContext' (context -> 'View' context props model action)
 --   | 'VProps' (props -> 'View' context props model action)
@@ -229,9 +229,6 @@
 -- data t'SomeComponent' context
 --   = forall model action props . ('Eq' context, 'Eq' model, 'Eq' props)
 --   => t'SomeComponent' (Maybe t'Key') props ('Miso.Types.Component' context props model action)
---
--- data t'StaticMount' context
---   = forall props . t'StaticMount' (StaticPtr (t'SomeStaticComponent' props context)) props
 -- @
 --
 -- The smart constructors:

--- a/src/Miso.hs
+++ b/src/Miso.hs
@@ -576,7 +576,7 @@
 --
 -- data Item = Item { itemId, itemLabel :: 'MisoString' }
 --
--- renderItem :: Item -> 'View' context Action
+-- renderItem :: Item -> 'View' context props model Action
 -- renderItem item = 'Miso.Html.Element.li_' [] [ 'textKey' (itemId item) (itemLabel item) ]
 -- @
 --

--- a/src/Miso.hs
+++ b/src/Miso.hs
@@ -141,7 +141,7 @@
 --          * - The type of the global @context@
 --          |     * - The type of the @props@ inherited from the parent t'Miso.Types.Component'
 --          |     |      * - The type of the current t'Miso.Types.Component' @model@
---          |     |      |           * - The global @context@ threaded into the 'View' (@'View' context model action@)
+--          |     |      |           * - The global @context@ threaded into the 'View' (@'View' context props model action@)
 --          |     |      |           |  * - The type of the action that updates t'Miso.Types.Component' @model@
 --          |     |      |           |  |
 --     v :: () -> () -> 'Int' -> 'View' () 'Int' Action
@@ -213,16 +213,17 @@
 -- of nodes mutually recursive with t'Miso.Types.Component' via the 'Miso.Lens.view' function.
 --
 -- @
--- data 'View' context model action
---   = 'VNode' 'Namespace' 'Tag' ['Attribute' model action] ['View' context model action] 'DirectEvents'
+-- data 'View' context props model action
+--   = 'VNode' 'Namespace' 'Tag' ['Attribute' model action] ['View' context props model action] 'DirectEvents'
 --   | 'VText' (Maybe t'Key') 'MisoString'
 --   | 'VComp' ('SomeComponent' context)
---   | forall props . 'VCompStatic' (StaticPtr ('SomeStaticComponent' props context)) props
---   | 'VFrag' (Maybe t'Key') ['View' context model action]
---   | 'VContext' (context -> 'View' context model action)
+--   | forall childProps . 'VCompStatic' (StaticPtr ('SomeStaticComponent' childProps context)) childProps
+--   | 'VFrag' (Maybe t'Key') ['View' context props model action]
+--   | 'VContext' (context -> 'View' context props model action)
+--   | 'VProps' (props -> 'View' context props model action)
 -- @
 --
--- 'VNode' and 'VText' have a one-to-one mapping from the virtual DOM to the physical DOM. The 'VComp', 'VFrag' and 'VContext' constructors are abstract (live only on the virtual DOM) and do not contain a reference to the physical DOM. The existential t'SomeComponent' is what allows embedding polymorphic t'Miso.Types.Component' within a 'View'.
+-- 'VNode' and 'VText' have a one-to-one mapping from the virtual DOM to the physical DOM. The 'VComp', 'VFrag', 'VContext' and 'VProps' constructors are abstract (live only on the virtual DOM) and do not contain a reference to the physical DOM. The existential t'SomeComponent' is what allows embedding polymorphic t'Miso.Types.Component' within a 'View'.
 --
 -- @
 -- data t'SomeComponent' context
@@ -239,6 +240,7 @@
 -- * ('+>') — key and mount a child t'Miso.Types.Component'
 -- * 'vcomp', 'vcomp_' — build a 'VCompStatic' (see below)
 -- * 'vcontext' \/ 'withContext' — build a 'VContext'
+-- * 'vprops' \/ 'withProps' — build a 'VProps'
 --
 -- A full list of element smart constructors built on 'node' (e.g. 'Miso.Html.Element.Miso.Html.Element.div_') can be found in "Miso.Html.Element".
 --
@@ -255,7 +257,7 @@
 -- * __@context@__ — global; the same value is visible to the whole tree.
 --
 -- This is why @context@ is a type parameter on both t'Miso.Types.Component' and 'View'
--- (@'Miso.Types.Component' context props model action@, @'View' context model action@): the
+-- (@'Miso.Types.Component' context props model action@, @'View' context props model action@): the
 -- parameter is threaded through the entire view tree so that every nested
 -- t'Miso.Types.Component' — reachable via t'SomeComponent' — is statically guaranteed to
 -- agree on __one__ @context@ type. There is exactly one live @context@ value per
@@ -280,7 +282,7 @@
 -- nested — can read it synchronously during render:
 --
 -- @
--- view :: context -> props -> model -> 'View' context model action
+-- view :: context -> props -> model -> 'View' context props model action
 -- view ctx _props _model = ...
 -- @
 --
@@ -326,7 +328,7 @@
 --
 -- = 'VContext' (Context nodes)
 --
--- 'VContext' embeds a subtree built from a @context -> 'View' context model
+-- 'VContext' embeds a subtree built from a @context -> 'View' context props model
 -- action@ function, so a helper deep in a view tree can read the app-global
 -- @context@ without needing it threaded through as an explicit argument —
 -- unlike 'Miso.Types.view' itself, which already receives @context@ as its
@@ -344,6 +346,35 @@
 -- The smart constructors for 'VContext' are 'vcontext' and 'withContext'
 -- (a synonym).
 --
+-- = 'VProps' (Props nodes)
+--
+-- 'VProps' is the @props@ counterpart of 'VContext': it embeds a subtree
+-- built from a @props -> 'View' context props model action@ function, so a
+-- helper deep in a view tree can read the enclosing t'Miso.Types.Component'\'s
+-- @props@ without needing it threaded through as an explicit argument —
+-- unlike 'Miso.Types.view' itself, which already receives @props@ as its
+-- second parameter.
+--
+-- @
+-- 'vprops' $ \\Props { title } -> 'Miso.Html.Element.h1_' [] [ 'Miso.Types.text' title ]
+-- @
+--
+-- Unlike @context@, which is one global value, @props@ are per-component.
+-- That is why @props@ is a type parameter of 'View' (just like @model@): the
+-- @props@ a 'VProps' sees is statically the @props@ of the
+-- t'Miso.Types.Component' whose 'Miso.Types.view' contains it, and a mismatch
+-- is a compile-time error. A child mounted with 'mountWithProps' \/ 'vcomp'
+-- sees /its own/ @props@, never its parent's — the mount boundary forgets
+-- the child's @props@ type just as it forgets its @model@ and @action@.
+--
+-- The function is applied to the current @props@ whenever the enclosing
+-- 'View' is built or rendered. It adds no redraw logic of its own: a
+-- component is redrawn when its parent passes it different @props@ (the
+-- props phase), and the node is re-resolved as part of that redraw.
+--
+-- The smart constructors for 'VProps' are 'vprops' and 'withProps'
+-- (a synonym).
+--
 -- = 'VComp' (Component nodes)
 --
 -- == Composition
@@ -358,14 +389,14 @@
 --   :: ('Eq' context, 'Eq' model)
 --   => 'MisoString'
 --   -> t'Miso.Types.Component' context () model action
---   -> 'View' context model action
+--   -> 'View' context props model action
 -- key '+>' comp = 'VComp' ('SomeComponent' (Just ('toKey' key)) () comp)
 -- @
 --
 -- Practically, using this combinator looks like:
 --
 -- @
--- viewModel :: context -> props -> Int -> 'View' context model action
+-- viewModel :: context -> props -> Int -> 'View' context props model action
 -- viewModel _ _ _ = 'Miso.Html.Element.div_' [ 'Miso.Html.Property.id_' "container" ] [ "counter" '+>' counter ]
 -- @
 --
@@ -468,7 +499,7 @@
 --   Highlight domRef -> 'io_' $ do
 --     ['Miso.FFI.QQ.js'| hljs.highlight(${domRef}) |]
 --
--- view :: context -> props -> model -> 'View' context model Action
+-- view :: context -> props -> model -> 'View' context props model Action
 -- view _ _ x =
 --   'Miso.Html.Element.code_'
 --   [ 'onCreatedWith' Highlight
@@ -827,7 +858,7 @@
 -- its first argument and the @props@ as its second:
 --
 -- @
--- view :: context -> props -> model -> 'View' context model action
+-- view :: context -> props -> model -> 'View' context props model action
 -- @
 --
 -- Top-level applications have no parent, so @props@ is always @()@:
@@ -883,7 +914,7 @@
 --   => 'MisoString'
 --   -> props
 --   -> t'Miso.Types.Component' context props childModel childAction
---   -> 'View' context model action
+--   -> 'View' context props model action
 -- @
 --
 -- === Example: child reading parent-supplied props
@@ -1223,8 +1254,8 @@
 -- import Servant.Miso.Html (HTML)
 --
 -- type Home    = \"home\"    :\> Get '[HTML] ('Miso.Types.Component' context props model action)
--- type About   = \"about\"   :\> Get '[HTML] ('View' context model action)
--- type Contact = \"contact\" :\> Get '[HTML] ['View' context model action]
+-- type About   = \"about\"   :\> Get '[HTML] ('View' context props model action)
+-- type Contact = \"contact\" :\> Get '[HTML] ['View' context props model action]
 -- type API = Home :\<|\> About :\<|\> Contact
 -- @
 --
@@ -1756,6 +1787,8 @@ module Miso
   , fragment_
   , vcontext
   , withContext
+  , vprops
+  , withProps
     -- ** Sink
   , withSink
   , Sink

--- a/src/Miso.hs
+++ b/src/Miso.hs
@@ -913,12 +913,15 @@
 --
 -- @
 -- 'mountWithProps_'
---   :: ('Eq' context, 'Eq' childModel, 'Eq' props)
+--   :: ('Eq' context, 'Eq' childModel, 'Eq' childProps)
 --   => 'MisoString'
---   -> props
---   -> t'Miso.Types.Component' context props childModel childAction
+--   -> childProps
+--   -> t'Miso.Types.Component' context childProps childModel childAction
 --   -> 'View' context props model action
 -- @
+--
+-- The child's @childProps@ are forgotten at the mount boundary, so the
+-- resulting 'View' lives in the /parent's/ @props@ (here @()@).
 --
 -- === Example: child reading parent-supplied props
 --

--- a/src/Miso.hs
+++ b/src/Miso.hs
@@ -144,7 +144,7 @@
 --          |     |      |           * - The global @context@ threaded into the 'View' (@'View' context props model action@)
 --          |     |      |           |  * - The type of the action that updates t'Miso.Types.Component' @model@
 --          |     |      |           |  |
---     v :: () -> () -> 'Int' -> 'View' () 'Int' Action
+--     v :: () -> () -> 'Int' -> 'View' () () 'Int' Action
 --     v _context _props x = 'Miso.Types.vfrag'
 --       [ H.'Miso.Html.Element.button_' [ HE.'Miso.Html.Event.onClick' Add, HP.'Miso.Html.Property.id_' "add" ] [ "+" ]
 --       , 'Miso.Types.text' ('ms' x)
@@ -867,7 +867,7 @@
 -- Top-level applications have no parent, so @props@ is always @()@:
 --
 -- @
--- view :: () -> () -> model -> 'View' () model action
+-- view :: () -> () -> model -> 'View' () () model action
 -- view _context _props model = …
 -- @
 --
@@ -938,7 +938,7 @@
 -- child :: t'Miso.Types.Component' ()      Greeting ()     ChildAction
 -- child = 'Miso.Types.component' () updateChild viewChild
 --   where
---     viewChild :: () -> Greeting -> () -> 'View' () () ChildAction
+--     viewChild :: () -> Greeting -> () -> 'View' () Greeting () ChildAction
 --     viewChild _ (Greeting g) _ =
 --       'Miso.Html.Element.div_' [] [ 'Miso.Types.text' ("Hello, " <> g <> "!") ]
 --
@@ -952,7 +952,7 @@
 -- parentComp :: 'App' ParentModel ParentAction
 -- parentComp = 'Miso.Types.component' (ParentModel \"World\") 'noop' viewParent
 --   where
---     viewParent :: () -> () -> ParentModel -> 'View' () ParentModel ParentAction
+--     viewParent :: () -> () -> ParentModel -> 'View' () () ParentModel ParentAction
 --     viewParent _ _ (ParentModel g) = 'mountWithProps_' "child" (Greeting g) child
 -- -----------------------------------------------------------------------------
 -- newtype ParentModel = ParentModel 'MisoString' deriving ('Eq')
@@ -1239,13 +1239,23 @@
 --   'Miso.Html.ToHtml.toHtml' :: a -> 'Data.ByteString.Lazy.ByteString'
 -- @
 --
--- Instances are provided for @'View' c m a@ and @['View' c m a]@:
+-- Instances are provided for @'View' c () m a@ and @['View' c () m a]@ — a
+-- bare 'View' has no enclosing component to supply @props@, so they are
+-- fixed to @()@ (a 'View' left polymorphic in @props@ resolves to this):
 --
 -- @
 -- import "Miso.Html.Render" ('Miso.Html.Render.toHtml')
 --
 -- pageHtml :: 'Data.ByteString.Lazy.ByteString'
 -- pageHtml = 'Miso.Html.Render.toHtml' $ 'Miso.Html.Element.div_' [ 'Miso.Html.Property.id_' "root" ] [ "Hello, world!" ]
+-- @
+--
+-- To render a 'View' whose @props@ type is something else — e.g. a
+-- component's 'Miso.Types.view' applied directly, or a subtree containing
+-- 'vprops' — pass the @props@ value with 'Miso.Html.Render.toHtmlWith':
+--
+-- @
+-- 'Miso.Html.Render.toHtmlWith' props ('Miso.Types.view' comp ctx props model)
 -- @
 --
 -- This is typically wired into a Servant handler on the server using the
@@ -1723,7 +1733,7 @@
 -- in a @\<script\>@ tag alongside the rendered HTML:
 --
 -- @
--- serverView :: context -> props -> Model -> 'View' context Action
+-- serverView :: context -> props -> Model -> 'View' context props Model Action
 -- serverView _ _ m =
 --   'Miso.Html.Element.div_' []
 --     [ 'Miso.Html.Element.script_' [] [ 'textRaw' ("window.__initialModel__ = " \<\> 'Miso.JSON.encode' m) ]

--- a/src/Miso.hs
+++ b/src/Miso.hs
@@ -217,7 +217,7 @@
 --   = 'VNode' 'Namespace' 'Tag' ['Attribute' model action] ['View' context props model action] 'DirectEvents'
 --   | 'VText' (Maybe t'Key') 'MisoString'
 --   | 'VComp' ('SomeComponent' context)
---   | forall childProps . 'VCompStatic' (StaticPtr ('SomeStaticComponent' childProps context)) childProps
+--   | 'VCompStatic' ('StaticMount' context)
 --   | 'VFrag' (Maybe t'Key') ['View' context props model action]
 --   | 'VContext' (context -> 'View' context props model action)
 --   | 'VProps' (props -> 'View' context props model action)
@@ -229,6 +229,9 @@
 -- data t'SomeComponent' context
 --   = forall model action props . ('Eq' context, 'Eq' model, 'Eq' props)
 --   => t'SomeComponent' (Maybe t'Key') props ('Miso.Types.Component' context props model action)
+--
+-- data t'StaticMount' context
+--   = forall props . t'StaticMount' (StaticPtr (t'SomeStaticComponent' props context)) props
 -- @
 --
 -- The smart constructors:

--- a/src/Miso.hs
+++ b/src/Miso.hs
@@ -223,7 +223,7 @@
 --   | 'VProps' (props -> 'View' context props model action)
 -- @
 --
--- 'VNode' and 'VText' have a one-to-one mapping from the virtual DOM to the physical DOM. The 'VComp', 'VFrag', 'VContext' and 'VProps' constructors are abstract (live only on the virtual DOM) and do not contain a reference to the physical DOM. The existential t'SomeComponent' is what allows embedding polymorphic t'Miso.Types.Component' within a 'View'.
+-- 'VNode' and 'VText' have a one-to-one mapping from the virtual DOM to the physical DOM. The 'VComp' and 'VFrag' constructors are abstract nodes (live only on the virtual DOM) and do not contain a reference to the physical DOM. 'VContext' and 'VProps' are not nodes at all: they are /ambient accessors/, resolved to one of the other constructors whenever the tree is built or rendered, and so never appear in the virtual DOM the runtime diffs. The existential t'SomeComponent' is what allows embedding polymorphic t'Miso.Types.Component' within a 'View'.
 --
 -- @
 -- data t'SomeComponent' context
@@ -326,13 +326,15 @@
 -- (usually nested) components whose 'Miso.Types.view' depends on the @context@
 -- and must refresh when it changes.
 --
--- = 'VContext' (Context nodes)
+-- = 'VContext' (ambient context)
 --
--- 'VContext' embeds a subtree built from a @context -> 'View' context props model
--- action@ function, so a helper deep in a view tree can read the app-global
--- @context@ without needing it threaded through as an explicit argument —
--- unlike 'Miso.Types.view' itself, which already receives @context@ as its
--- first parameter.
+-- 'VContext' is an /ambient accessor/ for the app-global @context@, not a
+-- node: it wraps a @context -> 'View' context props model action@ function
+-- that is applied, and the wrapper discarded, whenever the enclosing 'View'
+-- is built or rendered. It lets a helper deep in a view tree read @context@
+-- without needing it threaded through as an explicit argument — unlike
+-- 'Miso.Types.view' itself, which already receives @context@ as its first
+-- parameter.
 --
 -- @
 -- 'vcontext' $ \\theme -> 'Miso.Html.Element.span_' [] [ 'Miso.Types.text' (themeLabel theme) ]
@@ -346,14 +348,15 @@
 -- The smart constructors for 'VContext' are 'vcontext' and 'withContext'
 -- (a synonym).
 --
--- = 'VProps' (Props nodes)
+-- = 'VProps' (ambient props)
 --
--- 'VProps' is the @props@ counterpart of 'VContext': it embeds a subtree
--- built from a @props -> 'View' context props model action@ function, so a
--- helper deep in a view tree can read the enclosing t'Miso.Types.Component'\'s
--- @props@ without needing it threaded through as an explicit argument —
--- unlike 'Miso.Types.view' itself, which already receives @props@ as its
--- second parameter.
+-- 'VProps' is the @props@ counterpart of 'VContext': an ambient accessor
+-- for the enclosing t'Miso.Types.Component'\'s @props@. It wraps a
+-- @props -> 'View' context props model action@ function that is applied, and
+-- the wrapper discarded, whenever the enclosing 'View' is built or rendered,
+-- so a helper deep in a view tree can read @props@ without needing it
+-- threaded through as an explicit argument — unlike 'Miso.Types.view'
+-- itself, which already receives @props@ as its second parameter.
 --
 -- @
 -- 'vprops' $ \\Props { title } -> 'Miso.Html.Element.h1_' [] [ 'Miso.Types.text' title ]
@@ -374,6 +377,17 @@
 --
 -- The smart constructors for 'VProps' are 'vprops' and 'withProps'
 -- (a synonym).
+--
+-- == Why not @ImplicitParams@ or a @Reader@?
+--
+-- Both are alternatives for ambient values. @ImplicitParams@ (@?props@,
+-- @?context@) gives the same "read it where you need it" ergonomics, but is
+-- a GHC-specific extension whose constraints leak into every helper's
+-- signature. A @Reader@ (or @ReaderT@) over the 'View' would work on any
+-- compiler, but forces a monadic style onto view code that is otherwise
+-- plain applicative expressions and lists. 'VContext' and 'VProps' keep the
+-- 'View' DSL as ordinary Haskell values: the accessor is just another
+-- constructor, resolved by the runtime, with nothing to lift or thread.
 --
 -- = 'VComp' (Component nodes)
 --

--- a/src/Miso/CSS.hs
+++ b/src/Miso/CSS.hs
@@ -698,7 +698,7 @@ renderStyles indent (Media name frames) = MS.intercalate " "
 -- @\<style\>@ tag.
 --
 -- @
--- view_ :: View context action
+-- view_ :: View context props model action
 -- view_ = style [] [ text (renderStyleSheet mySheet) ]
 -- @
 --

--- a/src/Miso/Canvas.hs
+++ b/src/Miso/Canvas.hs
@@ -191,14 +191,14 @@ import           Miso.CSS (Color, renderColor)
 -- useful when building applications with three.js, or other libraries where
 -- explicit context is not necessary.
 canvas_
-  :: forall context model action canvasState
+  :: forall context props model action canvasState
    . (FromJSVal canvasState, ToJSVal canvasState)
   => [ Attribute model action ]
   -> (DOMRef -> IO canvasState)
   -- ^ Init function, takes @DOMRef@ as arg, returns canvas init. state.
   -> (canvasState -> IO ())
   -- ^ Callback to render graphics using this canvas' context, takes init state as arg.
-  -> View context model action
+  -> View context props model action
 canvas_ attributes initialize_ draw_ = node HTML "canvas" attrs []
   where
     attrs :: [ Attribute model action ]
@@ -220,14 +220,14 @@ canvas_ attributes initialize_ draw_ = node HTML "canvas" attrs []
 -- This function abstracts over the context and interpret callback,
 -- including dimension ("2d" or "3d") canvas.
 canvas
-  :: forall context model action canvasState
+  :: forall context props model action canvasState
    . (FromJSVal canvasState, ToJSVal canvasState)
   => [ Attribute model action ]
   -> (DOMRef -> Canvas canvasState)
   -- ^ Init function, takes @DOMRef@ as arg, returns canvas init. state.
   -> (canvasState -> Canvas ())
   -- ^ Callback to render graphics using this canvas' context, takes init state as arg.
-  -> View context model action
+  -> View context props model action
 canvas attributes initialize draw = node HTML "canvas" attrs []
   where
     attrs :: [ Attribute model action ]

--- a/src/Miso/Html/Element.hs
+++ b/src/Miso/Html/Element.hs
@@ -216,347 +216,347 @@ import           Miso.Svg.Element (svg_)
 -----------------------------------------------------------------------------
 -- | Low-level helper used to construct 'HTML' 'node' in 'Miso.Types.View'.
 -- Almost all functions in this module, like 'div_', 'table_' etc. are defined in terms of it.
-nodeHtml :: MisoString -> [Attribute model action] -> [View context model action] -> View context model action
+nodeHtml :: MisoString -> [Attribute model action] -> [View context props model action] -> View context props model action
 nodeHtml nodeName = node HTML nodeName
 -----------------------------------------------------------------------------
 -- | [\<div\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/div)
-div_ :: [Attribute model action] -> [View context model action] -> View context model action
+div_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 div_ = nodeHtml "div"
 -----------------------------------------------------------------------------
 -- | [\<table\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/table)
-table_ :: [Attribute model action] -> [View context model action] -> View context model action
+table_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 table_ = nodeHtml "table"
 -----------------------------------------------------------------------------
 -- | [\<thead\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/thead)
-thead_ :: [Attribute model action] -> [View context model action] -> View context model action
+thead_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 thead_ = nodeHtml "thead"
 -----------------------------------------------------------------------------
 -- | [\<tbody\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/tbody)
-tbody_ :: [Attribute model action] -> [View context model action] -> View context model action
+tbody_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 tbody_ = nodeHtml "tbody"
 -----------------------------------------------------------------------------
 -- | [\<tr\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/tr)
-tr_ :: [Attribute model action] -> [View context model action] -> View context model action
+tr_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 tr_ = nodeHtml "tr"
 -----------------------------------------------------------------------------
 -- | [\<th\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/th)
-th_ :: [Attribute model action] -> [View context model action] -> View context model action
+th_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 th_ = nodeHtml "th"
 -----------------------------------------------------------------------------
 -- | [\<td\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/td)
-td_ :: [Attribute model action] -> [View context model action] -> View context model action
+td_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 td_ = nodeHtml "td"
 -----------------------------------------------------------------------------
 -- | [\<tfoot\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/tfoot)
-tfoot_ :: [Attribute model action] -> [View context model action] -> View context model action
+tfoot_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 tfoot_ = nodeHtml "tfoot"
 -----------------------------------------------------------------------------
 -- | [\<section\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/section)
-section_ :: [Attribute model action] -> [View context model action] -> View context model action
+section_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 section_ = nodeHtml "section"
 -----------------------------------------------------------------------------
 -- | [\<header\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/header)
-header_ :: [Attribute model action] -> [View context model action] -> View context model action
+header_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 header_ = nodeHtml "header"
 -----------------------------------------------------------------------------
 -- | [\<footer\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/footer)
-footer_ :: [Attribute model action] -> [View context model action] -> View context model action
+footer_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 footer_ = nodeHtml "footer"
 -----------------------------------------------------------------------------
 -- | [\<button\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/button)
-button_ :: [Attribute model action] -> [View context model action] -> View context model action
+button_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 button_ = nodeHtml "button"
 -----------------------------------------------------------------------------
 -- | [\<form\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/form)
 --
 -- For usage in a real-world application with the @onSubmit@ event.
 --
--- > view :: Model -> View context model action
+-- > view :: Model -> View context props model action
 -- > view model = form_ [ onSubmit NoOp ] [ input [ type_ "submit" ] ]
 --
 -- Note: @onSubmit@ will use @preventDefault = True@. This will keep
 -- the form from submitting to the server.
 --
-form_ :: [Attribute model action] -> [View context model action] -> View context model action
+form_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 form_ = nodeHtml "form"
 -----------------------------------------------------------------------------
 -- | [\<p\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/p)
-p_ :: [Attribute model action] -> [View context model action] -> View context model action
+p_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 p_ = nodeHtml "p"
 -----------------------------------------------------------------------------
 -- | [\<s\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/s)
-s_ :: [Attribute model action] -> [View context model action] -> View context model action
+s_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 s_ = nodeHtml "s"
 -----------------------------------------------------------------------------
 -- | [\<ul\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/ul)
-ul_ :: [Attribute model action] -> [View context model action] -> View context model action
+ul_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 ul_ = nodeHtml "ul"
 -----------------------------------------------------------------------------
 -- | [\<span\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/span)
-span_ :: [Attribute model action] -> [View context model action] -> View context model action
+span_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 span_ = nodeHtml "span"
 -----------------------------------------------------------------------------
 -- | [\<strong\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/strong)
-strong_ :: [Attribute model action] -> [View context model action] -> View context model action
+strong_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 strong_ = nodeHtml "strong"
 -----------------------------------------------------------------------------
 -- | [\<li\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/li)
-li_ :: [Attribute model action] -> [View context model action] -> View context model action
+li_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 li_ = nodeHtml "li"
 -----------------------------------------------------------------------------
 -- | [\<h1\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/Heading_Elements)
-h1_ :: [Attribute model action] -> [View context model action] -> View context model action
+h1_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 h1_ = nodeHtml "h1"
 -----------------------------------------------------------------------------
 -- | [\<h2\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/Heading_Elements)
-h2_ :: [Attribute model action] -> [View context model action] -> View context model action
+h2_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 h2_ = nodeHtml "h2"
 -----------------------------------------------------------------------------
 -- | [\<h3\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/Heading_Elements)
-h3_ :: [Attribute model action] -> [View context model action] -> View context model action
+h3_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 h3_ = nodeHtml "h3"
 -----------------------------------------------------------------------------
 -- | [\<h4\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/Heading_Elements)
-h4_ :: [Attribute model action] -> [View context model action] -> View context model action
+h4_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 h4_ = nodeHtml "h4"
 -----------------------------------------------------------------------------
 -- | [\<h5\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/Heading_Elements)
-h5_ :: [Attribute model action] -> [View context model action] -> View context model action
+h5_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 h5_ = nodeHtml "h5"
 -----------------------------------------------------------------------------
 -- | [\<h6\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/Heading_Elements)
-h6_ :: [Attribute model action] -> [View context model action] -> View context model action
+h6_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 h6_ = nodeHtml "h6"
 -----------------------------------------------------------------------------
 -- | [\<hr\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/hr)
-hr_ :: [Attribute model action] -> View context model action
+hr_ :: [Attribute model action] -> View context props model action
 hr_ = flip (nodeHtml "hr") []
 -----------------------------------------------------------------------------
 -- | [\<pre\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/pre)
-pre_ :: [Attribute model action] -> [View context model action] -> View context model action
+pre_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 pre_ = nodeHtml "pre"
 -----------------------------------------------------------------------------
 -- | [\<input\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/input)
-input_ :: [Attribute model action] -> View context model action
+input_ :: [Attribute model action] -> View context props model action
 input_ = flip (nodeHtml "input") []
 -----------------------------------------------------------------------------
 -- | [\<label\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/label)
-label_ :: [Attribute model action] -> [View context model action] -> View context model action
+label_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 label_ = nodeHtml "label"
 -----------------------------------------------------------------------------
 -- | [\<a\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/a)
-a_ :: [Attribute model action] -> [View context model action] -> View context model action
+a_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 a_ = nodeHtml "a"
 -----------------------------------------------------------------------------
 -- | [\<mark\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/mark)
-mark_ :: [Attribute model action] -> [View context model action] -> View context model action
+mark_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 mark_ = nodeHtml "mark"
 -----------------------------------------------------------------------------
 -- | [\<ruby\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/ruby)
-ruby_ :: [Attribute model action] -> [View context model action] -> View context model action
+ruby_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 ruby_ = nodeHtml "ruby"
 -----------------------------------------------------------------------------
 -- | [\<rt\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/rt)
-rt_ :: [Attribute model action] -> [View context model action] -> View context model action
+rt_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 rt_ = nodeHtml "rt"
 -----------------------------------------------------------------------------
 -- | [\<rp\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/rp)
-rp_ :: [Attribute model action] -> [View context model action] -> View context model action
+rp_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 rp_ = nodeHtml "rp"
 -----------------------------------------------------------------------------
 -- | [\<bdi\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/bdi)
-bdi_ :: [Attribute model action] -> [View context model action] -> View context model action
+bdi_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 bdi_ = nodeHtml "bdi"
 -----------------------------------------------------------------------------
 -- | [\<bdo\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/bdo)
-bdo_ :: [Attribute model action] -> [View context model action] -> View context model action
+bdo_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 bdo_ = nodeHtml "bdo"
 -----------------------------------------------------------------------------
 -- | [\<wbr\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/wbr)
-wbr_ :: [Attribute model action] -> View context model action
+wbr_ :: [Attribute model action] -> View context props model action
 wbr_ = flip (nodeHtml "wbr") []
 -----------------------------------------------------------------------------
 -- | [\<details\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/details)
-details_ :: [Attribute model action] -> [View context model action] -> View context model action
+details_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 details_ = nodeHtml "details"
 -----------------------------------------------------------------------------
 -- | [\<summary\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/summary)
-summary_ :: [Attribute model action] -> [View context model action] -> View context model action
+summary_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 summary_ = nodeHtml "summary"
 -----------------------------------------------------------------------------
 -- | [\<menu\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/menu)
-menu_ :: [Attribute model action] -> [View context model action] -> View context model action
+menu_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 menu_ = nodeHtml "menu"
 -----------------------------------------------------------------------------
 -- | [\<fieldset\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/fieldset)
-fieldset_ :: [Attribute model action] -> [View context model action] -> View context model action
+fieldset_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 fieldset_ = nodeHtml "fieldset"
 -----------------------------------------------------------------------------
 -- | [\<legend\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/legend)
-legend_ :: [Attribute model action] -> [View context model action] -> View context model action
+legend_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 legend_ = nodeHtml "legend"
 -----------------------------------------------------------------------------
 -- | [\<datalist\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/datalist)
-datalist_ :: [Attribute model action] -> [View context model action] -> View context model action
+datalist_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 datalist_ = nodeHtml "datalist"
 -----------------------------------------------------------------------------
 -- | [\<optgroup\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/optgroup)
-optgroup_ :: [Attribute model action] -> [View context model action] -> View context model action
+optgroup_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 optgroup_ = nodeHtml "optgroup"
 -----------------------------------------------------------------------------
 -- | [\<output\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/output)
-output_ :: [Attribute model action] -> [View context model action] -> View context model action
+output_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 output_ = nodeHtml "output"
 -----------------------------------------------------------------------------
 -- | [\<progress\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/progress)
-progress_ :: [Attribute model action] -> [View context model action] -> View context model action
+progress_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 progress_ = nodeHtml "progress"
 -----------------------------------------------------------------------------
 -- | [\<meter\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/meter)
-meter_ :: [Attribute model action] -> [View context model action] -> View context model action
+meter_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 meter_ = nodeHtml "meter"
 -----------------------------------------------------------------------------
 -- | [\<audio\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/audio)
-audio_ :: [Attribute model action] -> [View context model action] -> View context model action
+audio_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 audio_ = nodeHtml "audio"
 -----------------------------------------------------------------------------
 -- | [\<video\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/video)
-video_ :: [Attribute model action] -> [View context model action] -> View context model action
+video_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 video_ = nodeHtml "video"
 -----------------------------------------------------------------------------
 -- | [\<source\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/source)
-source_ :: [Attribute model action] -> View context model action
+source_ :: [Attribute model action] -> View context props model action
 source_ = flip (nodeHtml "source") []
 -----------------------------------------------------------------------------
 -- | [\<track\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/track)
-track_ :: [Attribute model action] -> View context model action
+track_ :: [Attribute model action] -> View context props model action
 track_ = flip (nodeHtml "track") []
 -----------------------------------------------------------------------------
 -- | [\<embed\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/embed)
-embed_ :: [Attribute model action] -> View context model action
+embed_ :: [Attribute model action] -> View context props model action
 embed_ = flip (nodeHtml "embed") []
 -----------------------------------------------------------------------------
 -- | [\<object\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/object)
-object_ :: [Attribute model action] -> [View context model action] -> View context model action
+object_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 object_ = nodeHtml "object"
 -----------------------------------------------------------------------------
 -- | [\<ins\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/ins)
-ins_ :: [Attribute model action] -> [View context model action] -> View context model action
+ins_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 ins_ = nodeHtml "ins"
 -----------------------------------------------------------------------------
 -- | [\<del\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/del)
-del_ :: [Attribute model action] -> [View context model action] -> View context model action
+del_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 del_ = nodeHtml "del"
 -----------------------------------------------------------------------------
 -- | [\<small\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/small)
-small_ :: [Attribute model action] -> [View context model action] -> View context model action
+small_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 small_ = nodeHtml "small"
 -----------------------------------------------------------------------------
 -- | [\<cite\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/cite)
-cite_ :: [Attribute model action] -> [View context model action] -> View context model action
+cite_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 cite_ = nodeHtml "cite"
 -----------------------------------------------------------------------------
 -- | [\<dfn\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/dfn)
-dfn_ :: [Attribute model action] -> [View context model action] -> View context model action
+dfn_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 dfn_ = nodeHtml "dfn"
 -----------------------------------------------------------------------------
 -- | [\<abbr\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/abbr)
-abbr_ :: [Attribute model action] -> [View context model action] -> View context model action
+abbr_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 abbr_ = nodeHtml "abbr"
 -----------------------------------------------------------------------------
 -- | [\<time\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/time)
-time_ :: [Attribute model action] -> [View context model action] -> View context model action
+time_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 time_ = nodeHtml "time"
 -----------------------------------------------------------------------------
 -- | [\<var\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/var)
-var_ :: [Attribute model action] -> [View context model action] -> View context model action
+var_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 var_ = nodeHtml "var"
 -----------------------------------------------------------------------------
 -- | [\<samp\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/samp)
-samp_ :: [Attribute model action] -> [View context model action] -> View context model action
+samp_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 samp_ = nodeHtml "samp"
 -----------------------------------------------------------------------------
 -- | [\<kbd\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/kbd)
-kbd_ :: [Attribute model action] -> [View context model action] -> View context model action
+kbd_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 kbd_ = nodeHtml "kbd"
 -----------------------------------------------------------------------------
 -- | [\<caption\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/caption)
-caption_ :: [Attribute model action] -> [View context model action] -> View context model action
+caption_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 caption_ = nodeHtml "caption"
 -----------------------------------------------------------------------------
 -- | [\<colgroup\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/colgroup)
-colgroup_ :: [Attribute model action] -> [View context model action] -> View context model action
+colgroup_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 colgroup_ = nodeHtml "colgroup"
 -----------------------------------------------------------------------------
 -- | [\<col\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/col)
-col_ :: [Attribute model action] -> View context model action
+col_ :: [Attribute model action] -> View context props model action
 col_ = flip (nodeHtml "col") []
 -----------------------------------------------------------------------------
 -- | [\<nav\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/nav)
-nav_ :: [Attribute model action] -> [View context model action] -> View context model action
+nav_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 nav_ = nodeHtml "nav"
 -----------------------------------------------------------------------------
 -- | [\<article\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/article)
-article_ :: [Attribute model action] -> [View context model action] -> View context model action
+article_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 article_ = nodeHtml "article"
 -----------------------------------------------------------------------------
 -- | [\<aside\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/aside)
-aside_ :: [Attribute model action] -> [View context model action] -> View context model action
+aside_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 aside_ = nodeHtml "aside"
 -----------------------------------------------------------------------------
 -- | [\<address\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/address)
-address_ :: [Attribute model action] -> [View context model action] -> View context model action
+address_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 address_ = nodeHtml "address"
 -----------------------------------------------------------------------------
 -- | [\<main\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/main)
-main_ :: [Attribute model action] -> [View context model action] -> View context model action
+main_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 main_ = nodeHtml "main"
 -----------------------------------------------------------------------------
 -- | [\<body\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/body)
-body_ :: [Attribute model action] -> [View context model action] -> View context model action
+body_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 body_ = nodeHtml "body"
 -----------------------------------------------------------------------------
 -- | [\<figure\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/figure)
-figure_ :: [Attribute model action] -> [View context model action] -> View context model action
+figure_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 figure_ = nodeHtml "figure"
 -----------------------------------------------------------------------------
 -- | [\<figcaption\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/figcaption)
-figcaption_ :: [Attribute model action] -> [View context model action] -> View context model action
+figcaption_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 figcaption_ = nodeHtml "figcaption"
 -----------------------------------------------------------------------------
 -- | [\<dl\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/dl)
-dl_ :: [Attribute model action] -> [View context model action] -> View context model action
+dl_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 dl_ = nodeHtml "dl"
 -----------------------------------------------------------------------------
 -- | [\<dt\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/dt)
-dt_ :: [Attribute model action] -> [View context model action] -> View context model action
+dt_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 dt_ = nodeHtml "dt"
 -----------------------------------------------------------------------------
 -- | [\<dd\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/dd)
-dd_ :: [Attribute model action] -> [View context model action] -> View context model action
+dd_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 dd_ = nodeHtml "dd"
 -----------------------------------------------------------------------------
 -- | [\<img\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/img)
-img_ :: [Attribute model action] -> View context model action
+img_ :: [Attribute model action] -> View context props model action
 img_ = flip (nodeHtml "img") []
 -----------------------------------------------------------------------------
 -- | [\<iframe\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/iframe)
-iframe_ :: [Attribute model action] -> [View context model action] -> View context model action
+iframe_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 iframe_ = nodeHtml "iframe"
 -----------------------------------------------------------------------------
 -- | [\<canvas\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/canvas)
 --
 -- Note this just renders a canvas element.
 -- See also 'Miso.Canvas.canvas_' which supports canvas drawing DSL.
-canvas_ :: [Attribute model action] -> [View context model action] -> View context model action
+canvas_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 canvas_ = nodeHtml "canvas"
 -----------------------------------------------------------------------------
 -- | [\<select\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/select)
-select_ :: [Attribute model action] -> [View context model action] -> View context model action
+select_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 select_ = nodeHtml "select"
 -----------------------------------------------------------------------------
 -- | [\<option\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/option)
-option_ :: [Attribute model action] -> [View context model action] -> View context model action
+option_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 option_ = nodeHtml "option"
 -----------------------------------------------------------------------------
 -- | [\<textarea\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/textarea)
@@ -568,7 +568,7 @@ option_ = nodeHtml "option"
 -- When compiling on the server, this combinator will render HTML as \<textarea\>text\<\/textarea\>.
 --
 -- @since 1.9.0.0
-textarea_ :: [Attribute model action] -> View context model action
+textarea_ :: [Attribute model action] -> View context props model action
 #ifdef VANILLA
 textarea_ attrs = nodeHtml "textarea" newAttrs
   [ text x
@@ -582,51 +582,51 @@ textarea_ = flip (nodeHtml "textarea") []
 #endif
 -----------------------------------------------------------------------------
 -- | [\<sub\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/sub)
-sub_ :: [Attribute model action] -> [View context model action] -> View context model action
+sub_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 sub_ = nodeHtml "sub"
 -----------------------------------------------------------------------------
 -- | [\<sup\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/sup)
-sup_ :: [Attribute model action] -> [View context model action] -> View context model action
+sup_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 sup_ = nodeHtml "sup"
 -----------------------------------------------------------------------------
 -- | [\<br\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/br)
-br_ :: [Attribute model action] -> View context model action
+br_ :: [Attribute model action] -> View context props model action
 br_ = flip (nodeHtml "br") []
 -----------------------------------------------------------------------------
 -- | [\<ol\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/ol)
-ol_ :: [Attribute model action] -> [View context model action] -> View context model action
+ol_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 ol_ = nodeHtml "ol"
 -----------------------------------------------------------------------------
 -- | [\<blockquote\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/blockquote)
-blockquote_ :: [Attribute model action] -> [View context model action] -> View context model action
+blockquote_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 blockquote_ = nodeHtml "blockquote"
 -----------------------------------------------------------------------------
 -- | [\<code\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/code)
-code_ :: [Attribute model action] -> [View context model action] -> View context model action
+code_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 code_ = nodeHtml "code"
 -----------------------------------------------------------------------------
 -- | [\<em\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/em)
-em_ :: [Attribute model action] -> [View context model action] -> View context model action
+em_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 em_ = nodeHtml "em"
 -----------------------------------------------------------------------------
 -- | [\<i\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/i)
-i_ :: [Attribute model action] -> [View context model action] -> View context model action
+i_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 i_ = nodeHtml "i"
 -----------------------------------------------------------------------------
 -- | [\<b\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/b)
-b_ :: [Attribute model action] -> [View context model action] -> View context model action
+b_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 b_ = nodeHtml "b"
 -----------------------------------------------------------------------------
 -- | [\<u\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/u)
-u_ :: [Attribute model action] -> [View context model action] -> View context model action
+u_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 u_ = nodeHtml "u"
 -----------------------------------------------------------------------------
 -- | [\<q\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/q)
-q_ :: [Attribute model action] -> [View context model action] -> View context model action
+q_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 q_ = nodeHtml "q"
 -----------------------------------------------------------------------------
 -- | [\<link\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/link)
-link_ :: [Attribute model action] -> View context model action
+link_ :: [Attribute model action] -> View context props model action
 link_ = flip (nodeHtml "link") []
 -----------------------------------------------------------------------------
 -- | [\<style\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/style)
@@ -643,7 +643,7 @@ link_ = flip (nodeHtml "link") []
 -- @
 --
 -- You can use 'Miso.CSS.style_' as a safer anternative.
-style_ :: [Attribute model action] -> MisoString -> View context model action
+style_ :: [Attribute model action] -> MisoString -> View context props model action
 style_ attrs rawText = node HTML "style" attrs [text rawText]
 -----------------------------------------------------------------------------
 -- | [\<script\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/script)
@@ -657,100 +657,100 @@ style_ attrs rawText = node HTML "style" attrs [text rawText]
 -- You can also easily shoot yourself in the foot with something like:
 --
 -- @'script_' [] "\</script\>"@
-script_ :: [Attribute model action] -> MisoString -> View context model action
+script_ :: [Attribute model action] -> MisoString -> View context props model action
 script_ attrs rawText = node HTML "script" attrs [textRaw rawText]
 -----------------------------------------------------------------------------
 -- | [\<doctype\>](https://developer.mozilla.org/en-US/docs/Glossary/Doctype)
-doctype_ :: View context model action
+doctype_ :: View context props model action
 doctype_ = nodeHtml "doctype" [] []
 -----------------------------------------------------------------------------
 -- | [\<html\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/html)
-html_ :: [Attribute model action] -> [View context model action] -> View context model action
+html_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 html_ = nodeHtml "html"
 -----------------------------------------------------------------------------
 -- | [\<head\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/head)
-head_ :: [Attribute model action] -> [View context model action] -> View context model action
+head_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 head_ = nodeHtml "head"
 -----------------------------------------------------------------------------
 -- | [\<meta\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/meta)
-meta_ :: [Attribute model action] -> View context model action
+meta_ :: [Attribute model action] -> View context props model action
 meta_ = flip (nodeHtml "meta") []
 -----------------------------------------------------------------------------
 -- | [\<area\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/area)
 --
 -- @since 1.9.0.0
-area_ :: [Attribute model action] -> View context model action
+area_ :: [Attribute model action] -> View context props model action
 area_ = flip (nodeHtml "area") []
 -----------------------------------------------------------------------------
 -- | [\<base\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/base)
 --
 -- @since 1.9.0.0
-base_ :: [Attribute model action] -> View context model action
+base_ :: [Attribute model action] -> View context props model action
 base_ = flip (nodeHtml "base") []
 -----------------------------------------------------------------------------
 -- | [\<data\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/data)
 --
 -- @since 1.9.0.0
-data_ :: [Attribute model action] -> [View context model action] -> View context model action
+data_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 data_ = nodeHtml "data"
 -----------------------------------------------------------------------------
 -- | [\<dialog\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/dialog)
 --
 -- @since 1.9.0.0
-dialog_ :: [Attribute model action] -> [View context model action] -> View context model action
+dialog_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 dialog_ = nodeHtml "dialog"
 -----------------------------------------------------------------------------
 -- | [\<fencedframe\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/fencedframe)
 --
 -- @since 1.9.0.0
-fencedframe_ :: [Attribute model action] -> [View context model action] -> View context model action
+fencedframe_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 fencedframe_ = nodeHtml "fencedframe"
 -----------------------------------------------------------------------------
 -- | [\<hgroup\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/hgroup)
 --
 -- @since 1.9.0.0
-hgroup_ :: [Attribute model action] -> [View context model action] -> View context model action
+hgroup_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 hgroup_ = nodeHtml "hgroup"
 -----------------------------------------------------------------------------
 -- | [\<map\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/map)
 --
 -- @since 1.9.0.0
-map_ :: [Attribute model action] -> [View context model action] -> View context model action
+map_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 map_ = nodeHtml "map"
 -----------------------------------------------------------------------------
 -- | [\<noscript\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/noscript)
 --
 -- @since 1.9.0.0
-noscript_ :: [Attribute model action] -> [View context model action] -> View context model action
+noscript_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 noscript_ = nodeHtml "noscript"
 -----------------------------------------------------------------------------
 -- | [\<picture\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/picture)
 --
 -- @since 1.9.0.0
-picture_ :: [Attribute model action] -> [View context model action] -> View context model action
+picture_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 picture_ = nodeHtml "picture"
 -----------------------------------------------------------------------------
 -- | [\<search\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/search)
 --
 -- @since 1.9.0.0
-search_ :: [Attribute model action] -> [View context model action] -> View context model action
+search_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 search_ = nodeHtml "search"
 -----------------------------------------------------------------------------
 -- | [\<slot\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/slot)
 --
 -- @since 1.9.0.0
-slot_ :: [Attribute model action] -> [View context model action] -> View context model action
+slot_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 slot_ = nodeHtml "slot"
 -----------------------------------------------------------------------------
 -- | [\<template\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/template)
 --
 -- @since 1.9.0.0
-template_ :: [Attribute model action] -> [View context model action] -> View context model action
+template_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 template_ = nodeHtml "template"
 -----------------------------------------------------------------------------
 -- | [\<title\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/title)
 --
 -- @since 1.9.0.0
-title_ :: [Attribute model action] -> [View context model action] -> View context model action
+title_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 title_ = nodeHtml "title"
 -----------------------------------------------------------------------------

--- a/src/Miso/Html/Render.hs
+++ b/src/Miso/Html/Render.hs
@@ -53,11 +53,13 @@
 -- * __'Miso.Types.VComp'__ — recursively renders the sub-component's view
 --   using its initial (or hydrated) model.
 -- * __'Miso.Types.VFrag'__ — renders all children inline, no wrapper tag.
--- * __'Miso.Types.VContext'__ — resolved against the app-global @context@
---   (read from 'globalContext') and the result rendered in its place.
--- * __'Miso.Types.VProps'__ — resolved against the @props@ of the enclosing
---   component (@()@ for a bare 'Miso.Types.View' under 'toHtml'; the value
---   given to 'toHtmlWith' otherwise) and the result rendered in its place.
+-- * __'Miso.Types.VContext'__ (ambient accessor, not a node) — applied to
+--   the app-global @context@ (read from 'globalContext') and the result
+--   rendered in its place.
+-- * __'Miso.Types.VProps'__ (ambient accessor, not a node) — applied to the
+--   @props@ of the enclosing component (@()@ for a bare 'Miso.Types.View'
+--   under 'toHtml'; the value given to 'toHtmlWith' otherwise) and the
+--   result rendered in its place.
 -- * __Event handlers__ (@'Miso.Types.On'@) — silently dropped; they have
 --   no meaning in a static HTML string.
 -- * __Boolean properties__ (@disabled@, @checked@, @required@, …) — rendered

--- a/src/Miso/Html/Render.hs
+++ b/src/Miso/Html/Render.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE ScopedTypeVariables   #-}
 {-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE TypeOperators         #-}
 {-# LANGUAGE OverloadedStrings     #-}
 {-# LANGUAGE CPP                   #-}
 #ifdef SSR
@@ -53,6 +54,9 @@
 -- * __'Miso.Types.VFrag'__ — renders all children inline, no wrapper tag.
 -- * __'Miso.Types.VContext'__ — resolved against the app-global @context@
 --   (read from 'globalContext') and the result rendered in its place.
+-- * __'Miso.Types.VProps'__ — resolved against the @props@ of the enclosing
+--   component (@()@ for a bare 'Miso.Types.View') and the result rendered
+--   in its place.
 -- * __Event handlers__ (@'Miso.Types.On'@) — silently dropped; they have
 --   no meaning in a static HTML string.
 -- * __Boolean properties__ (@disabled@, @checked@, @required@, …) — rendered
@@ -101,15 +105,21 @@ class ToHtml a where
   toHtml :: a -> L.ByteString
 ----------------------------------------------------------------------------
 -- | Render a @Miso.Types.View@ to a @L.ByteString@
-instance ToHtml (View context model action) where
+--
+-- A bare 'View' has no enclosing t'Component' to supply @props@, so its
+-- @props@ are fixed to @()@ (the @props ~ ()@ constraint lets a 'View' that is
+-- polymorphic in @props@ still resolve this instance). A 'Miso.Types.VProps'
+-- node at this level therefore sees @()@; one nested inside a mounted
+-- component sees that component's real @props@.
+instance (props ~ ()) => ToHtml (View context props model action) where
   toHtml = renderView
 ----------------------------------------------------------------------------
 -- | Render a @[Miso.Types.View]@ to a @L.ByteString@
-instance ToHtml [View context model action] where
+instance (props ~ ()) => ToHtml [View context props model action] where
   toHtml = foldMap renderView
 ----------------------------------------------------------------------------
-renderView :: View context model action -> L.ByteString
-renderView = toLazyByteString . renderBuilder
+renderView :: View context () model action -> L.ByteString
+renderView = toLazyByteString . renderBuilder ()
 ----------------------------------------------------------------------------
 intercalate :: Builder -> [Builder] -> Builder
 intercalate _ [] = ""
@@ -154,11 +164,13 @@ booleanProperties = S.fromList
   , "truespeed"
   ]
 ----------------------------------------------------------------------------
-renderBuilder :: View context model action -> Builder
-renderBuilder (VText _ "")    = fromMisoString " "
-renderBuilder (VText _ s)     = fromMisoString s
-renderBuilder (VNode _ "doctype" [] [] _) = "<!doctype html>"
-renderBuilder (VNode ns tag attrs children _) = mconcat
+-- | Serialise a 'View' given the @props@ of the t'Component' it belongs to.
+-- Entering a @VComp@ \/ @VCompStatic@ switches to that child's @props@.
+renderBuilder :: props -> View context props model action -> Builder
+renderBuilder _ (VText _ "")    = fromMisoString " "
+renderBuilder _ (VText _ s)     = fromMisoString s
+renderBuilder _ (VNode _ "doctype" [] [] _) = "<!doctype html>"
+renderBuilder props_ (VNode ns tag attrs children _) = mconcat
   [ "<"
   , fromMisoString tag
   , mconcat [ " " <> intercalate " " (renderAttrs <$> attrs)
@@ -167,7 +179,7 @@ renderBuilder (VNode ns tag attrs children _) = mconcat
   , if tag `elem` selfClosing then "/>" else ">"
   , mconcat
     [ mconcat
-      [ foldMap renderBuilder (collapseSiblingTextNodes children)
+      [ foldMap (renderBuilder props_) (collapseSiblingTextNodes children)
       , "</" <> fromMisoString tag <> ">"
       ]
     | tag `notElem` selfClosing
@@ -187,7 +199,7 @@ renderBuilder (VNode ns tag attrs children _) = mconcat
               | ns == MATHML
               , x <- ["mglyph", "mprescripts", "none", "maligngroup", "malignmark" ]
               ]
-renderBuilder (VComp someComp) =
+renderBuilder _ (VComp someComp) =
   case someComp of
     SomeComponent _key props comp_ ->
       -- The app-global @context@ is read from 'globalContext'. For the common
@@ -197,11 +209,11 @@ renderBuilder (VComp someComp) =
       -- forcing @ctx@ raises an exception. See 'Miso.setContext' for details.
       let ctx = unsafePerformIO (readIORef globalContext) in
 #ifdef SSR
-      renderBuilder (view comp_ ctx props (getInitialComponentModel comp_))
+      renderBuilder props (view comp_ ctx props (getInitialComponentModel comp_))
 #else
-      renderBuilder (view comp_ ctx props (model comp_))
+      renderBuilder props (view comp_ ctx props (model comp_))
 #endif
-renderBuilder (VCompStatic ptr props0) =
+renderBuilder _ (VCompStatic ptr props0) =
   case deRefStaticPtr ptr of
    SomeStaticComponent mk -> case mk props0 of
     SomeComponent _key props comp_ ->
@@ -212,14 +224,15 @@ renderBuilder (VCompStatic ptr props0) =
       -- forcing @ctx@ raises an exception. See 'Miso.setContext' for details.
       let ctx = unsafePerformIO (readIORef globalContext) in
 #ifdef SSR
-      renderBuilder (view comp_ ctx props (getInitialComponentModel comp_))
+      renderBuilder props (view comp_ ctx props (getInitialComponentModel comp_))
 #else
-      renderBuilder (view comp_ ctx props (model comp_))
+      renderBuilder props (view comp_ ctx props (model comp_))
 #endif
-renderBuilder (VFrag _ kids) = foldMap renderBuilder kids
-renderBuilder (VContext f) =
+renderBuilder props_ (VFrag _ kids) = foldMap (renderBuilder props_) kids
+renderBuilder props_ (VContext f) =
   let ctx = unsafePerformIO (readIORef globalContext) in
-  renderBuilder (f ctx)
+  renderBuilder props_ (f ctx)
+renderBuilder props_ (VProps f) = renderBuilder props_ (f props_)
 ----------------------------------------------------------------------------
 renderAttrs :: Attribute model action -> Builder
 renderAttrs (ClassList classes) =
@@ -267,7 +280,7 @@ renderAttrs (Styles styles_) =
 -- | The browser can't distinguish between multiple text nodes
 -- and a single text node. So it will always parse a single text node
 -- this means we must collapse adjacent text nodes during hydration.
-collapseSiblingTextNodes :: [View context model action] -> [View context model action]
+collapseSiblingTextNodes :: [View context props model action] -> [View context props model action]
 collapseSiblingTextNodes [] = []
 collapseSiblingTextNodes (VText _ x : VText k y : xs) =
   collapseSiblingTextNodes (VText k (x <> y) : xs)

--- a/src/Miso/Html/Render.hs
+++ b/src/Miso/Html/Render.hs
@@ -217,7 +217,7 @@ renderBuilder props_ (VNode ns tag attrs children _) = mconcat
               , x <- ["mglyph", "mprescripts", "none", "maligngroup", "malignmark" ]
               ]
 renderBuilder _ (VComp someComp) = renderComp someComp
-renderBuilder _ (VCompStatic (StaticMount ptr props0)) =
+renderBuilder _ (VCompStatic ptr props0) =
   case deRefStaticPtr ptr of
     SomeStaticComponent mk -> renderComp (mk props0)
 renderBuilder props_ (VFrag _ kids) = foldMap (renderBuilder props_) kids

--- a/src/Miso/Html/Render.hs
+++ b/src/Miso/Html/Render.hs
@@ -196,7 +196,7 @@ renderBuilder props_ (VNode ns tag attrs children _) = mconcat
   , if tag `elem` selfClosing then "/>" else ">"
   , mconcat
     [ mconcat
-      [ foldMap (renderBuilder props_) (collapseSiblingTextNodes children)
+      [ foldMap (renderBuilder props_) (collapseSiblingTextNodes props_ children)
       , "</" <> fromMisoString tag <> ">"
       ]
     | tag `notElem` selfClosing
@@ -216,28 +216,33 @@ renderBuilder props_ (VNode ns tag attrs children _) = mconcat
               | ns == MATHML
               , x <- ["mglyph", "mprescripts", "none", "maligngroup", "malignmark" ]
               ]
-renderBuilder _ (VComp someComp) =
-  case someComp of
-    SomeComponent _key props comp_ ->
-      -- The app-global @context@ is read from 'globalContext'. For the common
-      -- @context ~ ()@ case the 'Miso.Lens.view' ignores it, so the initial @undefined@ is
-      -- never forced. But if a 'Miso.Lens.view' here inspects a non-trivial @context@,
-      -- SSR must seed the cell with 'Miso.setContext' before serializing, or
-      -- forcing @ctx@ raises an exception. See 'Miso.setContext' for details.
-      let ctx = unsafePerformIO (readIORef globalContext) in
-#ifdef SSR
-      renderBuilder props (view comp_ ctx props (getInitialComponentModel comp_))
-#else
-      renderBuilder props (view comp_ ctx props (model comp_))
-#endif
+renderBuilder _ (VComp someComp) = renderComp someComp
 renderBuilder _ (VCompStatic (StaticMount ptr props0)) =
   case deRefStaticPtr ptr of
-    SomeStaticComponent mk -> renderBuilder () (VComp (mk props0))
+    SomeStaticComponent mk -> renderComp (mk props0)
 renderBuilder props_ (VFrag _ kids) = foldMap (renderBuilder props_) kids
 renderBuilder props_ (VContext f) =
   let ctx = unsafePerformIO (readIORef globalContext) in
   renderBuilder props_ (f ctx)
 renderBuilder props_ (VProps f) = renderBuilder props_ (f props_)
+----------------------------------------------------------------------------
+-- | Render a mounted child component: its 'view' applied to the app-global
+-- @context@, the @props@ it was mounted with, and its initial (or hydrated)
+-- @model@. The enclosing component's @props@ play no part, which is why the
+-- @VComp@ \/ @VCompStatic@ arms of 'renderBuilder' ignore theirs.
+renderComp :: SomeComponent context -> Builder
+renderComp (SomeComponent _key props comp_) =
+  -- The app-global @context@ is read from 'globalContext'. For the common
+  -- @context ~ ()@ case the 'Miso.Lens.view' ignores it, so the initial @undefined@ is
+  -- never forced. But if a 'Miso.Lens.view' here inspects a non-trivial @context@,
+  -- SSR must seed the cell with 'Miso.setContext' before serializing, or
+  -- forcing @ctx@ raises an exception. See 'Miso.setContext' for details.
+  let ctx = unsafePerformIO (readIORef globalContext) in
+#ifdef SSR
+  renderBuilder props (view comp_ ctx props (getInitialComponentModel comp_))
+#else
+  renderBuilder props (view comp_ ctx props (model comp_))
+#endif
 ----------------------------------------------------------------------------
 renderAttrs :: Attribute model action -> Builder
 renderAttrs (ClassList classes) =
@@ -285,12 +290,22 @@ renderAttrs (Styles styles_) =
 -- | The browser can't distinguish between multiple text nodes
 -- and a single text node. So it will always parse a single text node
 -- this means we must collapse adjacent text nodes during hydration.
-collapseSiblingTextNodes :: [View context props model action] -> [View context props model action]
-collapseSiblingTextNodes [] = []
-collapseSiblingTextNodes (VText _ x : VText k y : xs) =
-  collapseSiblingTextNodes (VText k (x <> y) : xs)
-collapseSiblingTextNodes (x:xs) =
-  x : collapseSiblingTextNodes xs
+collapseSiblingTextNodes
+  :: props
+  -> [View context props model action]
+  -> [View context props model action]
+collapseSiblingTextNodes props_ = go
+  where
+    -- Look through the wrapper constructors first, so a 'VProps' \/ 'VContext'
+    -- that resolves to text is collapsed with its neighbours exactly as the
+    -- client does after 'buildVTree' has resolved it. Otherwise an empty
+    -- 'VText' behind a wrapper renders as a lone space that hydration
+    -- cannot reconcile.
+    go (VProps f : xs) = go (f props_ : xs)
+    go (VContext f : xs) = go (f (unsafePerformIO (readIORef globalContext)) : xs)
+    go (VText _ x : VText k y : xs) = go (VText k (x <> y) : xs)
+    go (x : xs) = x : go xs
+    go [] = []
 ----------------------------------------------------------------------------
 -- | Helper for turning JSON into Text
 -- Object, Array and Null are kind of non-sensical here

--- a/src/Miso/Html/Render.hs
+++ b/src/Miso/Html/Render.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE ScopedTypeVariables   #-}
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE TypeOperators         #-}
+{-# LANGUAGE TypeFamilies          #-}
 {-# LANGUAGE OverloadedStrings     #-}
 {-# LANGUAGE CPP                   #-}
 #ifdef SSR

--- a/src/Miso/Html/Render.hs
+++ b/src/Miso/Html/Render.hs
@@ -56,8 +56,8 @@
 -- * __'Miso.Types.VContext'__ — resolved against the app-global @context@
 --   (read from 'globalContext') and the result rendered in its place.
 -- * __'Miso.Types.VProps'__ — resolved against the @props@ of the enclosing
---   component (@()@ for a bare 'Miso.Types.View') and the result rendered
---   in its place.
+--   component (@()@ for a bare 'Miso.Types.View' under 'toHtml'; the value
+--   given to 'toHtmlWith' otherwise) and the result rendered in its place.
 -- * __Event handlers__ (@'Miso.Types.On'@) — silently dropped; they have
 --   no meaning in a static HTML string.
 -- * __Boolean properties__ (@disabled@, @checked@, @required@, …) — rendered
@@ -80,6 +80,8 @@
 module Miso.Html.Render
   ( -- *** Classes
     ToHtml (..)
+    -- *** Functions
+  , toHtmlWith
   ) where
 ----------------------------------------------------------------------------
 import qualified Data.Set as S
@@ -120,7 +122,21 @@ instance (props ~ ()) => ToHtml [View context props model action] where
   toHtml = foldMap renderView
 ----------------------------------------------------------------------------
 renderView :: View context () model action -> L.ByteString
-renderView = toLazyByteString . renderBuilder ()
+renderView = toHtmlWith ()
+----------------------------------------------------------------------------
+-- | Render a 'View' to a @L.ByteString@, supplying the @props@ that any
+-- 'Miso.Types.VProps' node in it resolves against.
+--
+-- This is the general form of 'toHtml', for a 'View' whose @props@ type is
+-- not @()@ — e.g. a component's 'Miso.Types.view' applied directly:
+--
+-- @
+-- toHtmlWith props (view comp ctx props model)
+-- @
+--
+-- @since 1.14.0.0
+toHtmlWith :: props -> View context props model action -> L.ByteString
+toHtmlWith props = toLazyByteString . renderBuilder props
 ----------------------------------------------------------------------------
 intercalate :: Builder -> [Builder] -> Builder
 intercalate _ [] = ""
@@ -216,19 +232,7 @@ renderBuilder _ (VComp someComp) =
 #endif
 renderBuilder _ (VCompStatic (StaticMount ptr props0)) =
   case deRefStaticPtr ptr of
-   SomeStaticComponent mk -> case mk props0 of
-    SomeComponent _key props comp_ ->
-      -- The app-global @context@ is read from 'globalContext'. For the common
-      -- @context ~ ()@ case the 'Miso.Lens.view' ignores it, so the initial @undefined@ is
-      -- never forced. But if a 'Miso.Lens.view' here inspects a non-trivial @context@,
-      -- SSR must seed the cell with 'Miso.setContext' before serializing, or
-      -- forcing @ctx@ raises an exception. See 'Miso.setContext' for details.
-      let ctx = unsafePerformIO (readIORef globalContext) in
-#ifdef SSR
-      renderBuilder props (view comp_ ctx props (getInitialComponentModel comp_))
-#else
-      renderBuilder props (view comp_ ctx props (model comp_))
-#endif
+    SomeStaticComponent mk -> renderBuilder () (VComp (mk props0))
 renderBuilder props_ (VFrag _ kids) = foldMap (renderBuilder props_) kids
 renderBuilder props_ (VContext f) =
   let ctx = unsafePerformIO (readIORef globalContext) in

--- a/src/Miso/Html/Render.hs
+++ b/src/Miso/Html/Render.hs
@@ -213,7 +213,7 @@ renderBuilder _ (VComp someComp) =
 #else
       renderBuilder props (view comp_ ctx props (model comp_))
 #endif
-renderBuilder _ (VCompStatic ptr props0) =
+renderBuilder _ (VCompStatic (StaticMount ptr props0)) =
   case deRefStaticPtr ptr of
    SomeStaticComponent mk -> case mk props0 of
     SomeComponent _key props comp_ ->

--- a/src/Miso/Mathml.hs
+++ b/src/Miso/Mathml.hs
@@ -14,7 +14,7 @@
 -- __Example__ — render /x²/:
 --
 -- @
--- xSquared :: View context action
+-- xSquared :: View context props model action
 -- xSquared =
 --   math_ []
 --     [ msup_ []

--- a/src/Miso/Mathml/Element.hs
+++ b/src/Miso/Mathml/Element.hs
@@ -103,186 +103,186 @@ import           Miso.Types
 -----------------------------------------------------------------------------
 -- | Low-level helper used to construct 'MATHML' 'node' in 'Miso.Types.View'.
 -- Most View helpers in this module are defined in terms of it.
-nodeMathml :: MisoString -> [Attribute model action] -> [View context model action] -> View context model action
+nodeMathml :: MisoString -> [Attribute model action] -> [View context props model action] -> View context props model action
 nodeMathml nodeName = node MATHML nodeName
 -----------------------------------------------------------------------------
 -- | [\<annotation-xml\>](https://developer.mozilla.org/en-US/docs/Web/MathML/Reference/Element/annotation-xml)
 --
 -- @since 1.9.0.0
-annotationXml_ :: [Attribute model action] -> [View context model action] -> View context model action
+annotationXml_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 annotationXml_ = nodeMathml "annotation-xml"
 -----------------------------------------------------------------------------
 -- | [\<annotation\>](https://developer.mozilla.org/en-US/docs/Web/MathML/Reference/Element/annotation)
 --
 -- @since 1.9.0.0
-annotation_ :: [Attribute model action] -> [View context model action] -> View context model action
+annotation_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 annotation_ = nodeMathml "annotation"
 -----------------------------------------------------------------------------
 -- | [\<math\>](https://developer.mozilla.org/en-US/docs/Web/MathML/Reference/Element/math)
 --
 -- @since 1.9.0.0
-math_ :: [Attribute model action] -> [View context model action] -> View context model action
+math_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 math_ = nodeMathml "math"
 -----------------------------------------------------------------------------
 -- | [\<merror\>](https://developer.mozilla.org/en-US/docs/Web/MathML/Reference/Element/merror)
 --
 -- @since 1.9.0.0
-merror_ :: [Attribute model action] -> [View context model action] -> View context model action
+merror_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 merror_ = nodeMathml "merror"
 -----------------------------------------------------------------------------
 -- | [\<mfrac\>](https://developer.mozilla.org/en-US/docs/Web/MathML/Reference/Element/mfrac)
 --
 -- @since 1.9.0.0
-mfrac_ :: [Attribute model action] -> [View context model action] -> View context model action
+mfrac_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 mfrac_ = nodeMathml "mfrac"
 -----------------------------------------------------------------------------
 -- | [\<mi\>](https://developer.mozilla.org/en-US/docs/Web/MathML/Reference/Element/mi)
 --
 -- @since 1.9.0.0
-mi_ :: [Attribute model action] -> [View context model action] -> View context model action
+mi_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 mi_ = nodeMathml "mi"
 -----------------------------------------------------------------------------
 -- | [\<mmultiscripts\>](https://developer.mozilla.org/en-US/docs/Web/MathML/Reference/Element/mmultiscripts)
 --
 -- @since 1.9.0.0
-mmultiscripts_ :: [Attribute model action] -> [View context model action] -> View context model action
+mmultiscripts_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 mmultiscripts_ = nodeMathml "mmultiscripts"
 -----------------------------------------------------------------------------
 -- | [\<mn\>](https://developer.mozilla.org/en-US/docs/Web/MathML/Reference/Element/mn)
 --
 -- @since 1.9.0.0
-mn_ :: [Attribute model action] -> [View context model action] -> View context model action
+mn_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 mn_ = nodeMathml "mn"
 -----------------------------------------------------------------------------
 -- | [\<mo\>](https://developer.mozilla.org/en-US/docs/Web/MathML/Reference/Element/mo)
 --
 -- @since 1.9.0.0
-mo_ :: [Attribute model action] -> [View context model action] -> View context model action
+mo_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 mo_ = nodeMathml "mo"
 -----------------------------------------------------------------------------
 -- | [\<mover\>](https://developer.mozilla.org/en-US/docs/Web/MathML/Reference/Element/mover)
 --
 -- @since 1.9.0.0
-mover_ :: [Attribute model action] -> [View context model action] -> View context model action
+mover_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 mover_ = nodeMathml "mover"
 -----------------------------------------------------------------------------
 -- | [\<mpadded\>](https://developer.mozilla.org/en-US/docs/Web/MathML/Reference/Element/mpadded)
 --
 -- @since 1.9.0.0
-mpadded_ :: [Attribute model action] -> [View context model action] -> View context model action
+mpadded_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 mpadded_ = nodeMathml "mpadded"
 -----------------------------------------------------------------------------
 -- | [\<mphantom\>](https://developer.mozilla.org/en-US/docs/Web/MathML/Reference/Element/mphantom)
 --
 -- @since 1.9.0.0
-mphantom_ :: [Attribute model action] -> [View context model action] -> View context model action
+mphantom_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 mphantom_ = nodeMathml "mphantom"
 -----------------------------------------------------------------------------
 -- | [\<mprescripts\>](https://developer.mozilla.org/en-US/docs/Web/MathML/Reference/Element/mprescripts)
 --
 -- @since 1.9.0.0
-mprescripts_ :: [Attribute model action] -> [View context model action] -> View context model action
+mprescripts_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 mprescripts_ = nodeMathml "mprescripts"
 -----------------------------------------------------------------------------
 -- | [\<mroot\>](https://developer.mozilla.org/en-US/docs/Web/MathML/Reference/Element/mroot)
 --
 -- @since 1.9.0.0
-mroot_ :: [Attribute model action] -> [View context model action] -> View context model action
+mroot_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 mroot_ = nodeMathml "mroot"
 -----------------------------------------------------------------------------
 -- | [\<mrow\>](https://developer.mozilla.org/en-US/docs/Web/MathML/Reference/Element/mrow)
 --
 -- @since 1.9.0.0
-mrow_ :: [Attribute model action] -> [View context model action] -> View context model action
+mrow_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 mrow_ = nodeMathml "mrow"
 -----------------------------------------------------------------------------
 -- | [\<ms\>](https://developer.mozilla.org/en-US/docs/Web/MathML/Reference/Element/ms)
 --
 -- @since 1.9.0.0
-ms_ :: [Attribute model action] -> [View context model action] -> View context model action
+ms_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 ms_ = nodeMathml "ms"
 -----------------------------------------------------------------------------
 -- | [\<mspace\>](https://developer.mozilla.org/en-US/docs/Web/MathML/Reference/Element/mspace)
 --
 -- @since 1.9.0.0
-mspace_ :: [Attribute model action] -> [View context model action] -> View context model action
+mspace_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 mspace_ = nodeMathml "mspace"
 -----------------------------------------------------------------------------
 -- | [\<msqrt\>](https://developer.mozilla.org/en-US/docs/Web/MathML/Reference/Element/msqrt)
 --
 -- @since 1.9.0.0
-msqrt_ :: [Attribute model action] -> [View context model action] -> View context model action
+msqrt_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 msqrt_ = nodeMathml "msqrt"
 -----------------------------------------------------------------------------
 -- | [\<mstyle\>](https://developer.mozilla.org/en-US/docs/Web/MathML/Reference/Element/mstyle)
 --
 -- @since 1.9.0.0
-mstyle_ :: [Attribute model action] -> [View context model action] -> View context model action
+mstyle_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 mstyle_ = nodeMathml "mstyle"
 -----------------------------------------------------------------------------
 -- | [\<msub\>](https://developer.mozilla.org/en-US/docs/Web/MathML/Reference/Element/msub)
 --
 -- @since 1.9.0.0
-msub_ :: [Attribute model action] -> [View context model action] -> View context model action
+msub_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 msub_ = nodeMathml "msub"
 -----------------------------------------------------------------------------
 -- | [\<msubsup\>](https://developer.mozilla.org/en-US/docs/Web/MathML/Reference/Element/msubsup)
 --
 -- @since 1.9.0.0
-msubsup_ :: [Attribute model action] -> [View context model action] -> View context model action
+msubsup_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 msubsup_ = nodeMathml "msubsup"
 -----------------------------------------------------------------------------
 -- | [\<msup\>](https://developer.mozilla.org/en-US/docs/Web/MathML/Reference/Element/msup)
 --
 -- @since 1.9.0.0
-msup_ :: [Attribute model action] -> [View context model action] -> View context model action
+msup_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 msup_ = nodeMathml "msup"
 -----------------------------------------------------------------------------
 -- | [\<mtable\>](https://developer.mozilla.org/en-US/docs/Web/MathML/Reference/Element/mtable)
 --
 -- @since 1.9.0.0
-mtable_ :: [Attribute model action] -> [View context model action] -> View context model action
+mtable_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 mtable_ = nodeMathml "mtable"
 -----------------------------------------------------------------------------
 -- | [\<mtd\>](https://developer.mozilla.org/en-US/docs/Web/MathML/Reference/Element/mtd)
 --
 -- @since 1.9.0.0
-mtd_ :: [Attribute model action] -> [View context model action] -> View context model action
+mtd_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 mtd_ = nodeMathml "mtd"
 -----------------------------------------------------------------------------
 -- | [\<mtext\>](https://developer.mozilla.org/en-US/docs/Web/MathML/Reference/Element/mtext)
 --
 -- @since 1.9.0.0
-mtext_ :: [Attribute model action] -> [View context model action] -> View context model action
+mtext_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 mtext_ = nodeMathml "mtext"
 -----------------------------------------------------------------------------
 -- | [\<mtr\>](https://developer.mozilla.org/en-US/docs/Web/MathML/Reference/Element/mtr)
 --
 -- @since 1.9.0.0
-mtr_ :: [Attribute model action] -> [View context model action] -> View context model action
+mtr_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 mtr_ = nodeMathml "mtr"
 -----------------------------------------------------------------------------
 -- | [\<munder\>](https://developer.mozilla.org/en-US/docs/Web/MathML/Reference/Element/munder)
 --
 -- @since 1.9.0.0
-munder_ :: [Attribute model action] -> [View context model action] -> View context model action
+munder_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 munder_ = nodeMathml "munder"
 -----------------------------------------------------------------------------
 -- | [\<munderover\>](https://developer.mozilla.org/en-US/docs/Web/MathML/Reference/Element/munderover)
 --
 -- @since 1.9.0.0
-munderover_ :: [Attribute model action] -> [View context model action] -> View context model action
+munderover_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 munderover_ = nodeMathml "munderover"
 -----------------------------------------------------------------------------
 -- | [\<semantics\>](https://developer.mozilla.org/en-US/docs/Web/MathML/Reference/Element/semantics)
 --
 -- @since 1.9.0.0
-semantics_ :: [Attribute model action] -> [View context model action] -> View context model action
+semantics_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 semantics_ = nodeMathml "semantics"
 -----------------------------------------------------------------------------
 -- | [\<semantics\>](https://developer.mozilla.org/en-US/docs/Web/MathML/Reference/Element/mfenced)
 --
 -- @since 1.9.0.0
-mfenced_ :: [Attribute model action] -> [View context model action] -> View context model action
+mfenced_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 mfenced_ = nodeMathml "mfenced"
 -----------------------------------------------------------------------------

--- a/src/Miso/Native/Element.hs
+++ b/src/Miso/Native/Element.hs
@@ -41,7 +41,7 @@ import           Miso.Types (View, Attribute, node, nodeDirectEvents, Namespace(
 -----------------------------------------------------------------------------
 -- | Smart constructor for constructing a built-in lynx element.
 --
-lynx_ :: MisoString -> [Attribute model action] -> [View context model action] -> View context model action
+lynx_ :: MisoString -> [Attribute model action] -> [View context props model action] -> View context props model action
 lynx_ = node HTML
 -----------------------------------------------------------------------------
 -- | Like 'lynx_', but declares the events this element dispatches /directly/ on
@@ -55,8 +55,8 @@ lynxDirect_
   -> MisoString
   -- ^ Tag name
   -> [Attribute model action]
-  -> [View context model action]
-  -> View context model action
+  -> [View context props model action]
+  -> View context props model action
 lynxDirect_ direct tag attrs kids = nodeDirectEvents HTML tag attrs direct kids
 -----------------------------------------------------------------------------
 -- | <https://lynxjs.org/api/elements/built-in/page.html>
@@ -70,7 +70,7 @@ lynxDirect_ direct tag attrs kids = nodeDirectEvents HTML tag attrs direct kids
 -- only be one @page@ present at at time. We include it here for completeness,
 -- and because @page@ functionality might change in the future.
 --
-page_ :: [Attribute model action] -> [View context model action] -> View context model action
+page_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 page_ = lynx_ "page"
 -----------------------------------------------------------------------------
 -- | <https://lynxjs.org/api/elements/built-in/scroll-view.html>
@@ -79,7 +79,7 @@ page_ = lynx_ "page"
 -- for all other elements; its attributes, events, and methods can be
 -- used in other elements.
 --
-scrollView_ :: [Attribute model action] -> [View context model action] -> View context model action
+scrollView_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 scrollView_ = lynxDirect_
   [ "scroll", "scrolltoupper", "scrolltolower", "scrollend", "contentsizechanged" ]
   "scroll-view"
@@ -90,7 +90,7 @@ scrollView_ = lynxDirect_
 -- for all other elements; its attributes, events, and methods can be
 -- used in other elements.
 --
-view_ :: [Attribute model action] -> [View context model action] -> View context model action
+view_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 view_ = lynx_ "view"
 -----------------------------------------------------------------------------
 -- | <https://lynxjs.org/api/elements/built-in/image.html>
@@ -112,19 +112,19 @@ view_ = lynx_ "view"
 --
 -- > image_ "https://url.com/image.png" []
 --
-image_ :: MisoString -> [Attribute model action] -> View context model action
+image_ :: MisoString -> [Attribute model action] -> View context props model action
 image_ url attrs = lynxDirect_
   [ "load", "error", "startplay", "currentloopcomplete", "finalloopcomplete" ]
   "image" (textProp "src" url : attrs) []
 -----------------------------------------------------------------------------
 -- | <https://lynxjs.org/api/elements/built-in/list.html>
 --
-listItem_ :: [Attribute model action] -> [View context model action] -> View context model action
+listItem_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 listItem_ = lynx_ "list-item"
 -----------------------------------------------------------------------------
 -- | <https://lynxjs.org/api/elements/built-in/list.html>
 --
-list_ :: ListOptions -> [Attribute model action] -> [View context model action] -> View context model action
+list_ :: ListOptions -> [Attribute model action] -> [View context props model action] -> View context props model action
 list_ ListOptions {..} attrs = lynxDirect_
   [ "scroll", "scrolltoupper", "scrolltolower", "scrollstatechange", "layoutcomplete", "snap" ]
   "list" (defaults <> attrs)
@@ -142,7 +142,7 @@ list_ ListOptions {..} attrs = lynxDirect_
 -- nest <text>, <image>, and <view> components to achieve relatively complex
 -- text and image content presentation.
 --
-text_ :: [Attribute model action] -> [View context model action] -> View context model action
+text_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 text_ = lynxDirect_ [ "layout", "selectionchange" ] "text"
 -----------------------------------------------------------------------------
 -- | <https://lynxjs.org/api/elements/built-in/frame.html>
@@ -150,6 +150,6 @@ text_ = lynxDirect_ [ "layout", "selectionchange" ] "text"
 -- A page element similar to HTML's \<iframe\>, which can embed a Lynx page
 -- into the current page.
 --
-frame_ :: [Attribute model action] -> View context model action
+frame_ :: [Attribute model action] -> View context props model action
 frame_ attrs = lynxDirect_ [ "load", "loadmetrics" ] "frame" attrs []
 -----------------------------------------------------------------------------

--- a/src/Miso/Native/X/Element.hs
+++ b/src/Miso/Native/X/Element.hs
@@ -57,14 +57,14 @@ import           Miso.Types (View, Attribute)
 --
 -- Single-line text input element. Does not support children.
 --
-input_ :: [Attribute model action] -> View context model action
+input_ :: [Attribute model action] -> View context props model action
 input_ attrs = lynxDirect_ inputDirectEvents "input" attrs []
 -----------------------------------------------------------------------------
 -- | <https://lynxjs.org/api/elements/built-in/textarea.html>
 --
 -- Multi-line text input element. Does not support children.
 --
-textarea_ :: [Attribute model action] -> View context model action
+textarea_ :: [Attribute model action] -> View context props model action
 textarea_ attrs = lynxDirect_ inputDirectEvents "textarea" attrs []
 -----------------------------------------------------------------------------
 -- | Events that @input@ and @textarea@ dispatch directly on the element (Lynx
@@ -76,7 +76,7 @@ inputDirectEvents = [ "blur", "confirm", "focus", "input", "selection" ]
 --
 -- Renders its children on an independent layer above the page.
 --
-overlay_ :: [Attribute model action] -> [View context model action] -> View context model action
+overlay_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 overlay_ = lynxDirect_
   [ "dismissoverlay", "error", "overlaytouch", "requestclose", "showoverlay" ]
   "overlay"
@@ -86,7 +86,7 @@ overlay_ = lynxDirect_
 -- Displays SVG content, supplied either inline via @content_@ or by URL via
 -- @src_@.
 --
-svg_ :: [Attribute model action] -> [View context model action] -> View context model action
+svg_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 svg_ = lynxDirect_ [ "load" ] "svg"
 -----------------------------------------------------------------------------
 -- | <https://lynxjs.org/api/elements/built-in/refresh.html>
@@ -94,7 +94,7 @@ svg_ = lynxDirect_ [ "load" ] "svg"
 -- Pull-to-refresh container. Wraps a @refreshHeader_@ and a vertically
 -- scrollable child.
 --
-refresh_ :: [Attribute model action] -> [View context model action] -> View context model action
+refresh_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 refresh_ = lynxDirect_
   [ "headeroffset", "refreshstatechange", "startrefresh" ]
   "refresh"
@@ -103,21 +103,21 @@ refresh_ = lynxDirect_
 --
 -- Customizable header revealed during the pull gesture of a @refresh_@.
 --
-refreshHeader_ :: [Attribute model action] -> [View context model action] -> View context model action
+refreshHeader_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 refreshHeader_ = lynx_ "refresh-header"
 -----------------------------------------------------------------------------
 -- | <https://lynxjs.org/api/elements/built-in/viewpager.html>
 --
 -- Horizontally paged container. Each page is a @viewpagerItem_@.
 --
-viewpager_ :: [Attribute model action] -> [View context model action] -> View context model action
+viewpager_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 viewpager_ = lynxDirect_ [ "change", "offsetchange", "willchange" ] "viewpager"
 -----------------------------------------------------------------------------
 -- | <https://lynxjs.org/api/elements/built-in/viewpager.html>
 --
 -- A single page within a @viewpager_@.
 --
-viewpagerItem_ :: [Attribute model action] -> [View context model action] -> View context model action
+viewpagerItem_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 viewpagerItem_ = lynx_ "viewpager-item"
 -----------------------------------------------------------------------------
 -- | <https://lynxjs.org/api/elements/built-in/scroll-coordinator.html>
@@ -125,7 +125,7 @@ viewpagerItem_ = lynx_ "viewpager-item"
 -- Coordinates nested scrolling, typically used with sticky headers and
 -- tabbed layouts.
 --
-scrollCoordinator_ :: [Attribute model action] -> [View context model action] -> View context model action
+scrollCoordinator_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 scrollCoordinator_ = lynxDirect_ [ "offset" ] "scroll-coordinator"
 -----------------------------------------------------------------------------
 -- | <https://lynxjs.org/api/elements/built-in/scroll-coordinator.html>
@@ -133,7 +133,7 @@ scrollCoordinator_ = lynxDirect_ [ "offset" ] "scroll-coordinator"
 -- The collapsing header of a @scrollCoordinator_@. Folds away as the slot
 -- content scrolls. Required (together with @scrollCoordinatorSlot_@).
 --
-scrollCoordinatorHeader_ :: [Attribute model action] -> [View context model action] -> View context model action
+scrollCoordinatorHeader_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 scrollCoordinatorHeader_ = lynx_ "scroll-coordinator-header"
 -----------------------------------------------------------------------------
 -- | <https://lynxjs.org/api/elements/built-in/scroll-coordinator.html>
@@ -142,7 +142,7 @@ scrollCoordinatorHeader_ = lynx_ "scroll-coordinator-header"
 -- header fold. Holds the scrollable child (e.g. a @scrollView_@). Required
 -- (together with @scrollCoordinatorHeader_@).
 --
-scrollCoordinatorSlot_ :: [Attribute model action] -> [View context model action] -> View context model action
+scrollCoordinatorSlot_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 scrollCoordinatorSlot_ = lynx_ "scroll-coordinator-slot"
 -----------------------------------------------------------------------------
 -- | <https://lynxjs.org/api/elements/built-in/scroll-coordinator.html>
@@ -150,21 +150,21 @@ scrollCoordinatorSlot_ = lynx_ "scroll-coordinator-slot"
 -- An optional sticky bar of a @scrollCoordinator_@ that stays pinned while the
 -- header folds (e.g. tabs above the content).
 --
-scrollCoordinatorToolbar_ :: [Attribute model action] -> [View context model action] -> View context model action
+scrollCoordinatorToolbar_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 scrollCoordinatorToolbar_ = lynx_ "scroll-coordinator-toolbar"
 -----------------------------------------------------------------------------
 -- | <https://lynxjs.org/api/elements/built-in/blur-view.html>
 --
 -- Applies a Gaussian blur / material effect to the content behind it.
 --
-blurView_ :: [Attribute model action] -> [View context model action] -> View context model action
+blurView_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 blurView_ = lynx_ "blur-view"
 -----------------------------------------------------------------------------
 -- | <https://lynxjs.org/api/elements/built-in/webview.html>
 --
 -- Embeds a web page. Does not support children.
 --
-webview_ :: [Attribute model action] -> View context model action
+webview_ :: [Attribute model action] -> View context props model action
 webview_ attrs = lynxDirect_
   [ "error", "load", "locationchange", "message", "openwindow" ]
   "webview" attrs []
@@ -173,6 +173,6 @@ webview_ attrs = lynxDirect_
 --
 -- Defines a custom draggable window region (Clay Windows / macOS).
 --
-titleBarView_ :: [Attribute model action] -> [View context model action] -> View context model action
+titleBarView_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 titleBarView_ = lynx_ "title-bar-view"
 -----------------------------------------------------------------------------

--- a/src/Miso/Native/X/Element/Svg/Property.hs
+++ b/src/Miso/Native/X/Element/Svg/Property.hs
@@ -47,7 +47,11 @@ contentRaw_ = textProp "content"
 -- 'Miso.Types.vprops' inside the content:
 --
 -- > withProps $ \Props { color } ->
--- >   svg_ [ content_ (circle_ [ fill_ color ] []) ] []
+-- >   svg_
+-- >     [ content_ $ Svg.svg_ [ textProp "xmlns" "http://www.w3.org/2000/svg" ]
+-- >         [ Svg.circle_ [ Svg.fill_ color ] [] ]
+-- >     ]
+-- >     []
 --
 content_ :: View context () model action -> Attribute model action
 content_ = textProp "content" . ms . toHtml

--- a/src/Miso/Native/X/Element/Svg/Property.hs
+++ b/src/Miso/Native/X/Element/Svg/Property.hs
@@ -40,7 +40,7 @@ contentRaw_ = textProp "content"
 --
 -- N.B. Must use "Miso.Svg" and 'Miso.Svg.Element.svg_' combinator.
 --
-content_ :: View context model action -> Attribute model action
+content_ :: View context () model action -> Attribute model action
 content_ = textProp "content" . ms . toHtml
 -----------------------------------------------------------------------------
 -- | https://lynxjs.org/api/elements/built-in/svg.html#src

--- a/src/Miso/Native/X/Element/Svg/Property.hs
+++ b/src/Miso/Native/X/Element/Svg/Property.hs
@@ -14,6 +14,7 @@
 module Miso.Native.X.Element.Svg.Property
   ( -- *** Property
     content_
+  , contentWith_
   , contentRaw_
   , src_
   ) where
@@ -21,7 +22,7 @@ module Miso.Native.X.Element.Svg.Property
 import           Miso.String (MisoString, ms)
 import           Miso.Types (Attribute, View)
 import           Miso.Property
-import           Miso.Html.Render (toHtml)
+import           Miso.Html.Render (toHtmlWith)
 -----------------------------------------------------------------------------
 -- | https://lynxjs.org/api/elements/built-in/svg.html#content
 --
@@ -41,7 +42,18 @@ contentRaw_ = textProp "content"
 -- N.B. Must use "Miso.Svg" and 'Miso.Svg.Element.svg_' combinator.
 --
 content_ :: View context () model action -> Attribute model action
-content_ = textProp "content" . ms . toHtml
+content_ = contentWith_ ()
+-----------------------------------------------------------------------------
+-- | Like 'content_', but for a 'Miso.Types.View' whose @props@ type is not
+-- @()@ — e.g. one containing a 'Miso.Types.vprops' node. The @props@ value
+-- is what those nodes resolve against; the caller is always inside
+-- 'Miso.Types.view', where it is in scope.
+--
+-- > contentWith_ props (svg_ [] [ vprops $ \Props { color } -> circle_ [ fill_ color ] [] ])
+--
+-- @since 1.14.0.0
+contentWith_ :: props -> View context props model action -> Attribute model action
+contentWith_ props = textProp "content" . ms . toHtmlWith props
 -----------------------------------------------------------------------------
 -- | https://lynxjs.org/api/elements/built-in/svg.html#src
 --

--- a/src/Miso/Native/X/Element/Svg/Property.hs
+++ b/src/Miso/Native/X/Element/Svg/Property.hs
@@ -14,7 +14,6 @@
 module Miso.Native.X.Element.Svg.Property
   ( -- *** Property
     content_
-  , contentWith_
   , contentRaw_
   , src_
   ) where
@@ -22,7 +21,7 @@ module Miso.Native.X.Element.Svg.Property
 import           Miso.String (MisoString, ms)
 import           Miso.Types (Attribute, View)
 import           Miso.Property
-import           Miso.Html.Render (toHtmlWith)
+import           Miso.Html.Render (toHtml)
 -----------------------------------------------------------------------------
 -- | https://lynxjs.org/api/elements/built-in/svg.html#content
 --
@@ -35,25 +34,23 @@ contentRaw_ = textProp "content"
 -----------------------------------------------------------------------------
 -- | https://lynxjs.org/api/elements/built-in/svg.html#content
 --
--- Inline SVG XML content using 'Miso.miso' 'Miso.Typess.View' Syntax.
+-- Inline SVG XML content using 'Miso.miso' 'Miso.Types.View' Syntax.
 --
 -- > content_ (svg_ [] [])
 --
 -- N.B. Must use "Miso.Svg" and 'Miso.Svg.Element.svg_' combinator.
 --
+-- The content is serialised to a string when the attribute is built, so the
+-- 'Miso.Types.View' has no enclosing component to take @props@ from and its
+-- @props@ are fixed to @()@. To draw from the component's @props@, lift
+-- 'Miso.Types.withProps' above the element instead of using
+-- 'Miso.Types.vprops' inside the content:
+--
+-- > withProps $ \Props { color } ->
+-- >   svg_ [ content_ (circle_ [ fill_ color ] []) ] []
+--
 content_ :: View context () model action -> Attribute model action
-content_ = contentWith_ ()
------------------------------------------------------------------------------
--- | Like 'content_', but for a 'Miso.Types.View' whose @props@ type is not
--- @()@ — e.g. one containing a 'Miso.Types.vprops' node. The @props@ value
--- is what those nodes resolve against; the caller is always inside
--- 'Miso.Types.view', where it is in scope.
---
--- > contentWith_ props (svg_ [] [ vprops $ \Props { color } -> circle_ [ fill_ color ] [] ])
---
--- @since 1.14.0.0
-contentWith_ :: props -> View context props model action -> Attribute model action
-contentWith_ props = textProp "content" . ms . toHtmlWith props
+content_ = textProp "content" . ms . toHtml
 -----------------------------------------------------------------------------
 -- | https://lynxjs.org/api/elements/built-in/svg.html#src
 --

--- a/src/Miso/Runtime.hs
+++ b/src/Miso/Runtime.hs
@@ -1250,7 +1250,7 @@ buildVTree
 buildVTree events_ parentId_ vcompId hydrate live snk logLevel_ props_ model_ = \case
   VComp someComp -> buildComp Nothing someComp
 
-  VCompStatic (StaticMount ptr props) -> case deRefStaticPtr ptr of
+  VCompStatic ptr props -> case deRefStaticPtr ptr of
     SomeStaticComponent mk -> buildComp (Just (staticKey ptr)) (mk props)
 
   VNode ns tag attrs kids _directEvents -> do

--- a/src/Miso/Runtime.hs
+++ b/src/Miso/Runtime.hs
@@ -1261,7 +1261,7 @@ buildVTree events_ parentId_ vcompId hydrate live snk logLevel_ props_ model_ = 
     -- never reads it (all HTML/SVG/MathML nodes carry an empty set anyway).
     FFI.set "directEvents" (Set.toList _directEvents) vnode_
 #endif
-    children_ <- procreate vnode_
+    children_ <- procreate vnode_ kids
     vchildren <- toJSVal (map snd children_)
     FFI.set "children" vchildren vnode_
     nodeType <- toJSVal VNodeType
@@ -1272,25 +1272,6 @@ buildVTree events_ parentId_ vcompId hydrate live snk logLevel_ props_ model_ = 
     freeJSVal vchildren
     mapM_ freeKid children_
     pure (VTree vnode_)
-      where
-        procreate parentVTree = do
-          kidsViews <- foldM (buildKid parentVTree) [] kids
-          let ordered = reverse kidsViews
-          setNextSibling (map snd ordered)
-          pure ordered
-            where
-              setNextSibling xs =
-                zipWithM_ (flip setField "nextSibling")
-                  xs (drop 1 xs)
-              -- Resolve wrapper nodes first so 'freeable' (and the empty
-              -- fragment skip below) see the constructor they resolve to.
-              buildKid p acc (VProps f) = buildKid p acc (f props_)
-              buildKid p acc (VContext f) = buildKid p acc . f =<< readIORef @context globalContext
-              buildKid _ acc (VFrag _ []) = pure acc
-              buildKid p acc kid = do
-                VTree child <- go kid
-                FFI.set "parent" p child
-                pure ((kid, child) : acc)
   VText key t -> do
     vtree <- create
     flip (FFI.set "type") vtree =<< toJSVal VTextType
@@ -1302,34 +1283,54 @@ buildVTree events_ parentId_ vcompId hydrate live snk logLevel_ props_ model_ = 
     frag <- create
     FFI.set "type" VFragType frag
     forM_ maybeKey $ \(Key k) -> FFI.set "key" k frag
-    children_ <- procreateFragChildren frag
+    children_ <- procreate frag kids
     vchildren <- toJSVal (map snd children_)
     FFI.set "children" vchildren frag
     freeJSVal vchildren
     mapM_ freeKid children_
     pure (VTree frag)
-      where
-        procreateFragChildren parentVTree = do
-          kidsViews <- foldM buildKid [] kids
-          let ordered = reverse kidsViews
-          zipWithM_ (flip setField "nextSibling") (map snd ordered) (drop 1 (map snd ordered))
-          pure ordered
-            where
-              buildKid acc (VProps f) = buildKid acc (f props_)
-              buildKid acc (VContext f) = buildKid acc . f =<< readIORef @context globalContext
-              buildKid acc (VFrag _ []) = pure acc
-              buildKid acc kid = do
-                VTree child <- go kid
-                FFI.set "parent" parentVTree child
-                pure ((kid, child) : acc)
 
-  VContext f -> go . f =<< readIORef @context globalContext
+  v@VContext {} -> go =<< resolve v
 
-  VProps f -> go (f props_)
+  v@VProps {} -> go =<< resolve v
   where
     -- Recurse with every argument but the 'View' unchanged.
     go :: View context props model action -> IO VTree
     go = buildVTree events_ parentId_ vcompId hydrate live snk logLevel_ props_ model_
+
+    -- Look through the wrapper constructors ('VProps', 'VContext') to the
+    -- node they resolve to. Every child goes through this before it is
+    -- built, so 'freeable' decides on the real constructor and a wrapper
+    -- resolving to @fragment []@ hits the empty-fragment skip in 'buildKid'.
+    resolve :: View context props model action -> IO (View context props model action)
+    resolve = \case
+      VProps f -> resolve (f props_)
+      VContext f -> resolve . f =<< readIORef @context globalContext
+      v -> pure v
+
+    -- Build @kids@ under @parent@ in order, link each to its next sibling,
+    -- and return them paired with their JS handles for 'freeKid'.
+    procreate
+      :: Object
+      -> [View context props model action]
+      -> IO [(View context props model action, Object)]
+    procreate parent kids = do
+      ordered <- reverse <$> foldM (buildKid parent) [] kids
+      zipWithM_ (flip setField "nextSibling") (map snd ordered) (drop 1 (map snd ordered))
+      pure ordered
+
+    -- Build one (resolved) child and link it to @parent@; accumulates in reverse.
+    buildKid
+      :: Object
+      -> [(View context props model action, Object)]
+      -> View context props model action
+      -> IO [(View context props model action, Object)]
+    buildKid parent acc kid0 = resolve kid0 >>= \case
+      VFrag _ [] -> pure acc
+      kid -> do
+        VTree child <- go kid
+        FFI.set "parent" parent child
+        pure ((kid, child) : acc)
 
     -- Note [Freeing VTree handles]
     -- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1357,6 +1358,8 @@ buildVTree events_ parentId_ vcompId hydrate live snk logLevel_ props_ model_ = 
       VFrag {} -> True
       VComp {} -> False
       VCompStatic {} -> False
+      -- Never reached: 'buildKid' resolves wrappers before building, so a
+      -- 'freeKid' pair always holds the resolved node. Conservative anyway.
       VContext {} -> False
       VProps {} -> False
 

--- a/src/Miso/Runtime.hs
+++ b/src/Miso/Runtime.hs
@@ -1250,7 +1250,7 @@ buildVTree
 buildVTree events_ parentId_ vcompId hydrate live snk logLevel_ props_ model_ = \case
   VComp someComp -> buildComp Nothing someComp
 
-  VCompStatic ptr props -> case deRefStaticPtr ptr of
+  VCompStatic (StaticMount ptr props) -> case deRefStaticPtr ptr of
     SomeStaticComponent mk -> buildComp (Just (staticKey ptr)) (mk props)
 
   VNode ns tag attrs kids _directEvents -> do

--- a/src/Miso/Runtime.hs
+++ b/src/Miso/Runtime.hs
@@ -261,7 +261,7 @@ initialize events _componentParentId hydrate isRoot live initialProps maybeKey _
         currentContext <- readIORef globalContext
         newVTree <-
           buildVTree events _componentParentId _componentId Draw live
-            _componentSink logLevel newModel (view currentContext currentProps newModel)
+            _componentSink logLevel currentProps newModel (view currentContext currentProps newModel)
         newHandlers <- collectEventHandlers
         oldVTree <- readIORef _componentVTree
         _frame <- requestAnimationFrame rAFCallback
@@ -532,7 +532,7 @@ initialDraw initializedModel events hydrate isRoot live Component {..} Component
 #endif
   currentContext <- readIORef globalContext
   vtree <- buildVTree events _componentParentId _componentId hydrate live _componentSink logLevel
-    initializedModel (view currentContext _componentProps initializedModel)
+    _componentProps initializedModel (view currentContext _componentProps initializedModel)
   vtreeHandlers0 <- collectEventHandlers
 #ifdef BENCH
   end <- FFI.now
@@ -554,7 +554,7 @@ initialDraw initializedModel events hydrate isRoot live Component {..} Component
             else do
               newTree <-
                 buildVTree events _componentParentId _componentId Draw live
-                  _componentSink logLevel initializedModel (view currentContext _componentProps initializedModel)
+                  _componentSink logLevel _componentProps initializedModel (view currentContext _componentProps initializedModel)
               newHandlers <- collectEventHandlers
               -- the discarded hydration tree's callbacks are unreachable
               mapM_ freeFunction vtreeHandlers0
@@ -1232,7 +1232,7 @@ unmountComponent cs@ComponentState {..} = do
 -- infrastructure for each sub-component. During this
 -- process we go between the Haskell heap and the JS heap.
 buildVTree
-  :: forall context model action . Eq context
+  :: forall context props model action . Eq context
   => Events
   -> ComponentId
   -> ComponentId
@@ -1242,10 +1242,12 @@ buildVTree
   -- mounting child components.
   -> Sink action
   -> LogLevel
+  -> props
+  -- ^ The mounting component's current @props@, resolved by 'VProps'.
   -> model
-  -> View context model action
+  -> View context props model action
   -> IO VTree
-buildVTree events_ parentId_ vcompId hydrate live snk logLevel_ model_ = \case
+buildVTree events_ parentId_ vcompId hydrate live snk logLevel_ props_ model_ = \case
   VComp someComp -> buildComp Nothing someComp
 
   VCompStatic ptr props -> case deRefStaticPtr ptr of
@@ -1282,7 +1284,7 @@ buildVTree events_ parentId_ vcompId hydrate live snk logLevel_ model_ = \case
                   xs (drop 1 xs)
               buildKid _ acc (VFrag _ []) = pure acc
               buildKid p acc kid = do
-                VTree child <- buildVTree events_ parentId_ vcompId hydrate live snk logLevel_ model_ kid
+                VTree child <- buildVTree events_ parentId_ vcompId hydrate live snk logLevel_ props_ model_ kid
                 FFI.set "parent" p child
                 pure ((kid, child) : acc)
   VText key t -> do
@@ -1311,13 +1313,16 @@ buildVTree events_ parentId_ vcompId hydrate live snk logLevel_ model_ = \case
             where
               buildKid acc (VFrag _ []) = pure acc
               buildKid acc kid = do
-                VTree child <- buildVTree events_ parentId_ vcompId hydrate live snk logLevel_ model_ kid
+                VTree child <- buildVTree events_ parentId_ vcompId hydrate live snk logLevel_ props_ model_ kid
                 FFI.set "parent" parentVTree child
                 pure ((kid, child) : acc)
 
   VContext f -> do
     ctx <- readIORef @context globalContext
-    buildVTree events_ parentId_ vcompId hydrate live snk logLevel_ model_ (f ctx)
+    buildVTree events_ parentId_ vcompId hydrate live snk logLevel_ props_ model_ (f ctx)
+
+  VProps f ->
+    buildVTree events_ parentId_ vcompId hydrate live snk logLevel_ props_ model_ (f props_)
   where
     -- Note [Freeing VTree handles]
     -- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1335,10 +1340,10 @@ buildVTree events_ parentId_ vcompId hydrate live snk logLevel_ model_ = \case
     --    component object.
     --
     -- The root handle is returned to the caller and is never freed here.
-    freeKid :: (View context model action, Object) -> IO ()
+    freeKid :: (View context props model action, Object) -> IO ()
     freeKid (kid, Object child) = when (freeable kid) (freeJSVal child)
 
-    freeable :: View context model action -> Bool
+    freeable :: View context props model action -> Bool
     freeable = \case
       VNode _ _ attrs _ _ -> not (any isEvent attrs)
       VText {} -> True
@@ -1346,6 +1351,7 @@ buildVTree events_ parentId_ vcompId hydrate live snk logLevel_ model_ = \case
       VComp {} -> False
       VCompStatic {} -> False
       VContext {} -> False
+      VProps {} -> False
 
     isEvent :: Attribute model action -> Bool
     isEvent = \case

--- a/src/Miso/Runtime.hs
+++ b/src/Miso/Runtime.hs
@@ -1282,9 +1282,13 @@ buildVTree events_ parentId_ vcompId hydrate live snk logLevel_ props_ model_ = 
               setNextSibling xs =
                 zipWithM_ (flip setField "nextSibling")
                   xs (drop 1 xs)
+              -- Resolve wrapper nodes first so 'freeable' (and the empty
+              -- fragment skip below) see the constructor they resolve to.
+              buildKid p acc (VProps f) = buildKid p acc (f props_)
+              buildKid p acc (VContext f) = buildKid p acc . f =<< readIORef @context globalContext
               buildKid _ acc (VFrag _ []) = pure acc
               buildKid p acc kid = do
-                VTree child <- buildVTree events_ parentId_ vcompId hydrate live snk logLevel_ props_ model_ kid
+                VTree child <- go kid
                 FFI.set "parent" p child
                 pure ((kid, child) : acc)
   VText key t -> do
@@ -1311,19 +1315,22 @@ buildVTree events_ parentId_ vcompId hydrate live snk logLevel_ props_ model_ = 
           zipWithM_ (flip setField "nextSibling") (map snd ordered) (drop 1 (map snd ordered))
           pure ordered
             where
+              buildKid acc (VProps f) = buildKid acc (f props_)
+              buildKid acc (VContext f) = buildKid acc . f =<< readIORef @context globalContext
               buildKid acc (VFrag _ []) = pure acc
               buildKid acc kid = do
-                VTree child <- buildVTree events_ parentId_ vcompId hydrate live snk logLevel_ props_ model_ kid
+                VTree child <- go kid
                 FFI.set "parent" parentVTree child
                 pure ((kid, child) : acc)
 
-  VContext f -> do
-    ctx <- readIORef @context globalContext
-    buildVTree events_ parentId_ vcompId hydrate live snk logLevel_ props_ model_ (f ctx)
+  VContext f -> go . f =<< readIORef @context globalContext
 
-  VProps f ->
-    buildVTree events_ parentId_ vcompId hydrate live snk logLevel_ props_ model_ (f props_)
+  VProps f -> go (f props_)
   where
+    -- Recurse with every argument but the 'View' unchanged.
+    go :: View context props model action -> IO VTree
+    go = buildVTree events_ parentId_ vcompId hydrate live snk logLevel_ props_ model_
+
     -- Note [Freeing VTree handles]
     -- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     -- On WASM each 'JSVal' handle carries a weak pointer that every GC must

--- a/src/Miso/Svg/Element.hs
+++ b/src/Miso/Svg/Element.hs
@@ -160,258 +160,258 @@ import           Miso.Types  hiding (text_)
 --
 -- > document.createElementNS('http://www.w3.org/2000/svg', 'circle');
 --
-nodeSvg :: MisoString -> [Attribute model action] -> [View context model action] -> View context model action
+nodeSvg :: MisoString -> [Attribute model action] -> [View context props model action] -> View context props model action
 nodeSvg nodeName = node SVG nodeName
 -----------------------------------------------------------------------------
 -- | [\<svg\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/svg)
-svg_ :: [Attribute model action] -> [View context model action] -> View context model action
+svg_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 svg_ = nodeSvg "svg"
 -----------------------------------------------------------------------------
 -- | [\<foreignObject\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/foreignObject)
-foreignObject_ :: [Attribute model action] -> [View context model action] -> View context model action
+foreignObject_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 foreignObject_ = nodeSvg "foreignObject"
 -----------------------------------------------------------------------------
 -- | [\<circle\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/circle)
-circle_ :: [Attribute model action] -> View context model action
+circle_ :: [Attribute model action] -> View context props model action
 circle_ = flip (nodeSvg "circle") []
 -----------------------------------------------------------------------------
 -- | [\<ellipse\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/ellipse)
-ellipse_ :: [Attribute model action] -> View context model action
+ellipse_ :: [Attribute model action] -> View context props model action
 ellipse_ = flip (nodeSvg "ellipse") []
 -----------------------------------------------------------------------------
 -- | [\<image\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/image)
-image_ :: [Attribute model action] -> View context model action
+image_ :: [Attribute model action] -> View context props model action
 image_ = flip (nodeSvg "image") []
 -----------------------------------------------------------------------------
 -- | [\<line\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/line)
-line_ :: [Attribute model action] -> View context model action
+line_ :: [Attribute model action] -> View context props model action
 line_ = flip (nodeSvg "line") []
 -----------------------------------------------------------------------------
 -- | [\<path\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/path)
-path_ :: [Attribute model action] -> View context model action
+path_ :: [Attribute model action] -> View context props model action
 path_ = flip (nodeSvg "path") []
 -----------------------------------------------------------------------------
 -- | [\<polygon\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/polygon)
-polygon_ :: [Attribute model action] -> View context model action
+polygon_ :: [Attribute model action] -> View context props model action
 polygon_ = flip (nodeSvg "polygon") []
 -----------------------------------------------------------------------------
 -- | [\<polyline\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/polyline)
-polyline_ :: [Attribute model action] -> View context model action
+polyline_ :: [Attribute model action] -> View context props model action
 polyline_ = flip (nodeSvg "polyline") []
 -----------------------------------------------------------------------------
 -- | [\<rect\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/rect)
-rect_ :: [Attribute model action] -> View context model action
+rect_ :: [Attribute model action] -> View context props model action
 rect_ = flip (nodeSvg "rect") []
 -----------------------------------------------------------------------------
 -- | [\<use\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/use)
-use_ :: [Attribute model action] -> View context model action
+use_ :: [Attribute model action] -> View context props model action
 use_ = flip (nodeSvg "use") []
 -----------------------------------------------------------------------------
 -- | [\<animate\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/animate)
-animate_ :: [Attribute model action] -> View context model action
+animate_ :: [Attribute model action] -> View context props model action
 animate_ = flip (nodeSvg "animate") []
 -----------------------------------------------------------------------------
 -- | [\<animateMotion\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/animateMotion)
-animateMotion_ :: [Attribute model action] -> View context model action
+animateMotion_ :: [Attribute model action] -> View context props model action
 animateMotion_ = flip (nodeSvg "animateMotion") []
 -----------------------------------------------------------------------------
 -- | [\<animateTransform\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/animateTransform)
-animateTransform_ :: [Attribute model action] -> View context model action
+animateTransform_ :: [Attribute model action] -> View context props model action
 animateTransform_ = flip (nodeSvg "animateTransform") []
 -----------------------------------------------------------------------------
 -- | [\<mpath\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/mpath)
-mpath_ :: [Attribute model action] -> View context model action
+mpath_ :: [Attribute model action] -> View context props model action
 mpath_ = flip (nodeSvg "mpath") []
 -----------------------------------------------------------------------------
 -- | [\<set\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/set)
-set_ :: [Attribute model action] -> View context model action
+set_ :: [Attribute model action] -> View context props model action
 set_ = flip (nodeSvg "set") []
 -----------------------------------------------------------------------------
 -- | [\<desc\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/desc)
-desc_ :: [Attribute model action] -> [View context model action] -> View context model action
+desc_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 desc_ = nodeSvg "desc"
 -----------------------------------------------------------------------------
 -- | [\<metadata\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/metadata)
-metadata_ :: [Attribute model action] -> [View context model action] -> View context model action
+metadata_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 metadata_ = nodeSvg "metadata"
 -----------------------------------------------------------------------------
 -- | [\<title\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/title)
-title_ :: [Attribute model action] -> [View context model action] -> View context model action
+title_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 title_ = nodeSvg "title"
 -----------------------------------------------------------------------------
 -- | [\<defs\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/defs)
-defs_ :: [Attribute model action] -> [View context model action] -> View context model action
+defs_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 defs_ = nodeSvg "defs"
 -----------------------------------------------------------------------------
 -- | [\<g\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/g)
-g_ :: [Attribute model action] -> [View context model action] -> View context model action
+g_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 g_ = nodeSvg "g"
 -----------------------------------------------------------------------------
 -- | [\<marker\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/marker)
-marker_ :: [Attribute model action] -> [View context model action] -> View context model action
+marker_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 marker_ = nodeSvg "marker"
 -----------------------------------------------------------------------------
 -- | [\<mask\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/mask)
-mask_ :: [Attribute model action] -> [View context model action] -> View context model action
+mask_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 mask_ = nodeSvg "mask"
 -----------------------------------------------------------------------------
 -- | [\<pattern\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/pattern)
-pattern_ :: [Attribute model action] -> [View context model action] -> View context model action
+pattern_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 pattern_ = nodeSvg "pattern"
 -----------------------------------------------------------------------------
 -- | [\<switch\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/switch)
-switch_ :: [Attribute model action] -> [View context model action] -> View context model action
+switch_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 switch_ = nodeSvg "switch"
 -----------------------------------------------------------------------------
 -- | [\<symbol\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/symbol)
-symbol_ :: [Attribute model action] -> [View context model action] -> View context model action
+symbol_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 symbol_ = nodeSvg "symbol"
 -----------------------------------------------------------------------------
 -- | [\<textPath\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/textPath)
-textPath_ :: [Attribute model action] -> [View context model action] -> View context model action
+textPath_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 textPath_ = nodeSvg "textPath"
 -----------------------------------------------------------------------------
 -- | [\<text\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/text)
-text_ :: [Attribute model action] -> [View context model action] -> View context model action
+text_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 text_ = nodeSvg "text"
 -----------------------------------------------------------------------------
 -- | [\<tspan\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/tspan)
-tspan_ :: [Attribute model action] -> [View context model action] -> View context model action
+tspan_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 tspan_ = nodeSvg "tspan"
 -----------------------------------------------------------------------------
 -- | [\<linearGradient\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/linearGradient)
-linearGradient_ :: [Attribute model action] -> [View context model action] -> View context model action
+linearGradient_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 linearGradient_ = nodeSvg "linearGradient"
 -----------------------------------------------------------------------------
 -- | [\<radialGradient\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/radialGradient)
-radialGradient_ :: [Attribute model action] -> [View context model action] -> View context model action
+radialGradient_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 radialGradient_ = nodeSvg "radialGradient"
 -----------------------------------------------------------------------------
 -- | [\<stop\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/stop)
-stop_ :: [Attribute model action] -> View context model action
+stop_ :: [Attribute model action] -> View context props model action
 stop_ = flip (nodeSvg "stop") []
 -----------------------------------------------------------------------------
 -- | [\<feBlend\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/feBlend)
-feBlend_ :: [Attribute model action] -> View context model action
+feBlend_ :: [Attribute model action] -> View context props model action
 feBlend_ = flip (nodeSvg "feBlend") []
 -----------------------------------------------------------------------------
 -- | [\<feColorMatrix\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/feColorMatrix)
-feColorMatrix_ :: [Attribute model action] -> View context model action
+feColorMatrix_ :: [Attribute model action] -> View context props model action
 feColorMatrix_ = flip (nodeSvg "feColorMatrix") []
 -----------------------------------------------------------------------------
 -- | [\<feComponentTransfer\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/feComponentTransfer)
-feComponentTransfer_ :: [Attribute model action] -> [View context model action] -> View context model action
+feComponentTransfer_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 feComponentTransfer_ = nodeSvg "feComponentTransfer"
 -----------------------------------------------------------------------------
 -- | [\<feComposite\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/feComposite)
-feComposite_ :: [Attribute model action] -> View context model action
+feComposite_ :: [Attribute model action] -> View context props model action
 feComposite_ = flip (nodeSvg "feComposite") []
 -----------------------------------------------------------------------------
 -- | [\<feConvolveMatrix\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/feConvolveMatrix)
-feConvolveMatrix_ :: [Attribute model action] -> View context model action
+feConvolveMatrix_ :: [Attribute model action] -> View context props model action
 feConvolveMatrix_ = flip (nodeSvg "feConvolveMatrix") []
 -----------------------------------------------------------------------------
 -- | [\<feDiffuseLighting\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/feDiffuseLighting)
-feDiffuseLighting_ :: [Attribute model action] -> [View context model action] -> View context model action
+feDiffuseLighting_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 feDiffuseLighting_ = nodeSvg "feDiffuseLighting"
 -----------------------------------------------------------------------------
 -- | [\<feDisplacementMap\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/feDisplacementMap)
-feDisplacementMap_ :: [Attribute model action] -> View context model action
+feDisplacementMap_ :: [Attribute model action] -> View context props model action
 feDisplacementMap_ = flip (nodeSvg "feDisplacementMap") []
 -----------------------------------------------------------------------------
 -- | [\<feDropShadow\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/feDropShadow)
 --
 -- @since 1.9.0.0
-feDropShadow_ :: [Attribute model action] -> View context model action
+feDropShadow_ :: [Attribute model action] -> View context props model action
 feDropShadow_ = flip (nodeSvg "feDropShadow") []
 -----------------------------------------------------------------------------
 -- | [\<feFlood\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/feFlood)
-feFlood_ :: [Attribute model action] -> View context model action
+feFlood_ :: [Attribute model action] -> View context props model action
 feFlood_ = flip (nodeSvg "feFlood") []
 -----------------------------------------------------------------------------
 -- | [\<feFuncA\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/feFuncA)
-feFuncA_ :: [Attribute model action] -> [View context model action] -> View context model action
+feFuncA_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 feFuncA_ = nodeSvg "feFuncA"
 -----------------------------------------------------------------------------
 -- | [\<feFuncB\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/feFuncB)
-feFuncB_ :: [Attribute model action] -> [View context model action] -> View context model action
+feFuncB_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 feFuncB_ = nodeSvg "feFuncB"
 -----------------------------------------------------------------------------
 -- | [\<feFuncG\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/feFuncG)
-feFuncG_ :: [Attribute model action] -> [View context model action] -> View context model action
+feFuncG_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 feFuncG_ = nodeSvg "feFuncG"
 -----------------------------------------------------------------------------
 -- | [\<feFuncR\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/feFuncR)
-feFuncR_ :: [Attribute model action] -> [View context model action] -> View context model action
+feFuncR_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 feFuncR_ = nodeSvg "feFuncR"
 -----------------------------------------------------------------------------
 -- | [\<feGaussianBlur\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/feGaussianBlur)
-feGaussianBlur_ :: [Attribute model action] -> View context model action
+feGaussianBlur_ :: [Attribute model action] -> View context props model action
 feGaussianBlur_ = flip (nodeSvg "feGaussianBlur") []
 -----------------------------------------------------------------------------
 -- | [\<feImage\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/feImage)
-feImage_ :: [Attribute model action] -> View context model action
+feImage_ :: [Attribute model action] -> View context props model action
 feImage_ = flip (nodeSvg "feImage") []
 -----------------------------------------------------------------------------
 -- | [\<feMerge\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/feMerge)
-feMerge_ :: [Attribute model action] -> [View context model action] -> View context model action
+feMerge_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 feMerge_ = nodeSvg "feMerge"
 -----------------------------------------------------------------------------
 -- | [\<feMergeNode\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/feMergeNode)
-feMergeNode_ :: [Attribute model action] -> View context model action
+feMergeNode_ :: [Attribute model action] -> View context props model action
 feMergeNode_ = flip (nodeSvg "feMergeNode") []
 -----------------------------------------------------------------------------
 -- | [\<feMorphology\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/feMorphology)
 --
 -- @since 1.9.0.0
-feMorphology_ :: [Attribute model action] -> View context model action
+feMorphology_ :: [Attribute model action] -> View context props model action
 feMorphology_ = flip (nodeSvg "feMorphology") []
 -----------------------------------------------------------------------------
 -- | [\<feOffset\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/feOffset)
-feOffset_ :: [Attribute model action] -> View context model action
+feOffset_ :: [Attribute model action] -> View context props model action
 feOffset_ = flip (nodeSvg "feOffset") []
 -----------------------------------------------------------------------------
 -- | [\<feSpecularLighting\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/feSpecularLighting)
-feSpecularLighting_ :: [Attribute model action] -> [View context model action] -> View context model action
+feSpecularLighting_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 feSpecularLighting_ = nodeSvg "feSpecularLighting"
 -----------------------------------------------------------------------------
 -- | [\<feTile\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/feTile)
-feTile_ :: [Attribute model action] -> View context model action
+feTile_ :: [Attribute model action] -> View context props model action
 feTile_ = flip (nodeSvg "feTile") []
 -----------------------------------------------------------------------------
 -- | [\<feTurbulence\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/feTurbulence)
-feTurbulence_ :: [Attribute model action] -> View context model action
+feTurbulence_ :: [Attribute model action] -> View context props model action
 feTurbulence_ = flip (nodeSvg "feTurbulence") []
 -----------------------------------------------------------------------------
 -- | [\<feDistantLight\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/feDistantLight)
-feDistantLight_ :: [Attribute model action] -> [View context model action] -> View context model action
+feDistantLight_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 feDistantLight_ = nodeSvg "feDistantLight"
 -----------------------------------------------------------------------------
 -- | [\<fePointLight\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/fePointLight)
-fePointLight_ :: [Attribute model action] -> View context model action
+fePointLight_ :: [Attribute model action] -> View context props model action
 fePointLight_ = flip (nodeSvg "fePointLight") []
 -----------------------------------------------------------------------------
 -- | [\<feSpotLight\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/feSpotLight)
-feSpotLight_ :: [Attribute model action] -> View context model action
+feSpotLight_ :: [Attribute model action] -> View context props model action
 feSpotLight_ = flip (nodeSvg "feSpotLight") []
 -----------------------------------------------------------------------------
 -- | [\<clipPath\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/clipPath)
-clipPath_ :: [Attribute model action] -> [View context model action] -> View context model action
+clipPath_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 clipPath_ = nodeSvg "clipPath"
 -----------------------------------------------------------------------------
 -- | [\<filter\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/filter)
-filter_ :: [Attribute model action] -> [View context model action] -> View context model action
+filter_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 filter_ = nodeSvg "filter"
 -----------------------------------------------------------------------------
 -- | [\<script\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/script)
-script_ :: [Attribute model action] -> [View context model action] -> View context model action
+script_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 script_ = nodeSvg "script"
 -----------------------------------------------------------------------------
 -- | [\<style\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/style)
-style_ :: [Attribute model action] -> [View context model action] -> View context model action
+style_ :: [Attribute model action] -> [View context props model action] -> View context props model action
 style_ = nodeSvg "style"
 -----------------------------------------------------------------------------
 -- | [\<view\>](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/view)
-view_ :: [Attribute model action] -> View context model action
+view_ :: [Attribute model action] -> View context props model action
 view_ = flip (nodeSvg "view") []
 -----------------------------------------------------------------------------

--- a/src/Miso/Types.hs
+++ b/src/Miso/Types.hs
@@ -41,7 +41,7 @@
 --   { model           :: model
 --   , hydrateModel    :: Maybe (IO model)
 --   , update          :: action -> 'Miso.Effect.Effect' context props model action
---   , view            :: context -> props -> model -> 'View' context model action
+--   , view            :: context -> props -> model -> 'View' context props model action
 --   , useContext      :: Bool
 --   , subs            :: ['Miso.Effect.Sub' action]
 --   , styles          :: ['CSS']
@@ -577,7 +577,7 @@ fragment_ key = VFrag (Just (Key key))
 --
 -- @since 1.9.0.0
 (+>)
-  :: forall context childModel childAction props model action .
+  :: forall context childModel childAction model action props .
 #ifdef NATIVE
      (Eq context, Eq childModel, FromJSON childModel, ToJSON childModel, FromJSON childAction, ToJSON childAction)
 #else
@@ -633,7 +633,7 @@ mountStaticWithProps child = SomeStaticComponent (\props -> SomeComponent Nothin
 -- @OnStatic@ handlers inside them. Use 'vcomp' with 'mountStaticWithProps'
 -- instead for anything that may mount dynamically under @NATIVE@.
 mountWithProps
-  :: forall context childProps childModel childAction props model action .
+  :: forall context childProps childModel childAction model action props .
 #ifdef NATIVE
      (Eq context, Eq childProps, Eq childModel, FromJSON childModel, ToJSON childModel, FromJSON childAction, ToJSON childAction, FromJSON childProps, ToJSON childProps)
 #else
@@ -659,7 +659,7 @@ mountWithProps props comp = VComp (SomeComponent Nothing props comp)
 -- under @NATIVE@ — the compile-time 'GHC.StaticPtr.StaticKey' already
 -- supplies the identity a manual key would, no explicit key needed.
 mountWithProps_
-  :: forall context childProps childModel childAction props model action .
+  :: forall context childProps childModel childAction model action props .
 #ifdef NATIVE
      (Eq context, Eq childProps, Eq childModel, FromJSON childAction, FromJSON childModel, ToJSON childModel, ToJSON childAction, FromJSON childProps, ToJSON childProps)
 #else
@@ -722,7 +722,7 @@ mountStatic child = SomeStaticComponent (const (SomeComponent Nothing () child))
 --
 -- @since 1.9.0.0
 mount_
-  :: forall context childModel childAction props model action .
+  :: forall context childModel childAction model action props .
 #ifdef NATIVE
      (Eq context, Eq childModel, FromJSON childModel, ToJSON childModel, FromJSON childAction, ToJSON childAction)
 #else
@@ -798,7 +798,7 @@ vcomp_ = vcomp ()
 --
 -- @since 1.13.0.0
 mountUseContext
-  :: forall context childModel childAction props model action .
+  :: forall context childModel childAction model action props .
 #ifdef NATIVE
      (Eq context, Eq childModel, FromJSON childModel, ToJSON childModel, FromJSON childAction, ToJSON childAction)
 #else

--- a/src/Miso/Types.hs
+++ b/src/Miso/Types.hs
@@ -69,8 +69,8 @@
 --
 -- = The View type
 --
--- @'View' context props model action@ is miso's virtual DOM tree. Its seven
--- constructors map to the node kinds the runtime handles:
+-- @'View' context props model action@ is miso's virtual DOM tree. Five of
+-- its constructors are the node kinds the runtime handles:
 --
 -- * 'VNode' — a regular DOM element (@\<div\>@, @\<svg\>@, …)
 -- * 'VText' — a text node
@@ -78,8 +78,17 @@
 -- * @VCompStatic@ — an embedded child t'Component' behind a 'GHC.StaticPtr.StaticPtr',
 --   so it can cross the Lynx dual-thread boundary (see 'vcomp' \/ 'mountStatic')
 -- * 'VFrag' — a group of siblings with no wrapper element, optionally keyed
--- * 'VContext' — a subtree resolved against the app-global @context@
--- * 'VProps' — a subtree resolved against the enclosing t'Component'\'s @props@
+--
+-- The remaining two are /ambient accessors/, not nodes. Each wraps a
+-- function that is applied — and the wrapper discarded — when the tree is
+-- built or rendered, so neither ever appears in the virtual DOM:
+--
+-- * 'VContext' — reads the app-global @context@
+-- * 'VProps' — reads the enclosing t'Component'\'s @props@
+--
+-- (@ImplicitParams@ or a @Reader@ could play the same role, at the cost of a
+-- GHC-specific extension or a monadic style for view code; see the
+-- 'VProps' section of the "Miso" module docs.)
 --
 -- The @props@ parameter is the @props@ type of the t'Component' whose
 -- 'view' produced the tree, exactly as @model@ is that component's @model@
@@ -462,13 +471,15 @@ data View context props model action
     -- in order to transfer context, props, event handlers etc.
   | VFrag (Maybe Key) [View context props model action]
   | VContext (context -> View context props model action)
-    -- ^ A subtree resolved against the app-global @context@ at the point this
-    -- 'View' is built or rendered, letting a helper read @context@ without
-    -- threading it through as an extra argument. See 'vcontext'.
+    -- ^ Ambient accessor for the app-global @context@ — not a node. The
+    -- function is applied, and this wrapper discarded, at the point the
+    -- enclosing 'View' is built or rendered, letting a helper read @context@
+    -- without threading it through as an extra argument. See 'vcontext'.
   | VProps (props -> View context props model action)
-    -- ^ A subtree resolved against the enclosing t'Component'\'s @props@ at the
-    -- point this 'View' is built or rendered, letting a helper read @props@
-    -- without threading it through as an extra argument. See 'vprops'.
+    -- ^ Ambient accessor for the enclosing t'Component'\'s @props@ — not a
+    -- node. The function is applied, and this wrapper discarded, at the point
+    -- the enclosing 'View' is built or rendered, letting a helper read
+    -- @props@ without threading it through as an extra argument. See 'vprops'.
 -----------------------------------------------------------------------------
 -- | Existential wrapper allowing nesting of t'Miso.Types.Component' in t'Miso.Types.Component'.
 --

--- a/src/Miso/Types.hs
+++ b/src/Miso/Types.hs
@@ -155,7 +155,6 @@ module Miso.Types
   , ComponentId
   , SomeComponent (..)
   , SomeStaticComponent         (..)
-  , StaticMount                 (..)
   , EventHandler  (..)
   , View          (..)
   , Key           (..)
@@ -453,7 +452,7 @@ data View context props model action
     -- elements. See 'nodeDirectEvents'.
   | VText (Maybe Key) MisoString
   | VComp (SomeComponent context)
-  | VCompStatic (StaticMount context)
+  | forall childProps . VCompStatic (StaticPtr (SomeStaticComponent childProps context)) childProps
     -- ^ An embedded child t'Component'. The 'StaticPtr' holds only the closed
     -- @props -> component@ constructor ('SomeStaticComponent'); the @props@ value — often
     -- derived from the parent's @model@ — rides alongside and crosses the
@@ -482,21 +481,6 @@ data SomeComponent context
    = forall model action props . (Eq context, Eq model, Eq props)
 #endif
   => SomeComponent (Maybe Key) props (Component context props model action)
------------------------------------------------------------------------------
--- | A 'StaticPtr' to a closed @props -> component@ constructor
--- ('SomeStaticComponent'), paired with the runtime @props@ value to apply it
--- to. The pairing is what a @VCompStatic@ node carries, mirroring how
--- @VComp@ carries a t'SomeComponent'.
---
--- The existential hides the child's @props@ type; within it the @props@
--- value and the constructor are guaranteed to agree, because 'vcomp' (the
--- only public way to build one) requires them to. Only the constructor is
--- behind @static@ — the @props@ value is ordinary runtime data, so it may
--- depend on the parent's @model@.
---
--- @since 1.14.0.0
-data StaticMount context
-  = forall props . StaticMount (StaticPtr (SomeStaticComponent props context)) props
 -----------------------------------------------------------------------------
 -- | A closed @props -> component@ constructor, bundled with the serialization
 -- dictionaries needed to move @props@ across the dual-thread (Lynx) boundary.
@@ -759,7 +743,7 @@ vcomp
   :: childProps
   -> StaticPtr (SomeStaticComponent childProps context)
   -> View context props model action
-vcomp props ptr = VCompStatic (StaticMount ptr props)
+vcomp = flip VCompStatic
 -----------------------------------------------------------------------------
 -- | Like 'vcomp', but for a t'Miso.Types.Component' that takes no @props@.
 --

--- a/src/Miso/Types.hs
+++ b/src/Miso/Types.hs
@@ -155,6 +155,7 @@ module Miso.Types
   , ComponentId
   , SomeComponent (..)
   , SomeStaticComponent         (..)
+  , StaticMount                 (..)
   , EventHandler  (..)
   , View          (..)
   , Key           (..)
@@ -452,7 +453,7 @@ data View context props model action
     -- elements. See 'nodeDirectEvents'.
   | VText (Maybe Key) MisoString
   | VComp (SomeComponent context)
-  | forall childProps . VCompStatic (StaticPtr (SomeStaticComponent childProps context)) childProps
+  | VCompStatic (StaticMount context)
     -- ^ An embedded child t'Component'. The 'StaticPtr' holds only the closed
     -- @props -> component@ constructor ('SomeStaticComponent'); the @props@ value — often
     -- derived from the parent's @model@ — rides alongside and crosses the
@@ -481,6 +482,21 @@ data SomeComponent context
    = forall model action props . (Eq context, Eq model, Eq props)
 #endif
   => SomeComponent (Maybe Key) props (Component context props model action)
+-----------------------------------------------------------------------------
+-- | A 'StaticPtr' to a closed @props -> component@ constructor
+-- ('SomeStaticComponent'), paired with the runtime @props@ value to apply it
+-- to. The pairing is what a @VCompStatic@ node carries, mirroring how
+-- @VComp@ carries a t'SomeComponent'.
+--
+-- The existential hides the child's @props@ type; within it the @props@
+-- value and the constructor are guaranteed to agree, because 'vcomp' (the
+-- only public way to build one) requires them to. Only the constructor is
+-- behind @static@ — the @props@ value is ordinary runtime data, so it may
+-- depend on the parent's @model@.
+--
+-- @since 1.14.0.0
+data StaticMount context
+  = forall props . StaticMount (StaticPtr (SomeStaticComponent props context)) props
 -----------------------------------------------------------------------------
 -- | A closed @props -> component@ constructor, bundled with the serialization
 -- dictionaries needed to move @props@ across the dual-thread (Lynx) boundary.
@@ -743,7 +759,7 @@ vcomp
   :: childProps
   -> StaticPtr (SomeStaticComponent childProps context)
   -> View context props model action
-vcomp = flip VCompStatic
+vcomp props ptr = VCompStatic (StaticMount ptr props)
 -----------------------------------------------------------------------------
 -- | Like 'vcomp', but for a t'Miso.Types.Component' that takes no @props@.
 --

--- a/src/Miso/Types.hs
+++ b/src/Miso/Types.hs
@@ -69,8 +69,8 @@
 --
 -- = The View type
 --
--- @'View' context model action@ is miso's virtual DOM tree. Its six
--- constructors map to the four node kinds the runtime handles:
+-- @'View' context props model action@ is miso's virtual DOM tree. Its seven
+-- constructors map to the node kinds the runtime handles:
 --
 -- * 'VNode' — a regular DOM element (@\<div\>@, @\<svg\>@, …)
 -- * 'VText' — a text node
@@ -79,6 +79,12 @@
 --   so it can cross the Lynx dual-thread boundary (see 'vcomp' \/ 'mountStatic')
 -- * 'VFrag' — a group of siblings with no wrapper element, optionally keyed
 -- * 'VContext' — a subtree resolved against the app-global @context@
+-- * 'VProps' — a subtree resolved against the enclosing t'Component'\'s @props@
+--
+-- The @props@ parameter is the @props@ type of the t'Component' whose
+-- 'view' produced the tree, exactly as @model@ is that component's @model@
+-- type. Both are forgotten at a mount boundary (@VComp@ \/ @VCompStatic@),
+-- so a parent with @props ~ P@ can freely mount a child with @props ~ Q@.
 --
 -- = Key types at a glance
 --
@@ -193,6 +199,9 @@ module Miso.Types
   -- ** Context combinator
   , vcontext
   , withContext
+  -- ** Props combinator
+  , vprops
+  , withProps
   -- ** Utils
   , getMountPoint
   , optionalAttrs
@@ -254,7 +263,7 @@ data Component context props model action
   --   @localStorage@ via 'Miso.Storage.getLocalStorage').
   , update :: action -> Effect context props model action
   -- ^ Updates model, optionally providing effects.
-  , view :: context -> props -> model -> View context model action
+  , view :: context -> props -> model -> View context props model action
   -- ^ Draws 'View'. Receives the app-global @context@, the @props@ passed by the
   --   parent, and the current @model@.
   , useContext :: Bool
@@ -377,7 +386,7 @@ component
   -- ^ model
   -> (action -> Effect context props model action)
   -- ^ update
-  -> (context -> props -> model -> View context model action)
+  -> (context -> props -> model -> View context props model action)
   -- ^ view
   -> Component context props model action
 component m u v = Component
@@ -435,15 +444,15 @@ type Tag = MisoString
 type DirectEvents = Set MisoString
 -----------------------------------------------------------------------------
 -- | Core type for constructing a virtual DOM in Haskell
-data View context model action
-  = VNode Namespace Tag [Attribute model action] [View context model action] DirectEvents
+data View context props model action
+  = VNode Namespace Tag [Attribute model action] [View context props model action] DirectEvents
     -- ^ The final 'Set' names the events this element dispatches /directly/ on
     -- itself rather than by bubbling to the delegated mount listener (Lynx
     -- native @input@\/@scroll@\/… events). Empty for all HTML\/SVG\/MathML
     -- elements. See 'nodeDirectEvents'.
   | VText (Maybe Key) MisoString
   | VComp (SomeComponent context)
-  | forall props . VCompStatic (StaticPtr (SomeStaticComponent props context)) props
+  | forall childProps . VCompStatic (StaticPtr (SomeStaticComponent childProps context)) childProps
     -- ^ An embedded child t'Component'. The 'StaticPtr' holds only the closed
     -- @props -> component@ constructor ('SomeStaticComponent'); the @props@ value — often
     -- derived from the parent's @model@ — rides alongside and crosses the
@@ -451,11 +460,15 @@ data View context model action
     -- (see 'mountStatic'). This split is what lets a mount escape @static@\'s
     -- closedness restriction. See 'vcomp'. This is necessary for lynx dual-thread
     -- in order to transfer context, props, event handlers etc.
-  | VFrag (Maybe Key) [View context model action]
-  | VContext (context -> View context model action)
+  | VFrag (Maybe Key) [View context props model action]
+  | VContext (context -> View context props model action)
     -- ^ A subtree resolved against the app-global @context@ at the point this
     -- 'View' is built or rendered, letting a helper read @context@ without
     -- threading it through as an extra argument. See 'vcontext'.
+  | VProps (props -> View context props model action)
+    -- ^ A subtree resolved against the enclosing t'Component'\'s @props@ at the
+    -- point this 'View' is built or rendered, letting a helper read @props@
+    -- without threading it through as an extra argument. See 'vprops'.
 -----------------------------------------------------------------------------
 -- | Existential wrapper allowing nesting of t'Miso.Types.Component' in t'Miso.Types.Component'.
 --
@@ -499,7 +512,7 @@ data SomeStaticComponent props context
 -- Synonym for `fragment'
 --
 -- @since 1.10.0.0
-vfrag :: [View context model action] -> View context model action
+vfrag :: [View context props model action] -> View context props model action
 vfrag = fragment
 -----------------------------------------------------------------------------
 -- | Create a fragment (keyless).
@@ -508,19 +521,19 @@ vfrag = fragment
 -- an extra DOM element.
 --
 -- @since 1.10.0.0
-fragment :: [View context model action] -> View context model action
+fragment :: [View context props model action] -> View context props model action
 fragment = VFrag Nothing
 -----------------------------------------------------------------------------
 -- | Like 'fragment', but keyed for efficient diffing.
 --
 -- @since 1.10.0.0
-vfrag_ :: MisoString -> [View context model action] -> View context model action
+vfrag_ :: MisoString -> [View context props model action] -> View context props model action
 vfrag_ key = VFrag (Just (Key key))
 -----------------------------------------------------------------------------
 -- | Like 'fragment', but keyed for efficient diffing.
 --
 -- @since 1.10.0.0
-fragment_ :: MisoString -> [View context model action] -> View context model action
+fragment_ :: MisoString -> [View context props model action] -> View context props model action
 fragment_ key = VFrag (Just (Key key))
 -----------------------------------------------------------------------------
 -- | t'Miso.Types.Component' mounting combinator
@@ -548,7 +561,7 @@ fragment_ key = VFrag (Just (Key key))
 --
 -- @since 1.9.0.0
 (+>)
-  :: forall context childModel childAction model action .
+  :: forall context childModel childAction props model action .
 #ifdef NATIVE
      (Eq context, Eq childModel, FromJSON childModel, ToJSON childModel, FromJSON childAction, ToJSON childAction)
 #else
@@ -558,7 +571,7 @@ fragment_ key = VFrag (Just (Key key))
   -- ^ @VComp@ @key_@
   -> Component context () childModel childAction
   -- ^ t'Component'
-  -> View context model action
+  -> View context props model action
 infixr 0 +>
 #ifdef NATIVE
 {-# WARNING (+>) "[NATIVE] '+>' has no StaticKey; a component mounted with it after the initial frame silently drops OnStatic handlers inside it. Use 'vcomp' with 'mountStaticWithProps' instead." #-}
@@ -604,16 +617,16 @@ mountStaticWithProps child = SomeStaticComponent (\props -> SomeComponent Nothin
 -- @OnStatic@ handlers inside them. Use 'vcomp' with 'mountStaticWithProps'
 -- instead for anything that may mount dynamically under @NATIVE@.
 mountWithProps
-  :: forall context props childModel childAction model action .
+  :: forall context childProps childModel childAction props model action .
 #ifdef NATIVE
-     (Eq context, Eq props, Eq childModel, FromJSON childModel, ToJSON childModel, FromJSON childAction, ToJSON childAction, FromJSON props, ToJSON props)
+     (Eq context, Eq childProps, Eq childModel, FromJSON childModel, ToJSON childModel, FromJSON childAction, ToJSON childAction, FromJSON childProps, ToJSON childProps)
 #else
-     (Eq context, Eq props, Eq childModel)
+     (Eq context, Eq childProps, Eq childModel)
 #endif
-  => props
-  -> Component context props childModel childAction
+  => childProps
+  -> Component context childProps childModel childAction
   -- ^ t'Component' to mount
-  -> View context model action
+  -> View context props model action
 #ifdef NATIVE
 {-# WARNING mountWithProps "[NATIVE] 'mountWithProps' has no StaticKey; a component mounted with it after the initial frame silently drops OnStatic handlers inside it. Use 'vcomp' with 'mountStaticWithProps' instead." #-}
 #endif
@@ -630,17 +643,17 @@ mountWithProps props comp = VComp (SomeComponent Nothing props comp)
 -- under @NATIVE@ — the compile-time 'GHC.StaticPtr.StaticKey' already
 -- supplies the identity a manual key would, no explicit key needed.
 mountWithProps_
-  :: forall context props childModel childAction model action .
+  :: forall context childProps childModel childAction props model action .
 #ifdef NATIVE
-     (Eq context, Eq props, Eq childModel, FromJSON childAction, FromJSON childModel, ToJSON childModel, ToJSON childAction, FromJSON props, ToJSON props)
+     (Eq context, Eq childProps, Eq childModel, FromJSON childAction, FromJSON childModel, ToJSON childModel, ToJSON childAction, FromJSON childProps, ToJSON childProps)
 #else
-     (Eq context, Eq childModel, Eq props)
+     (Eq context, Eq childModel, Eq childProps)
 #endif
   => MisoString
-  -> props
-  -> Component context props childModel childAction
+  -> childProps
+  -> Component context childProps childModel childAction
   -- ^ t'Component' to mount
-  -> View context model action
+  -> View context props model action
 #ifdef NATIVE
 {-# WARNING mountWithProps_ "[NATIVE] 'mountWithProps_' has no StaticKey; a component mounted with it after the initial frame silently drops OnStatic handlers inside it. Use 'vcomp' with 'mountStaticWithProps' instead." #-}
 #endif
@@ -693,7 +706,7 @@ mountStatic child = SomeStaticComponent (const (SomeComponent Nothing () child))
 --
 -- @since 1.9.0.0
 mount_
-  :: forall context childModel childAction model action .
+  :: forall context childModel childAction props model action .
 #ifdef NATIVE
      (Eq context, Eq childModel, FromJSON childModel, ToJSON childModel, FromJSON childAction, ToJSON childAction)
 #else
@@ -701,7 +714,7 @@ mount_
 #endif
   => Component context () childModel childAction
   -- ^ t'Component' to mount
-  -> View context model action
+  -> View context props model action
 #ifdef NATIVE
 {-# WARNING mount_ "[NATIVE] 'mount_' has no StaticKey; a component mounted with it after the initial frame silently drops OnStatic handlers inside it. Use 'vcomp_' with 'mountStatic' instead." #-}
 #endif
@@ -727,9 +740,9 @@ mount_ comp = VComp (SomeComponent Nothing () comp)
 --
 -- @since 1.12.0.0
 vcomp
-  :: props
-  -> StaticPtr (SomeStaticComponent props context)
-  -> View context model action
+  :: childProps
+  -> StaticPtr (SomeStaticComponent childProps context)
+  -> View context props model action
 vcomp = flip VCompStatic
 -----------------------------------------------------------------------------
 -- | Like 'vcomp', but for a t'Miso.Types.Component' that takes no @props@.
@@ -744,7 +757,7 @@ vcomp = flip VCompStatic
 -- @since 1.13.0.0
 vcomp_
   :: StaticPtr (SomeStaticComponent () context)
-  -> View context model action
+  -> View context props model action
 vcomp_ = vcomp ()
 -----------------------------------------------------------------------------
 -- | t'Miso.Types.Component' mounting combinator that opts the child into
@@ -769,7 +782,7 @@ vcomp_ = vcomp ()
 --
 -- @since 1.13.0.0
 mountUseContext
-  :: forall context childModel childAction model action .
+  :: forall context childModel childAction props model action .
 #ifdef NATIVE
      (Eq context, Eq childModel, FromJSON childModel, ToJSON childModel, FromJSON childAction, ToJSON childAction)
 #else
@@ -777,7 +790,7 @@ mountUseContext
 #endif
   => Component context () childModel childAction
   -- ^ t'Component' to mount
-  -> View context model action
+  -> View context props model action
 #ifdef NATIVE
 {-# WARNING mountUseContext "[NATIVE] 'mountUseContext' has no StaticKey; a component mounted with it after the initial frame silently drops OnStatic handlers inside it. Use 'vcomp_' with 'mountStatic' on a component with useContext = True instead." #-}
 #endif
@@ -801,15 +814,48 @@ mountUseContext comp = VComp (SomeComponent Nothing () comp { useContext = True 
 -- (re)built for some other, already-scheduled reason.
 --
 -- @since 1.14.0.0
-vcontext :: (context -> View context model action) -> View context model action
+vcontext :: (context -> View context props model action) -> View context props model action
 vcontext = VContext
 
 -----------------------------------------------------------------------------
 -- | Synonym for 'vcontext'.
 --
 -- @since 1.14.0.0
-withContext :: (context -> View context model action) -> View context model action
+withContext :: (context -> View context props model action) -> View context props model action
 withContext = vcontext
+
+-----------------------------------------------------------------------------
+-- | Create a new 'Miso.Types.VProps'.
+--
+-- Embeds a subtree that is resolved against the enclosing t'Component'\'s
+-- @props@ at the point the enclosing 'View' is built or rendered, so a helper
+-- deep in a view tree can read @props@ without needing it threaded through as
+-- an explicit argument — unlike 'view' itself, which already receives @props@
+-- as its second parameter.
+--
+-- @
+-- vprops $ \\Props { title } -> h1_ [] [ text title ]
+-- @
+--
+-- Because @props@ is a type parameter of 'View', the @props@ seen here is
+-- statically the @props@ of the t'Component' whose 'view' contains this
+-- node — a mismatch is a compile-time error. A child mounted with
+-- 'mountWithProps' \/ 'vcomp' sees /its own/ @props@, not its parent's.
+--
+-- __Note:__ a 'VProps' node adds no redraw logic of its own. A component is
+-- redrawn when its parent passes it different @props@ (the props phase), and
+-- the node is re-resolved against the new @props@ as part of that redraw.
+--
+-- @since 1.14.0.0
+vprops :: (props -> View context props model action) -> View context props model action
+vprops = VProps
+
+-----------------------------------------------------------------------------
+-- | Synonym for 'vprops'.
+--
+-- @since 1.14.0.0
+withProps :: (props -> View context props model action) -> View context props model action
+withProps = vprops
 -----------------------------------------------------------------------------
 -- | DOM element namespace.
 data Namespace
@@ -953,7 +999,7 @@ instance Show (Attribute model action) where
         ]
 -----------------------------------------------------------------------------
 -- | 'IsString' instance
-instance IsString (View context model action) where
+instance IsString (View context props model action) where
   fromString = VText Nothing . fromString
 -----------------------------------------------------------------------------
 -- | Virtual DOM implemented as a JavaScript t'Object'.
@@ -976,9 +1022,9 @@ node
   -- ^ Tag name (e.g. @\"div\"@, @\"circle\"@)
   -> [Attribute model action]
   -- ^ Attributes, properties, and event handlers
-  -> [View context model action]
+  -> [View context props model action]
   -- ^ Child nodes
-  -> View context model action
+  -> View context props model action
 node ns tag attrs kids = VNode ns tag attrs kids mempty
 -----------------------------------------------------------------------------
 -- | Like 'node', but declares the set of events this element dispatches
@@ -999,9 +1045,9 @@ nodeDirectEvents
   -- ^ Attributes, properties, and event handlers
   -> [MisoString]
   -- ^ Events dispatched directly on this element
-  -> [View context model action]
+  -> [View context props model action]
   -- ^ Child nodes
-  -> View context model action
+  -> View context props model action
 nodeDirectEvents ns tag attrs direct kids = VNode ns tag attrs kids (S.fromList direct)
 -----------------------------------------------------------------------------
 -- | Create a new 'Miso.Types.VNode'.
@@ -1015,13 +1061,13 @@ vnode
   -- ^ Tag name (e.g. @\"div\"@, @\"circle\"@)
   -> [Attribute model action]
   -- ^ Attributes, properties, and event handlers
-  -> [View context model action]
+  -> [View context props model action]
   -- ^ Child nodes
-  -> View context model action
+  -> View context props model action
 vnode = node
 -----------------------------------------------------------------------------
 -- | Create a new v'VText' with the given content.
-text :: MisoString -> View context model action
+text :: MisoString -> View context props model action
 #ifdef SSR
 text = VText Nothing . htmlEncode
 #else
@@ -1029,14 +1075,14 @@ text = VText Nothing
 #endif
 -----------------------------------------------------------------------------
 -- | Synonym for 'text'
-vtext :: MisoString -> View context model action
+vtext :: MisoString -> View context props model action
 vtext = text
 ----------------------------------------------------------------------------
 -- | Create a new v'VText', not subject to HTML escaping.
 --
 -- Like 'text', except will not escape HTML when used on the server.
 --
-textRaw :: MisoString -> View context model action
+textRaw :: MisoString -> View context props model action
 textRaw = VText Nothing
 ----------------------------------------------------------------------------
 -- |
@@ -1059,7 +1105,7 @@ htmlEncode = MS.concatMap $ \case
 -- | Create a new v'VText' containing concatenation of the given strings.
 --
 -- @
---   view :: View context model action
+--   view :: View context props model action
 --   view = div_
 --     [ className "container" ]
 --     [ text_
@@ -1073,46 +1119,46 @@ htmlEncode = MS.concatMap $ \case
 --
 -- A single additional space is added between elements.
 --
-text_ :: [MisoString] -> View context model action
+text_ :: [MisoString] -> View context props model action
 text_ = VText Nothing . MS.intercalate " "
 -----------------------------------------------------------------------------
 -- | Like 'text', but allow the node to be keyed for efficient diffing.
 --
 -- @
--- view :: model -> View context model action
+-- view :: model -> View context props model action
 -- view = \x -> div_ [] [ textKey (1 :: Int) "text here" ]
 -- @
 --
 -- @since 1.9.0.0
-textKey :: ToKey key => key -> MisoString -> View context model action
+textKey :: ToKey key => key -> MisoString -> View context props model action
 textKey k = VText (Just (toKey k))
 -----------------------------------------------------------------------------
 -- | Like 'text_', but allow the node to be keyed for efficient diffing.
 --
 -- @
--- view :: model -> View context model action
+-- view :: model -> View context props model action
 -- view = \x -> div_ [] [ textKey_ (1 :: Int) [ "text", "goes", "here" ] ]
 -- @
 --
 -- @since 1.9.0.0
-textKey_ :: ToKey key => key -> [MisoString] -> View context model action
+textKey_ :: ToKey key => key -> [MisoString] -> View context props model action
 textKey_ k xs = VText (Just (toKey k)) (MS.intercalate " " xs)
 -----------------------------------------------------------------------------
 -- | Utility function to make it easy to specify conditional attributes
 --
 -- @
--- view :: Bool -> View context model action
+-- view :: Bool -> View context props model action
 -- view danger = optionalAttrs div_ [ id_ "some-div" ] danger [ class_ "danger" ] ["child"]
 -- @
 --
 -- @since 1.9.0.0
 optionalAttrs
-  :: ([Attribute model action] -> [View context model action] -> View context model action)
+  :: ([Attribute model action] -> [View context props model action] -> View context props model action)
   -> [Attribute model action] -- ^ Attributes to be added unconditionally
   -> Bool -- ^ A condition
   -> [Attribute model action] -- ^ Additional attributes to add if the condition is True
-  -> [View context model action] -- ^ Children
-  -> View context model action
+  -> [View context props model action] -- ^ Children
+  -> View context props model action
 optionalAttrs element attrs condition opts kids =
   case element attrs kids of
     VNode ns name _ _ de -> do
@@ -1123,17 +1169,17 @@ optionalAttrs element attrs condition opts kids =
 -- | Utility function to make it easy to specify conditional attributes for void elements.
 --
 -- @
--- view :: Bool -> View context model action
+-- view :: Bool -> View context props model action
 -- view shouldClear = optionalVoidAttrs textarea_ [ value_ "" ] shouldClear [ id_ "text-area-id" ]
 -- @
 --
 -- @since 1.9.0.0
 optionalVoidAttrs
-  :: ([Attribute model action] -> View context model action)
+  :: ([Attribute model action] -> View context props model action)
   -> [Attribute model action] -- ^ Attributes to be added unconditionally
   -> Bool -- ^ A condition
   -> [Attribute model action] -- ^ Additional attributes to add if the condition is True
-  -> View context model action
+  -> View context props model action
 optionalVoidAttrs element attrs condition opts =
   case element attrs of
     VNode ns name _ kids de -> do
@@ -1144,18 +1190,18 @@ optionalVoidAttrs element attrs condition opts =
 -- | Conditionally adds children.
 --
 -- @
--- view :: Bool -> View context model action
+-- view :: Bool -> View context props model action
 -- view withChild = optionalChildren div_ [ id_ "txt" ] [] withChild [ "foo" ]
 -- @
 --
 -- @since 1.9.0.0
 optionalChildren
-  :: ([Attribute model action] -> [View context model action] -> View context model action)
+  :: ([Attribute model action] -> [View context props model action] -> View context props model action)
   -> [Attribute model action] -- ^ Attributes to be added unconditionally
-  -> [View context model action] -- ^ Children to be added unconditionally
+  -> [View context props model action] -- ^ Children to be added unconditionally
   -> Bool -- ^ A condition
-  -> [View context model action] -- ^ Additional children to add if the condition is True
-  -> View context model action
+  -> [View context props model action] -- ^ Additional children to add if the condition is True
+  -> View context props model action
 optionalChildren element attrs kids condition opts =
   case element attrs kids of
     VNode ns name _ _ de -> do

--- a/tests/app/Main.hs
+++ b/tests/app/Main.hs
@@ -152,6 +152,12 @@ data ContextAction = BumpContext
   deriving stock (Show, Eq, Generic)
   deriving anyclass (JSON.FromJSON, JSON.ToJSON)
 -----------------------------------------------------------------------------
+-- | Increments a parent's 'Int' model, which it forwards to a child as
+-- @props@; used to test that a 'vprops' subtree observes the props phase.
+data PropsAction = BumpProps
+  deriving stock (Show, Eq, Generic)
+  deriving anyclass (JSON.FromJSON, JSON.ToJSON)
+-----------------------------------------------------------------------------
 #ifdef WASM
 #ifndef INTERACTIVE
 foreign export javascript "hs_start" main :: IO ()
@@ -1849,6 +1855,69 @@ main = withJS $ do
         _ <- liftIO $ pollFor contextPropagationAttempts (pure False)
         txt <- liftIO readProbe
         txt `shouldBe` ("1" :: MisoString)
+
+    describe "VProps tests" $ do
+      let -- A child whose @props@ is an 'Int', displayed via 'vprops'.
+          propsProbe :: Component () Int () Action
+          propsProbe = component () noop $ \_ _ _ ->
+            div_ [ id_ "props-probe" ] [ vprops (text . ms) ]
+
+          -- A root that forwards its own 'Int' model to 'propsProbe' as @props@.
+          propsRoot :: Component () () Int PropsAction
+          propsRoot = component (1 :: Int) (\BumpProps -> this += 1) $ \_ _ m ->
+            div_ [] [ mountWithProps m propsProbe ]
+
+          readText :: MisoString -> IO MisoString
+          readText elemId = fromJSValUnchecked =<< eval
+            ("document.getElementById('" <> elemId <> "').textContent")
+
+          propsPropagationAttempts = 100 -- 100 * 20ms = 2s
+
+      it "vprops resolves the mounting component's props at initial mount" $ do
+        let root :: App () Action
+            root = component () noop $ \_ _ _ ->
+              div_ [] [ mountWithProps (100 :: Int) propsProbe ]
+        liftIO $ startApp mempty root
+        txt <- liftIO (readText "props-probe")
+        txt `shouldBe` ("100" :: MisoString)
+
+      it "vprops re-resolves when the parent redraws with new props" $ do
+        liftIO $ startApp mempty propsRoot
+        ComponentState {..} <- liftIO $
+          ((IM.! 1) <$> readIORef components :: IO (ComponentState () () Int PropsAction))
+        liftIO (_componentSink BumpProps)
+        updated <- liftIO $ pollFor propsPropagationAttempts ((== ("2" :: MisoString)) <$> readText "props-probe")
+        updated `shouldBe` True
+
+      it "nested components each see their own props type" $ do
+        -- The mount boundary forgets the child's @props@, so an 'Int'-props
+        -- parent can host a 'MisoString'-props child and each 'vprops' /
+        -- 'withProps' resolves against its own component.
+        let inner :: Component () MisoString () Action
+            inner = component () noop $ \_ _ _ ->
+              span_ [ id_ "props-inner" ] [ withProps text ]
+            outer :: Component () Int () Action
+            outer = component () noop $ \_ _ _ ->
+              div_ [ id_ "props-outer" ]
+                [ span_ [] [ vprops (text . ms) ]
+                , mountWithProps ("inner" :: MisoString) inner
+                ]
+            root :: App () Action
+            root = component () noop $ \_ _ _ ->
+              div_ [] [ mountWithProps (7 :: Int) outer ]
+        liftIO $ startApp mempty root
+        outerTxt <- liftIO (readText "props-outer")
+        innerTxt <- liftIO (readText "props-inner")
+        outerTxt `shouldBe` ("7inner" :: MisoString)
+        innerTxt `shouldBe` ("inner" :: MisoString)
+
+      it "toHtml resolves vprops against the mounted component's props" $ do
+        toHtml (div_ [] [ mountWithProps (7 :: Int) propsProbe ])
+          `shouldBe` "<div><div id=\"props-probe\">7</div></div>"
+
+      it "toHtml resolves a bare view's vprops against ()" $ do
+        toHtml (div_ [] [ vprops (\() -> "unit") ])
+          `shouldBe` "<div>unit</div>"
 
     describe "Miso.DSL `await` tests" $ do
       it "Successful Promise resolution should result in a value" $ do

--- a/tests/app/Main.hs
+++ b/tests/app/Main.hs
@@ -136,6 +136,16 @@ pollFor n check = do
   ok <- check
   if ok then pure True else threadDelay 20000 >> pollFor (n - 1) check
 -----------------------------------------------------------------------------
+-- | Budget for 'pollFor' when waiting on a scheduler-driven redraw
+-- (context \/ props propagation): 100 * 20ms = 2s.
+propagationAttempts :: Int
+propagationAttempts = 100
+-----------------------------------------------------------------------------
+-- | The @textContent@ of the element with the given @id@.
+readText :: MisoString -> IO MisoString
+readText elemId = fromJSValUnchecked =<< eval
+  ("document.getElementById('" <> elemId <> "').textContent")
+-----------------------------------------------------------------------------
 testComponent :: Component () () Int Action
 testComponent = component (0 :: Int) update_ $ \_ _ _ -> button_ [ id_ "foo", onClick AddOne ] [ "click me " ]
   where
@@ -149,12 +159,6 @@ data Action = AddOne
 -- | Increments the app-global @context@ (an 'Int'); used to test that
 -- 'useContext' gates whether a 'vcontext' subtree observes the change.
 data ContextAction = BumpContext
-  deriving stock (Show, Eq, Generic)
-  deriving anyclass (JSON.FromJSON, JSON.ToJSON)
------------------------------------------------------------------------------
--- | Increments a parent's 'Int' model, which it forwards to a child as
--- @props@; used to test that a 'vprops' subtree observes the props phase.
-data PropsAction = BumpProps
   deriving stock (Show, Eq, Generic)
   deriving anyclass (JSON.FromJSON, JSON.ToJSON)
 -----------------------------------------------------------------------------
@@ -1818,8 +1822,7 @@ main = withJS $ do
           contextRoot useContext = component () (\BumpContext -> modifyContext (+1)) $ \_ _ _ ->
             div_ [] [ mount_ contextProbe { useContext } ]
 
-          readProbe :: IO MisoString
-          readProbe = fromJSValUnchecked =<< eval ("document.getElementById('ctx-probe').textContent" :: MisoString)
+          readProbe = readText "ctx-probe"
 
       it "vcontext resolves the app-global context at initial mount" $ do
         liftIO $ startAppWithContext mempty (100 :: Int) contextProbe
@@ -1835,14 +1838,12 @@ main = withJS $ do
         txt <- liftIO readProbe
         txt `shouldBe` ("2" :: MisoString)
 
-      let contextPropagationAttempts = 100 -- 100 * 20ms = 2s
-
       it "useContext = True redraws vcontext when the context changes" $ do
         liftIO $ startAppWithContext mempty (1 :: Int) (contextRoot True)
         ComponentState {..} <- liftIO $
           ((IM.! 1) <$> readIORef components :: IO (ComponentState Int () () ContextAction))
         liftIO (_componentSink BumpContext)
-        updated <- liftIO $ pollFor contextPropagationAttempts ((== ("2" :: MisoString)) <$> readProbe)
+        updated <- liftIO $ pollFor propagationAttempts ((== ("2" :: MisoString)) <$> readProbe)
         updated `shouldBe` True
 
       it "useContext = False does not redraw vcontext when the context changes" $ do
@@ -1852,7 +1853,7 @@ main = withJS $ do
         liftIO (_componentSink BumpContext)
         -- Same total budget as the positive test above, so a non-change here
         -- isn't just "didn't wait long enough".
-        _ <- liftIO $ pollFor contextPropagationAttempts (pure False)
+        _ <- liftIO $ pollFor propagationAttempts (pure False)
         txt <- liftIO readProbe
         txt `shouldBe` ("1" :: MisoString)
 
@@ -1863,15 +1864,9 @@ main = withJS $ do
             div_ [ id_ "props-probe" ] [ vprops (text . ms) ]
 
           -- A root that forwards its own 'Int' model to 'propsProbe' as @props@.
-          propsRoot :: Component () () Int PropsAction
-          propsRoot = component (1 :: Int) (\BumpProps -> this += 1) $ \_ _ m ->
+          propsRoot :: Component () () Int Action
+          propsRoot = component (1 :: Int) (\AddOne -> this += 1) $ \_ _ m ->
             div_ [] [ mountWithProps m propsProbe ]
-
-          readText :: MisoString -> IO MisoString
-          readText elemId = fromJSValUnchecked =<< eval
-            ("document.getElementById('" <> elemId <> "').textContent")
-
-          propsPropagationAttempts = 100 -- 100 * 20ms = 2s
 
       it "vprops resolves the mounting component's props at initial mount" $ do
         let root :: App () Action
@@ -1884,9 +1879,9 @@ main = withJS $ do
       it "vprops re-resolves when the parent redraws with new props" $ do
         liftIO $ startApp mempty propsRoot
         ComponentState {..} <- liftIO $
-          ((IM.! 1) <$> readIORef components :: IO (ComponentState () () Int PropsAction))
-        liftIO (_componentSink BumpProps)
-        updated <- liftIO $ pollFor propsPropagationAttempts ((== ("2" :: MisoString)) <$> readText "props-probe")
+          ((IM.! 1) <$> readIORef components :: IO (ComponentState () () Int Action))
+        liftIO (_componentSink AddOne)
+        updated <- liftIO $ pollFor propagationAttempts ((== ("2" :: MisoString)) <$> readText "props-probe")
         updated `shouldBe` True
 
       it "nested components each see their own props type" $ do
@@ -1918,6 +1913,10 @@ main = withJS $ do
       it "toHtml resolves a bare view's vprops against ()" $ do
         toHtml (div_ [] [ vprops (\() -> "unit") ])
           `shouldBe` "<div>unit</div>"
+
+      it "toHtmlWith resolves vprops against the supplied props" $ do
+        toHtmlWith (7 :: Int) (div_ [] [ vprops (text . ms) ])
+          `shouldBe` "<div>7</div>"
 
     describe "Miso.DSL `await` tests" $ do
       it "Successful Promise resolution should result in a value" $ do

--- a/tests/app/Main.hs
+++ b/tests/app/Main.hs
@@ -1911,8 +1911,19 @@ main = withJS $ do
           `shouldBe` "<div><div id=\"props-probe\">7</div></div>"
 
       it "toHtml resolves a bare view's vprops against ()" $ do
-        toHtml (div_ [] [ vprops (\() -> "unit") ])
+        -- 'const' leaves @props@ polymorphic, so this only compiles because
+        -- the ToHtml instance's @props ~ ()@ context pins it.
+        toHtml (div_ [] [ vprops (const "unit") ])
           `shouldBe` "<div>unit</div>"
+
+      it "a vprops resolving to an empty fragment contributes no child" $ do
+        let root :: App () Action
+            root = component () noop $ \_ _ _ ->
+              div_ [ id_ "props-wrap" ] [ "a", vprops (\() -> vfrag []), "b" ]
+        liftIO $ startApp mempty root
+        count <- liftIO $ fromJSValUnchecked =<< eval
+          ("document.getElementById('props-wrap').childNodes.length" :: MisoString)
+        count `shouldBe` (2 :: Int)
 
       it "toHtmlWith resolves vprops against the supplied props" $ do
         toHtmlWith (7 :: Int) (div_ [] [ vprops (text . ms) ])


### PR DESCRIPTION
Add a `VProps` constructor to `View`, the `props` counterpart of `VContext`, with `vprops` / `withProps` smart constructors.

Because `props` are per-component (unlike the single global `context`), `View` gains a `props` type parameter, mirroring how `model` is already threaded: `View context model action` becomes
`View context props model action`. Mount combinators forget the child's `props` at the boundary exactly as they forget its `model` and `action`, so a `vprops` helper is checked against the enclosing component's props type at compile time.

- Types: `VProps`, `vprops`, `withProps`; child-props variables renamed to `childProps` in `mountWithProps`, `mountWithProps_`, `vcomp` and the `VCompStatic` existential so they no longer shadow the parameter.
- Runtime: `buildVTree` threads the mounting component's current props and resolves `VProps` against them.
- Render: `renderBuilder` takes the current props; `ToHtml (View …)` requires `props ~ ()` so bare views still resolve.
- Docs: `Miso` haddock section, `Miso.Types` header, `Miso.Html.Render` notes, CHANGELOG (breaking change noted), README signature.
- Tests: VProps mount, props-phase re-resolution, nested components with distinct props types, and `toHtml` resolution.