### PR TITLE
feat: `VModel`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ All notable changes to `miso` are documented here.
 
 ### Added
 
+- **`VModel` / `vmodel` / `withModel`.** The `model` counterpart of
+  `VProps`: an ambient accessor (not a node) wrapping a
+  `model -> View context props model action` function, so a helper deep in a
+  view tree can read the enclosing component's `model` without needing it
+  threaded through as an explicit argument. Resolved against the mounting
+  component's current `model` whenever the enclosing `View` is built, and
+  against its initial (or hydrated) `model` when rendered with `toHtml`. A
+  bare `View` has no `model`, so a top-level `vmodel` under `toHtml` raises
+  when forced; pass one with `toHtmlWith`. `withModel` is a synonym for
+  `vmodel`.
 - **`VProps` / `vprops` / `withProps`.** The `props` counterpart of
   `VContext`: an ambient accessor (not a node) wrapping a
   `props -> View context props model action` function, so a helper deep in a
@@ -16,9 +26,10 @@ All notable changes to `miso` are documented here.
   component's current `props` whenever the enclosing `View` is built or
   rendered (`toHtml` on a bare `View` uses `()`). `withProps` is a synonym
   for `vprops`.
-- **`toHtmlWith`.** `toHtmlWith :: props -> View context props model action
-  -> ByteString` renders a `View` whose `props` type is not `()`, supplying
-  the value a `VProps` node resolves against.
+- **`toHtmlWith`.** `toHtmlWith :: props -> model -> View context props model
+  action -> ByteString` renders a `View` whose `props` type is not `()` or
+  that contains a `vmodel`, supplying the values `VProps` / `VModel`
+  accessors resolve against.
 - **`VContext` / `vcontext` / `withContext`.** An ambient accessor (not a
   node) wrapping a `context -> View context props model action` function, so a helper deep in a view tree can read the app-global
   `context` without needing it threaded through as an explicit argument.
@@ -45,7 +56,7 @@ All notable changes to `miso` are documented here.
   synonym declares the shared dictionary set once for `SomeComponent` and
   `SomeStaticComponent`. Call sites such as
   `vcomp_ (static (mountStatic comp))` are unchanged.
-- **`vcontext` / `vprops` children are resolved before being built.** The
+- **`vcontext` / `vprops` / `vmodel` children are resolved before being built.** The
   runtime now looks through these wrappers before deciding what to do with
   a child, so one that resolves to an empty fragment is skipped like an
   inline `fragment []`, and one that resolves to a plain node has its JS

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,14 @@ All notable changes to `miso` are documented here.
   view tree can read the enclosing component's `model` without needing it
   threaded through as an explicit argument. Resolved against the mounting
   component's current `model` whenever the enclosing `View` is built, and
-  against its initial (or hydrated) `model` when rendered with `toHtml`. A
-  bare `View` has no `model`, so a top-level `vmodel` under `toHtml` raises
-  when forced; pass one with `toHtmlWith`. `withModel` is a synonym for
-  `vmodel`.
+  against its initial (or hydrated) `model` when rendered with `toHtml`.
+  `withModel` is a synonym for `vmodel`.
+- **`contentWith_` / `svgWith_`** (`Miso.Native.X.Element.Svg`). Native
+  inline SVG content that reads the enclosing component's `props` / `model`:
+  `contentWith_ props model` renders the content with `toHtmlWith`, and
+  `svgWith_ attrs content` is an `<svg>` that obtains both ambiently via
+  `withProps` / `withModel` so the content may use `vprops` / `vmodel`
+  directly.
 - **`VProps` / `vprops` / `withProps`.** The `props` counterpart of
   `VContext`: an ambient accessor (not a node) wrapping a
   `props -> View context props model action` function, so a helper deep in a
@@ -27,9 +31,8 @@ All notable changes to `miso` are documented here.
   rendered (`toHtml` on a bare `View` uses `()`). `withProps` is a synonym
   for `vprops`.
 - **`toHtmlWith`.** `toHtmlWith :: props -> model -> View context props model
-  action -> ByteString` renders a `View` whose `props` type is not `()` or
-  that contains a `vmodel`, supplying the values `VProps` / `VModel`
-  accessors resolve against.
+  action -> ByteString` renders a `View` whose `props` or `model` type is not
+  `()`, supplying the values `VProps` / `VModel` accessors resolve against.
 - **`VContext` / `vcontext` / `withContext`.** An ambient accessor (not a
   node) wrapping a `context -> View context props model action` function, so a helper deep in a view tree can read the app-global
   `context` without needing it threaded through as an explicit argument.
@@ -56,6 +59,11 @@ All notable changes to `miso` are documented here.
   synonym declares the shared dictionary set once for `SomeComponent` and
   `SomeStaticComponent`. Call sites such as
   `vcomp_ (static (mountStatic comp))` are unchanged.
+- **`toHtml` collapses adjacent text nodes inside fragments and across a
+  `[View]`.** Previously only an element's direct children were collapsed,
+  so an empty text node inside a `vfrag` rendered as a lone space that the
+  client's hydration walk (which recurses into fragments) could not
+  reconcile, silently falling back to a full re-render.
 - **`vcontext` / `vprops` / `vmodel` children are resolved before being built.** The
   runtime now looks through these wrappers before deciding what to do with
   a child, so one that resolves to an empty fragment is skipped like an
@@ -71,11 +79,16 @@ All notable changes to `miso` are documented here.
   (`mount_`, `mountWithProps`, `(+>)`, `vcomp`, …) forget the child's
   `props` at the boundary exactly as they forget its `model` and `action`.
   Update signatures by inserting a `props` variable after `context`; code
-  that leaves it polymorphic needs no other change. `ToHtml (View …)` now
-  requires `props ~ ()` (use `toHtmlWith` otherwise). `content_` in
+  that leaves it polymorphic needs no other change. `ToHtml (View …)` and
+  `ToHtml [View …]` now require `props ~ ()` and `model ~ ()`: a bare `View`
+  is static markup, and a component's view is rendered with
+  `toHtmlWith props model` (so `toHtml (view ctx () m)` becomes
+  `toHtmlWith () m (view ctx () m)`). `content_` in
   `Miso.Native.X.Element.Svg.Property` now takes a
-  `View context () model action`; lift `withProps` above the element to
-  draw from the component's `props`.
+  `View context () () action` — this pins the content's own type
+  parameters, not the enclosing component's; lift `withProps` / `withModel`
+  above the element, or use `svgWith_`, to draw from the component's
+  `props` / `model`.
 
 ## 1.13.0.0
 

--- a/sample-app-native/Main.hs
+++ b/sample-app-native/Main.hs
@@ -628,7 +628,9 @@ svgSection = section "<svg> \8212 inline content via Miso.Svg DSL / load"
     []
   ]
   where
-    svgArt :: View context props Model Action
+    -- 'content_' takes static markup: @props@ and @model@ fixed to @()@.
+    -- Content that reads the model goes through 'SvP.contentWith_' / 'svgWith_'.
+    svgArt :: View context () () Action
     svgArt = Svg.svg_
       [ SvgP.viewBox_ "0 0 100 100"
       , textProp "xmlns" "http://www.w3.org/2000/svg"

--- a/sample-app-native/Main.hs
+++ b/sample-app-native/Main.hs
@@ -46,6 +46,7 @@ import           Miso.Native.X.Element.Input.Property   (placeholder_)
 import qualified Miso.Native.X.Element.Textarea.Event     as TaE
 import qualified Miso.Native.X.Element.Svg.Property       as SvP
 import qualified Miso.Native.X.Element.Svg.Event          as SvE
+import           Miso.Native.X.Element.Svg (svgWith_)
 import qualified Miso.Svg                                  as Svg
 import qualified Miso.Svg.Property                         as SvgP
 import qualified Miso.Native.X.Element.Viewpager.Event    as VpE
@@ -620,17 +621,16 @@ refreshSection rows = section "<refresh> \8212 pull down from the top to load ro
 -- well-formed standalone SVG document.
 svgSection :: View context props Model Action
 svgSection = section "<svg> \8212 inline content via Miso.Svg DSL / load"
-  [ svg_
-    [ SvP.content_ svgArt
-    , SvE.onLoad (Log "svg: load")
+  [ svgWith_
+    [ SvE.onLoad (Log "svg: load")
     , CSS.style_ [ CSS.width "100px", CSS.height "100px" ]
     ]
-    []
+    svgArt
   ]
   where
     -- 'content_' takes static markup: @props@ and @model@ fixed to @()@.
     -- Content that reads the model goes through 'SvP.contentWith_' / 'svgWith_'.
-    svgArt :: View context () () Action
+    svgArt :: View context props Model Action
     svgArt = Svg.svg_
       [ SvgP.viewBox_ "0 0 100 100"
       , textProp "xmlns" "http://www.w3.org/2000/svg"

--- a/src/Miso.hs
+++ b/src/Miso.hs
@@ -221,9 +221,10 @@
 --   | 'VFrag' (Maybe t'Key') ['View' context props model action]
 --   | 'VContext' (context -> 'View' context props model action)
 --   | 'VProps' (props -> 'View' context props model action)
+--   | 'VModel' (model -> 'View' context props model action)
 -- @
 --
--- 'VNode' and 'VText' have a one-to-one mapping from the virtual DOM to the physical DOM. The 'VComp' and 'VFrag' constructors are abstract nodes (live only on the virtual DOM) and do not contain a reference to the physical DOM. 'VContext' and 'VProps' are not nodes at all: they are /ambient accessors/, resolved to one of the other constructors whenever the tree is built or rendered, and so never appear in the virtual DOM the runtime diffs. The existential t'SomeComponent' is what allows embedding polymorphic t'Miso.Types.Component' within a 'View'.
+-- 'VNode' and 'VText' have a one-to-one mapping from the virtual DOM to the physical DOM. The 'VComp' and 'VFrag' constructors are abstract nodes (live only on the virtual DOM) and do not contain a reference to the physical DOM. 'VContext', 'VProps' and 'VModel' are not nodes at all: they are /ambient accessors/, resolved to one of the other constructors whenever the tree is built or rendered, and so never appear in the virtual DOM the runtime diffs. The existential t'SomeComponent' is what allows embedding polymorphic t'Miso.Types.Component' within a 'View'.
 --
 -- @
 -- data t'SomeComponent' context
@@ -249,6 +250,7 @@
 -- * 'vcomp', 'vcomp_' — build a 'VCompStatic' (see below)
 -- * 'vcontext' \/ 'withContext' — build a 'VContext'
 -- * 'vprops' \/ 'withProps' — build a 'VProps'
+-- * 'vmodel' \/ 'withModel' — build a 'VModel'
 --
 -- A full list of element smart constructors built on 'node' (e.g. 'Miso.Html.Element.Miso.Html.Element.div_') can be found in "Miso.Html.Element".
 --
@@ -389,13 +391,49 @@
 -- == Why not @ImplicitParams@ or a @Reader@?
 --
 -- Both are alternatives for ambient values. @ImplicitParams@ (@?props@,
--- @?context@) gives the same "read it where you need it" ergonomics, but is
--- a GHC-specific extension whose constraints leak into every helper's
--- signature. A @Reader@ (or @ReaderT@) over the 'View' would work on any
--- compiler, but forces a monadic style onto view code that is otherwise
--- plain applicative expressions and lists. 'VContext' and 'VProps' keep the
--- 'View' DSL as ordinary Haskell values: the accessor is just another
--- constructor, resolved by the runtime, with nothing to lift or thread.
+-- @?context@, @?model@) gives the same "read it where you need it"
+-- ergonomics, but is a GHC-specific extension whose constraints leak into
+-- every helper's signature. A @Reader@ (or @ReaderT@) over the 'View' would
+-- work on any compiler, but forces a monadic style onto view code that is
+-- otherwise plain applicative expressions and lists. 'VContext', 'VProps'
+-- and 'VModel' keep the 'View' DSL as ordinary Haskell values: the accessor
+-- is just another constructor, resolved by the runtime, with nothing to lift
+-- or thread.
+--
+-- = 'VModel' (ambient model)
+--
+-- 'VModel' completes the trio: an ambient accessor for the enclosing
+-- t'Miso.Types.Component'\'s @model@. It wraps a
+-- @model -> 'View' context props model action@ function that is applied, and
+-- the wrapper discarded, whenever the enclosing 'View' is built or rendered,
+-- so a helper deep in a view tree can read @model@ without needing it
+-- threaded through as an explicit argument — unlike 'Miso.Types.view'
+-- itself, which already receives @model@ as its third parameter.
+--
+-- @
+-- 'vmodel' $ \\Model { count } -> 'Miso.Html.Element.span_' [] [ 'Miso.Types.text' ('Miso.String.ms' count) ]
+-- @
+--
+-- As with @props@, @model@ is a type parameter of 'View', so the @model@ a
+-- 'VModel' sees is statically the @model@ of the t'Miso.Types.Component'
+-- whose 'Miso.Types.view' contains it, and a mismatch is a compile-time
+-- error. A child mounted with 'mount_' \/ 'vcomp' sees /its own/ @model@,
+-- never its parent's.
+--
+-- The function is applied to the current @model@ whenever the enclosing
+-- 'View' is built or rendered. It adds no redraw logic of its own: a
+-- component is redrawn when its @model@ changes after an 'Miso.Types.update',
+-- and the accessor is re-resolved as part of that redraw.
+--
+-- When serialising with 'Miso.Html.Render.toHtml', a bare 'View' has no
+-- @model@ to resolve against, so a top-level 'VModel' raises an exception if
+-- forced — supply one with 'Miso.Html.Render.toHtmlWith'. A 'VModel' inside
+-- a mounted component sees that component's initial (or hydrated) @model@.
+--
+-- The smart constructors for 'VModel' are 'vmodel' and 'withModel'
+-- (a synonym). Like 'withContext' and 'withProps', 'withModel' provides
+-- /ambient/ access to the component's @model@: any helper in the view tree
+-- can reach it without the value being passed down explicitly.
 --
 -- = 'VComp' (Component nodes)
 --
@@ -1272,10 +1310,12 @@
 --
 -- To render a 'View' whose @props@ type is something else — e.g. a
 -- component's 'Miso.Types.view' applied directly, or a subtree containing
--- 'vprops' — pass the @props@ value with 'Miso.Html.Render.toHtmlWith':
+-- 'vprops' or 'vmodel' — pass the @props@ and @model@ values with
+-- 'Miso.Html.Render.toHtmlWith' (a bare 'View' has no @model@ either, so a
+-- top-level 'vmodel' under 'Miso.Html.Render.toHtml' raises when forced):
 --
 -- @
--- 'Miso.Html.Render.toHtmlWith' props ('Miso.Types.view' comp ctx props model)
+-- 'Miso.Html.Render.toHtmlWith' props model ('Miso.Types.view' comp ctx props model)
 -- @
 --
 -- This is typically wired into a Servant handler on the server using the
@@ -1822,6 +1862,8 @@ module Miso
   , withContext
   , vprops
   , withProps
+  , vmodel
+  , withModel
     -- ** Sink
   , withSink
   , Sink

--- a/src/Miso.hs
+++ b/src/Miso.hs
@@ -425,10 +425,10 @@
 -- component is redrawn when its @model@ changes after an 'Miso.Types.update',
 -- and the accessor is re-resolved as part of that redraw.
 --
--- When serialising with 'Miso.Html.Render.toHtml', a bare 'View' has no
--- @model@ to resolve against, so a top-level 'VModel' raises an exception if
--- forced — supply one with 'Miso.Html.Render.toHtmlWith'. A 'VModel' inside
--- a mounted component sees that component's initial (or hydrated) @model@.
+-- When serialising, a bare 'View' under 'Miso.Html.Render.toHtml' is static
+-- markup with @model ~ ()@; a view that reads a real @model@ is rendered with
+-- 'Miso.Html.Render.toHtmlWith', which takes the value. A 'VModel' inside a
+-- mounted component sees that component's initial (or hydrated) @model@.
 --
 -- The smart constructors for 'VModel' are 'vmodel' and 'withModel'
 -- (a synonym). Like 'withContext' and 'withProps', 'withModel' provides
@@ -1297,9 +1297,10 @@
 --   'Miso.Html.ToHtml.toHtml' :: a -> 'Data.ByteString.Lazy.ByteString'
 -- @
 --
--- Instances are provided for @'View' c () m a@ and @['View' c () m a]@ — a
--- bare 'View' has no enclosing component to supply @props@, so they are
--- fixed to @()@ (a 'View' left polymorphic in @props@ resolves to this):
+-- Instances are provided for @'View' c () () a@ and @['View' c () () a]@ — a
+-- bare 'View' is static markup with no enclosing component to supply
+-- @props@ or @model@, so both are fixed to @()@ (a 'View' left polymorphic
+-- in them resolves to this):
 --
 -- @
 -- import "Miso.Html.Render" ('Miso.Html.Render.toHtml')
@@ -1308,11 +1309,10 @@
 -- pageHtml = 'Miso.Html.Render.toHtml' $ 'Miso.Html.Element.div_' [ 'Miso.Html.Property.id_' "root" ] [ "Hello, world!" ]
 -- @
 --
--- To render a 'View' whose @props@ type is something else — e.g. a
--- component's 'Miso.Types.view' applied directly, or a subtree containing
+-- To render a 'View' whose @props@ or @model@ type is something else — e.g.
+-- a component's 'Miso.Types.view' applied directly, or a subtree containing
 -- 'vprops' or 'vmodel' — pass the @props@ and @model@ values with
--- 'Miso.Html.Render.toHtmlWith' (a bare 'View' has no @model@ either, so a
--- top-level 'vmodel' under 'Miso.Html.Render.toHtml' raises when forced):
+-- 'Miso.Html.Render.toHtmlWith':
 --
 -- @
 -- 'Miso.Html.Render.toHtmlWith' props model ('Miso.Types.view' comp ctx props model)
@@ -1837,7 +1837,7 @@ module Miso
     -- main :: 'IO' ()
     -- main = do
     --   'setContext' Dark
-    --   Data.ByteString.Lazy.putStr ('Miso.Html.Render.toHtml' (view Dark () model))
+    --   Data.ByteString.Lazy.putStr ('Miso.Html.Render.toHtmlWith' () model (view Dark () model))
     -- @
   , setContext
   , renderApp

--- a/src/Miso/Html/Render.hs
+++ b/src/Miso/Html/Render.hs
@@ -26,17 +26,23 @@
 -- <https://en.wikipedia.org/wiki/Server-side_scripting server-side rendering (SSR)>
 -- support.
 --
--- Instances are provided for both @'Miso.Types.View' m a@ (a single node)
--- and @['Miso.Types.View' m a]@ (a sequence of nodes).
+-- Instances are provided for both @'Miso.Types.View' c () () a@ (a single
+-- node) and @['Miso.Types.View' c () () a]@ (a sequence of nodes): a bare
+-- 'Miso.Types.View' is static markup with no enclosing component, so its
+-- @props@ and @model@ are fixed to @()@. A component's view, or any subtree
+-- that reads @props@ \/ @model@, is rendered with 'toHtmlWith'.
 --
 -- = Quick start
 --
 -- @
--- import           "Miso.Html.Render" ('ToHtml', 'toHtml')
+-- import           "Miso.Html.Render" ('ToHtml', 'toHtml', 'toHtmlWith')
 -- import qualified Data.ByteString.Lazy as L
 --
 -- renderPage :: Model -> L.ByteString
--- renderPage m = 'toHtml' (view m)
+-- renderPage m = 'toHtmlWith' () m (view () () m)
+--
+-- staticPage :: L.ByteString
+-- staticPage = 'toHtml' ('Miso.Html.Element.div_' [] [ "Hello, world!" ])
 -- @
 --
 -- With @servant@, use @'toHtml'@ inside a @'Data.ByteString.Lazy.ByteString'@
@@ -61,10 +67,9 @@
 --   under 'toHtml'; the value given to 'toHtmlWith' otherwise) and the
 --   result rendered in its place.
 -- * __'Miso.Types.VModel'__ (ambient accessor, not a node) — applied to the
---   initial (or hydrated) @model@ of the enclosing component (the value
---   given to 'toHtmlWith' for a bare 'Miso.Types.View'; under 'toHtml' there
---   is no @model@ to apply it to, and forcing the accessor raises an
---   exception) and the result rendered in its place.
+--   initial (or hydrated) @model@ of the enclosing component (@()@ for a
+--   bare 'Miso.Types.View' under 'toHtml'; the value given to 'toHtmlWith'
+--   otherwise) and the result rendered in its place.
 -- * __Event handlers__ (@'Miso.Types.On'@) — silently dropped; they have
 --   no meaning in a static HTML string.
 -- * __Boolean properties__ (@disabled@, @checked@, @required@, …) — rendered
@@ -116,45 +121,31 @@ class ToHtml a where
 ----------------------------------------------------------------------------
 -- | Render a @Miso.Types.View@ to a @L.ByteString@
 --
--- A bare 'View' has no enclosing t'Component' to supply @props@, so its
--- @props@ are fixed to @()@ (the @props ~ ()@ constraint lets a 'View' that is
--- polymorphic in @props@ still resolve this instance). A 'Miso.Types.VProps'
--- node at this level therefore sees @()@; one nested inside a mounted
--- component sees that component's real @props@.
---
--- Nor is there a @model@ to resolve a 'Miso.Types.VModel' node against: the
--- @model@ type is left free (so existing @toHtml (view ctx () m)@ code keeps
--- compiling), but forcing a 'Miso.Types.VModel' at this level raises an
--- exception. Use 'toHtmlWith' to supply one. A 'Miso.Types.VModel' nested
--- inside a mounted component sees that component's initial (or hydrated)
--- @model@ as usual.
-instance (props ~ ()) => ToHtml (View context props model action) where
+-- A bare 'View' has no enclosing t'Component' to supply @props@ or @model@,
+-- so both are fixed to @()@ (the equality constraints let a 'View' that is
+-- polymorphic in them still resolve this instance). A 'Miso.Types.VProps' \/
+-- 'Miso.Types.VModel' accessor at this level therefore sees @()@; one nested
+-- inside a mounted component sees that component's real @props@ and its
+-- initial (or hydrated) @model@. A 'View' whose @props@ or @model@ type is
+-- something else is rendered with 'toHtmlWith', which takes the values.
+instance (props ~ (), model ~ ()) => ToHtml (View context props model action) where
   toHtml = renderView
 ----------------------------------------------------------------------------
--- | Render a @[Miso.Types.View]@ to a @L.ByteString@
-instance (props ~ ()) => ToHtml [View context props model action] where
-  toHtml = foldMap renderView
+-- | Render a @[Miso.Types.View]@ to a @L.ByteString@. Adjacent text nodes
+-- are collapsed across the list, as they are among an element's children.
+instance (props ~ (), model ~ ()) => ToHtml [View context props model action] where
+  toHtml = toLazyByteString . foldMap (renderBuilder () ()) . collapseSiblingTextNodes () ()
 ----------------------------------------------------------------------------
-renderView :: View context () model action -> L.ByteString
-renderView = toHtmlWith () noModel
-----------------------------------------------------------------------------
--- | The @model@ a bare 'View' is rendered against under 'toHtml'. There is
--- none, so this is a lazy bottom: it is only ever forced by a
--- 'Miso.Types.VModel' node at the top level, where it explains the fix.
-noModel :: model
-noModel = errorWithoutStackTrace $ mconcat
-  [ "Miso.Html.Render.toHtml: a bare View has no enclosing Component to "
-  , "supply a model, so a vmodel / withModel node here cannot be resolved. "
-  , "Render it with toHtmlWith, passing the model explicitly."
-  ]
+renderView :: View context () () action -> L.ByteString
+renderView = toHtmlWith () ()
 ----------------------------------------------------------------------------
 -- | Render a 'View' to a @L.ByteString@, supplying the @props@ and @model@
--- that any 'Miso.Types.VProps' \/ 'Miso.Types.VModel' node in it resolves
--- against.
+-- that any 'Miso.Types.VProps' \/ 'Miso.Types.VModel' accessor in it
+-- resolves against.
 --
--- This is the general form of 'toHtml', for a 'View' whose @props@ type is
--- not @()@ or that contains a 'Miso.Types.vmodel' — e.g. a component's
--- 'Miso.Types.view' applied directly:
+-- This is the general form of 'toHtml', for a 'View' whose @props@ or
+-- @model@ type is not @()@ — e.g. a component's 'Miso.Types.view' applied
+-- directly:
 --
 -- @
 -- toHtmlWith props model (view comp ctx props model)
@@ -247,7 +238,10 @@ renderBuilder _ _ (VComp someComp) = renderComp someComp
 renderBuilder _ _ (VCompStatic ptr props0) =
   case deRefStaticPtr ptr of
     SomeStaticComponent comp_ -> renderComp (SomeComponent Nothing props0 comp_)
-renderBuilder props_ model_ (VFrag _ kids) = foldMap (renderBuilder props_ model_) kids
+renderBuilder props_ model_ (VFrag _ kids) =
+  -- Collapse inside the fragment too: the client's hydration walk recurses
+  -- into fragments before comparing text, so the server must match.
+  foldMap (renderBuilder props_ model_) (collapseSiblingTextNodes props_ model_ kids)
 renderBuilder props_ model_ (VContext f) =
   let ctx = unsafePerformIO (readIORef globalContext) in
   renderBuilder props_ model_ (f ctx)

--- a/src/Miso/Html/Render.hs
+++ b/src/Miso/Html/Render.hs
@@ -60,6 +60,11 @@
 --   @props@ of the enclosing component (@()@ for a bare 'Miso.Types.View'
 --   under 'toHtml'; the value given to 'toHtmlWith' otherwise) and the
 --   result rendered in its place.
+-- * __'Miso.Types.VModel'__ (ambient accessor, not a node) — applied to the
+--   initial (or hydrated) @model@ of the enclosing component (the value
+--   given to 'toHtmlWith' for a bare 'Miso.Types.View'; under 'toHtml' there
+--   is no @model@ to apply it to, and forcing the accessor raises an
+--   exception) and the result rendered in its place.
 -- * __Event handlers__ (@'Miso.Types.On'@) — silently dropped; they have
 --   no meaning in a static HTML string.
 -- * __Boolean properties__ (@disabled@, @checked@, @required@, …) — rendered
@@ -116,6 +121,13 @@ class ToHtml a where
 -- polymorphic in @props@ still resolve this instance). A 'Miso.Types.VProps'
 -- node at this level therefore sees @()@; one nested inside a mounted
 -- component sees that component's real @props@.
+--
+-- Nor is there a @model@ to resolve a 'Miso.Types.VModel' node against: the
+-- @model@ type is left free (so existing @toHtml (view ctx () m)@ code keeps
+-- compiling), but forcing a 'Miso.Types.VModel' at this level raises an
+-- exception. Use 'toHtmlWith' to supply one. A 'Miso.Types.VModel' nested
+-- inside a mounted component sees that component's initial (or hydrated)
+-- @model@ as usual.
 instance (props ~ ()) => ToHtml (View context props model action) where
   toHtml = renderView
 ----------------------------------------------------------------------------
@@ -124,21 +136,33 @@ instance (props ~ ()) => ToHtml [View context props model action] where
   toHtml = foldMap renderView
 ----------------------------------------------------------------------------
 renderView :: View context () model action -> L.ByteString
-renderView = toHtmlWith ()
+renderView = toHtmlWith () noModel
 ----------------------------------------------------------------------------
--- | Render a 'View' to a @L.ByteString@, supplying the @props@ that any
--- 'Miso.Types.VProps' node in it resolves against.
+-- | The @model@ a bare 'View' is rendered against under 'toHtml'. There is
+-- none, so this is a lazy bottom: it is only ever forced by a
+-- 'Miso.Types.VModel' node at the top level, where it explains the fix.
+noModel :: model
+noModel = errorWithoutStackTrace $ mconcat
+  [ "Miso.Html.Render.toHtml: a bare View has no enclosing Component to "
+  , "supply a model, so a vmodel / withModel node here cannot be resolved. "
+  , "Render it with toHtmlWith, passing the model explicitly."
+  ]
+----------------------------------------------------------------------------
+-- | Render a 'View' to a @L.ByteString@, supplying the @props@ and @model@
+-- that any 'Miso.Types.VProps' \/ 'Miso.Types.VModel' node in it resolves
+-- against.
 --
 -- This is the general form of 'toHtml', for a 'View' whose @props@ type is
--- not @()@ — e.g. a component's 'Miso.Types.view' applied directly:
+-- not @()@ or that contains a 'Miso.Types.vmodel' — e.g. a component's
+-- 'Miso.Types.view' applied directly:
 --
 -- @
--- toHtmlWith props (view comp ctx props model)
+-- toHtmlWith props model (view comp ctx props model)
 -- @
 --
 -- @since 1.14.0.0
-toHtmlWith :: props -> View context props model action -> L.ByteString
-toHtmlWith props = toLazyByteString . renderBuilder props
+toHtmlWith :: props -> model -> View context props model action -> L.ByteString
+toHtmlWith props model_ = toLazyByteString . renderBuilder props model_
 ----------------------------------------------------------------------------
 intercalate :: Builder -> [Builder] -> Builder
 intercalate _ [] = ""
@@ -183,13 +207,14 @@ booleanProperties = S.fromList
   , "truespeed"
   ]
 ----------------------------------------------------------------------------
--- | Serialise a 'View' given the @props@ of the t'Component' it belongs to.
--- Entering a @VComp@ \/ @VCompStatic@ switches to that child's @props@.
-renderBuilder :: props -> View context props model action -> Builder
-renderBuilder _ (VText _ "")    = fromMisoString " "
-renderBuilder _ (VText _ s)     = fromMisoString s
-renderBuilder _ (VNode _ "doctype" [] [] _) = "<!doctype html>"
-renderBuilder props_ (VNode ns tag attrs children _) = mconcat
+-- | Serialise a 'View' given the @props@ and @model@ of the t'Component' it
+-- belongs to. Entering a @VComp@ \/ @VCompStatic@ switches to that child's
+-- @props@ and @model@.
+renderBuilder :: props -> model -> View context props model action -> Builder
+renderBuilder _ _ (VText _ "")    = fromMisoString " "
+renderBuilder _ _ (VText _ s)     = fromMisoString s
+renderBuilder _ _ (VNode _ "doctype" [] [] _) = "<!doctype html>"
+renderBuilder props_ model_ (VNode ns tag attrs children _) = mconcat
   [ "<"
   , fromMisoString tag
   , mconcat [ " " <> intercalate " " (renderAttrs <$> attrs)
@@ -198,7 +223,7 @@ renderBuilder props_ (VNode ns tag attrs children _) = mconcat
   , if tag `elem` selfClosing then "/>" else ">"
   , mconcat
     [ mconcat
-      [ foldMap (renderBuilder props_) (collapseSiblingTextNodes props_ children)
+      [ foldMap (renderBuilder props_ model_) (collapseSiblingTextNodes props_ model_ children)
       , "</" <> fromMisoString tag <> ">"
       ]
     | tag `notElem` selfClosing
@@ -218,20 +243,21 @@ renderBuilder props_ (VNode ns tag attrs children _) = mconcat
               | ns == MATHML
               , x <- ["mglyph", "mprescripts", "none", "maligngroup", "malignmark" ]
               ]
-renderBuilder _ (VComp someComp) = renderComp someComp
-renderBuilder _ (VCompStatic ptr props0) =
+renderBuilder _ _ (VComp someComp) = renderComp someComp
+renderBuilder _ _ (VCompStatic ptr props0) =
   case deRefStaticPtr ptr of
     SomeStaticComponent comp_ -> renderComp (SomeComponent Nothing props0 comp_)
-renderBuilder props_ (VFrag _ kids) = foldMap (renderBuilder props_) kids
-renderBuilder props_ (VContext f) =
+renderBuilder props_ model_ (VFrag _ kids) = foldMap (renderBuilder props_ model_) kids
+renderBuilder props_ model_ (VContext f) =
   let ctx = unsafePerformIO (readIORef globalContext) in
-  renderBuilder props_ (f ctx)
-renderBuilder props_ (VProps f) = renderBuilder props_ (f props_)
+  renderBuilder props_ model_ (f ctx)
+renderBuilder props_ model_ (VProps f) = renderBuilder props_ model_ (f props_)
+renderBuilder props_ model_ (VModel f) = renderBuilder props_ model_ (f model_)
 ----------------------------------------------------------------------------
 -- | Render a mounted child component: its 'view' applied to the app-global
 -- @context@, the @props@ it was mounted with, and its initial (or hydrated)
--- @model@. The enclosing component's @props@ play no part, which is why the
--- @VComp@ \/ @VCompStatic@ arms of 'renderBuilder' ignore theirs.
+-- @model@. The enclosing component's @props@ and @model@ play no part, which
+-- is why the @VComp@ \/ @VCompStatic@ arms of 'renderBuilder' ignore theirs.
 renderComp :: SomeComponent context -> Builder
 renderComp (SomeComponent _key props comp_) =
   -- The app-global @context@ is read from 'globalContext'. For the common
@@ -239,12 +265,13 @@ renderComp (SomeComponent _key props comp_) =
   -- never forced. But if a 'Miso.Lens.view' here inspects a non-trivial @context@,
   -- SSR must seed the cell with 'Miso.setContext' before serializing, or
   -- forcing @ctx@ raises an exception. See 'Miso.setContext' for details.
-  let ctx = unsafePerformIO (readIORef globalContext) in
+  let ctx = unsafePerformIO (readIORef globalContext)
 #ifdef SSR
-  renderBuilder props (view comp_ ctx props (getInitialComponentModel comp_))
+      model_ = getInitialComponentModel comp_
 #else
-  renderBuilder props (view comp_ ctx props (model comp_))
+      model_ = model comp_
 #endif
+  in renderBuilder props model_ (view comp_ ctx props model_)
 ----------------------------------------------------------------------------
 renderAttrs :: Attribute model action -> Builder
 renderAttrs (ClassList classes) =
@@ -294,16 +321,18 @@ renderAttrs (Styles styles_) =
 -- this means we must collapse adjacent text nodes during hydration.
 collapseSiblingTextNodes
   :: props
+  -> model
   -> [View context props model action]
   -> [View context props model action]
-collapseSiblingTextNodes props_ = go
+collapseSiblingTextNodes props_ model_ = go
   where
-    -- Look through the wrapper constructors first, so a 'VProps' \/ 'VContext'
-    -- that resolves to text is collapsed with its neighbours exactly as the
-    -- client does after 'buildVTree' has resolved it. Otherwise an empty
-    -- 'VText' behind a wrapper renders as a lone space that hydration
-    -- cannot reconcile.
+    -- Look through the wrapper constructors first, so a 'VProps' \/ 'VModel'
+    -- \/ 'VContext' that resolves to text is collapsed with its neighbours
+    -- exactly as the client does after 'buildVTree' has resolved it.
+    -- Otherwise an empty 'VText' behind a wrapper renders as a lone space
+    -- that hydration cannot reconcile.
     go (VProps f : xs) = go (f props_ : xs)
+    go (VModel f : xs) = go (f model_ : xs)
     go (VContext f : xs) = go (f (unsafePerformIO (readIORef globalContext)) : xs)
     go (VText _ x : VText k y : xs) = go (VText k (x <> y) : xs)
     go (x : xs) = x : go xs

--- a/src/Miso/Native/X/Element/Svg.hs
+++ b/src/Miso/Native/X/Element/Svg.hs
@@ -31,7 +31,7 @@ import Miso.Types (Attribute, View, withModel, withProps)
 -- component's @props@ and @model@, so the content may itself use
 -- 'Miso.Types.vprops' \/ 'Miso.Types.vmodel'. The values are obtained
 -- ambiently with 'Miso.Types.withProps' \/ 'Miso.Types.withModel' and passed
--- to 'contentWith_':
+-- to 'content_':
 --
 -- @
 -- svgWith_ [ 'Miso.CSS.style_' [ 'Miso.CSS.width' "100px" ] ] $
@@ -50,5 +50,5 @@ svgWith_
   -> View context props model action
 svgWith_ attrs content =
   withProps $ \props -> withModel $ \model ->
-    svg_ (contentWith_ props model content : attrs) []
+    svg_ (content_ props model content : attrs) []
 -----------------------------------------------------------------------------

--- a/src/Miso/Native/X/Element/Svg.hs
+++ b/src/Miso/Native/X/Element/Svg.hs
@@ -16,10 +16,39 @@
 -- @since 1.13.0.0
 ----------------------------------------------------------------------------
 module Miso.Native.X.Element.Svg
-  ( module Miso.Native.X.Element.Svg.Event
+  ( -- *** Element
+    svgWith_
+  , module Miso.Native.X.Element.Svg.Event
   , module Miso.Native.X.Element.Svg.Property
   ) where
 -----------------------------------------------------------------------------
+import Miso.Native.X.Element (svg_)
 import Miso.Native.X.Element.Svg.Event
 import Miso.Native.X.Element.Svg.Property
+import Miso.Types (Attribute, View, withModel, withProps)
+-----------------------------------------------------------------------------
+-- | An @\<svg\>@ whose inline content is rendered against the enclosing
+-- component's @props@ and @model@, so the content may itself use
+-- 'Miso.Types.vprops' \/ 'Miso.Types.vmodel'. The values are obtained
+-- ambiently with 'Miso.Types.withProps' \/ 'Miso.Types.withModel' and passed
+-- to 'contentWith_':
+--
+-- @
+-- svgWith_ [ 'Miso.CSS.style_' [ 'Miso.CSS.width' "100px" ] ] $
+--   Svg.svg_ [ textProp "xmlns" "http://www.w3.org/2000/svg" ]
+--     [ 'Miso.Types.vmodel' $ \\Model { color } -> Svg.circle_ [ Svg.fill_ color ] [] ]
+-- @
+--
+-- Compare 'content_', which takes static content with @props@ and @model@
+-- fixed to @()@.
+--
+-- @since 1.14.0.0
+svgWith_
+  :: [Attribute model action]
+  -> View context props model action
+  -- ^ Inline SVG content, in the component's own @props@ \/ @model@ types
+  -> View context props model action
+svgWith_ attrs content =
+  withProps $ \props -> withModel $ \model ->
+    svg_ (contentWith_ props model content : attrs) []
 -----------------------------------------------------------------------------

--- a/src/Miso/Native/X/Element/Svg/Property.hs
+++ b/src/Miso/Native/X/Element/Svg/Property.hs
@@ -14,6 +14,7 @@
 module Miso.Native.X.Element.Svg.Property
   ( -- *** Property
     content_
+  , contentWith_
   , contentRaw_
   , src_
   ) where
@@ -21,7 +22,7 @@ module Miso.Native.X.Element.Svg.Property
 import           Miso.String (MisoString, ms)
 import           Miso.Types (Attribute, View)
 import           Miso.Property
-import           Miso.Html.Render (toHtml)
+import           Miso.Html.Render (toHtmlWith)
 -----------------------------------------------------------------------------
 -- | https://lynxjs.org/api/elements/built-in/svg.html#content
 --
@@ -42,20 +43,36 @@ contentRaw_ = textProp "content"
 --
 -- The content is serialised to a string when the attribute is built, so the
 -- 'Miso.Types.View' has no enclosing component to take @props@ or @model@
--- from: its @props@ are fixed to @()@, and a 'Miso.Types.vmodel' inside it
--- raises when forced. To draw from the component's @props@ or @model@, lift
--- 'Miso.Types.withProps' \/ 'Miso.Types.withModel' above the element instead
--- of using 'Miso.Types.vprops' \/ 'Miso.Types.vmodel' inside the content:
+-- from: both are fixed to @()@, and a 'Miso.Types.vprops' \/
+-- 'Miso.Types.vmodel' inside the content is a type error. Event handlers
+-- are dropped by the serialiser. Note this pins the /content's/ type
+-- parameters only — the enclosing component's @model@ is unconstrained. To
+-- draw from the component's @props@ or @model@, either lift
+-- 'Miso.Types.withProps' \/ 'Miso.Types.withModel' above the element so the
+-- values are closed over:
 --
--- > withProps $ \Props { color } ->
+-- > withModel $ \Model { color } ->
 -- >   svg_
 -- >     [ content_ $ Svg.svg_ [ textProp "xmlns" "http://www.w3.org/2000/svg" ]
 -- >         [ Svg.circle_ [ Svg.fill_ color ] [] ]
 -- >     ]
 -- >     []
 --
-content_ :: View context () model action -> Attribute model action
-content_ = textProp "content" . ms . toHtml
+-- or use 'Miso.Native.X.Element.Svg.svgWith_', which does that lifting and
+-- lets the content itself use 'Miso.Types.vprops' \/ 'Miso.Types.vmodel'.
+--
+content_ :: View context () () action -> Attribute model action
+content_ = contentWith_ () ()
+-----------------------------------------------------------------------------
+-- | 'content_' for a 'Miso.Types.View' that reads the enclosing component's
+-- @props@ \/ @model@ (via 'Miso.Types.vprops' \/ 'Miso.Types.vmodel'):
+-- the values are supplied explicitly and the content is rendered with
+-- 'Miso.Html.Render.toHtmlWith'. 'Miso.Native.X.Element.Svg.svgWith_'
+-- obtains them ambiently for you.
+--
+-- @since 1.14.0.0
+contentWith_ :: props -> model -> View context props model action -> Attribute model action
+contentWith_ props model = textProp "content" . ms . toHtmlWith props model
 -----------------------------------------------------------------------------
 -- | https://lynxjs.org/api/elements/built-in/svg.html#src
 --

--- a/src/Miso/Native/X/Element/Svg/Property.hs
+++ b/src/Miso/Native/X/Element/Svg/Property.hs
@@ -41,10 +41,11 @@ contentRaw_ = textProp "content"
 -- N.B. Must use "Miso.Svg" and 'Miso.Svg.Element.svg_' combinator.
 --
 -- The content is serialised to a string when the attribute is built, so the
--- 'Miso.Types.View' has no enclosing component to take @props@ from and its
--- @props@ are fixed to @()@. To draw from the component's @props@, lift
--- 'Miso.Types.withProps' above the element instead of using
--- 'Miso.Types.vprops' inside the content:
+-- 'Miso.Types.View' has no enclosing component to take @props@ or @model@
+-- from: its @props@ are fixed to @()@, and a 'Miso.Types.vmodel' inside it
+-- raises when forced. To draw from the component's @props@ or @model@, lift
+-- 'Miso.Types.withProps' \/ 'Miso.Types.withModel' above the element instead
+-- of using 'Miso.Types.vprops' \/ 'Miso.Types.vmodel' inside the content:
 --
 -- > withProps $ \Props { color } ->
 -- >   svg_

--- a/src/Miso/Native/X/Element/Svg/Property.hs
+++ b/src/Miso/Native/X/Element/Svg/Property.hs
@@ -14,7 +14,6 @@
 module Miso.Native.X.Element.Svg.Property
   ( -- *** Property
     content_
-  , contentWith_
   , contentRaw_
   , src_
   ) where
@@ -51,9 +50,10 @@ contentRaw_ = textProp "content"
 -- 'Miso.Types.withProps' \/ 'Miso.Types.withModel' above the element so the
 -- values are closed over:
 --
--- > withModel $ \Model { color } ->
+-- > withProps $ \props -> withModel $ \model ->
 -- >   svg_
--- >     [ content_ $ Svg.svg_ [ textProp "xmlns" "http://www.w3.org/2000/svg" ]
+-- >     [ content_ props model $ Svg.svg_
+-- >         [ textProp "xmlns" "http://www.w3.org/2000/svg" ]
 -- >         [ Svg.circle_ [ Svg.fill_ color ] [] ]
 -- >     ]
 -- >     []
@@ -61,18 +61,10 @@ contentRaw_ = textProp "content"
 -- or use 'Miso.Native.X.Element.Svg.svgWith_', which does that lifting and
 -- lets the content itself use 'Miso.Types.vprops' \/ 'Miso.Types.vmodel'.
 --
-content_ :: View context () () action -> Attribute model action
-content_ = contentWith_ () ()
------------------------------------------------------------------------------
--- | 'content_' for a 'Miso.Types.View' that reads the enclosing component's
--- @props@ \/ @model@ (via 'Miso.Types.vprops' \/ 'Miso.Types.vmodel'):
--- the values are supplied explicitly and the content is rendered with
--- 'Miso.Html.Render.toHtmlWith'. 'Miso.Native.X.Element.Svg.svgWith_'
--- obtains them ambiently for you.
 --
 -- @since 1.14.0.0
-contentWith_ :: props -> model -> View context props model action -> Attribute model action
-contentWith_ props model = textProp "content" . ms . toHtmlWith props model
+content_ :: props -> model -> View context props model action -> Attribute model action
+content_ props model = textProp "content" . ms . toHtmlWith props model
 -----------------------------------------------------------------------------
 -- | https://lynxjs.org/api/elements/built-in/svg.html#src
 --

--- a/src/Miso/Runtime.hs
+++ b/src/Miso/Runtime.hs
@@ -1245,6 +1245,7 @@ buildVTree
   -> props
   -- ^ The mounting component's current @props@, resolved by 'VProps'.
   -> model
+  -- ^ The mounting component's current @model@, resolved by 'VModel'.
   -> View context props model action
   -> IO VTree
 buildVTree events_ parentId_ vcompId hydrate live snk logLevel_ props_ model_ = \case
@@ -1293,18 +1294,21 @@ buildVTree events_ parentId_ vcompId hydrate live snk logLevel_ props_ model_ = 
   v@VContext {} -> go =<< resolve v
 
   v@VProps {} -> go =<< resolve v
+
+  v@VModel {} -> go =<< resolve v
   where
     -- Recurse with every argument but the 'View' unchanged.
     go :: View context props model action -> IO VTree
     go = buildVTree events_ parentId_ vcompId hydrate live snk logLevel_ props_ model_
 
-    -- Look through the wrapper constructors ('VProps', 'VContext') to the
-    -- node they resolve to. Every child goes through this before it is
+    -- Look through the wrapper constructors ('VProps', 'VModel', 'VContext')
+    -- to the node they resolve to. Every child goes through this before it is
     -- built, so 'freeable' decides on the real constructor and a wrapper
     -- resolving to @fragment []@ hits the empty-fragment skip in 'buildKid'.
     resolve :: View context props model action -> IO (View context props model action)
     resolve = \case
       VProps f -> resolve (f props_)
+      VModel f -> resolve (f model_)
       VContext f -> resolve . f =<< readIORef @context globalContext
       v -> pure v
 
@@ -1362,6 +1366,7 @@ buildVTree events_ parentId_ vcompId hydrate live snk logLevel_ props_ model_ = 
       -- 'freeKid' pair always holds the resolved node. Conservative anyway.
       VContext {} -> False
       VProps {} -> False
+      VModel {} -> False
 
     isEvent :: Attribute model action -> Bool
     isEvent = \case

--- a/src/Miso/Types.hs
+++ b/src/Miso/Types.hs
@@ -894,11 +894,11 @@ withProps = vprops
 -- redrawn when its @model@ changes after an 'update', and the node is
 -- re-resolved against the new @model@ as part of that redraw.
 --
--- When serialising with 'Miso.Html.Render.toHtml', a bare 'View' has no
--- enclosing component to supply a @model@, so a 'VModel' at that level
--- cannot be resolved and raises an exception if forced; pass the @model@
--- with 'Miso.Html.Render.toHtmlWith' instead. One nested inside a mounted
--- component always sees that component's initial (or hydrated) @model@.
+-- When serialising, a bare 'View' under 'Miso.Html.Render.toHtml' has no
+-- enclosing component to supply a @model@, so its @model@ is fixed to @()@;
+-- pass a real @model@ with 'Miso.Html.Render.toHtmlWith' instead. A 'VModel'
+-- nested inside a mounted component always sees that component's initial
+-- (or hydrated) @model@.
 --
 -- @since 1.14.0.0
 vmodel :: (model -> View context props model action) -> View context props model action

--- a/src/Miso/Types.hs
+++ b/src/Miso/Types.hs
@@ -80,12 +80,13 @@
 --   so it can cross the Lynx dual-thread boundary (see 'vcomp' \/ 'mountStatic')
 -- * 'VFrag' — a group of siblings with no wrapper element, optionally keyed
 --
--- The remaining two are /ambient accessors/, not nodes. Each wraps a
+-- The remaining three are /ambient accessors/, not nodes. Each wraps a
 -- function that is applied — and the wrapper discarded — when the tree is
--- built or rendered, so neither ever appears in the virtual DOM:
+-- built or rendered, so none of them ever appears in the virtual DOM:
 --
 -- * 'VContext' — reads the app-global @context@
 -- * 'VProps' — reads the enclosing t'Component'\'s @props@
+-- * 'VModel' — reads the enclosing t'Component'\'s @model@
 --
 -- (@ImplicitParams@ or a @Reader@ could play the same role, at the cost of a
 -- GHC-specific extension or a monadic style for view code; see the
@@ -213,6 +214,9 @@ module Miso.Types
   -- ** Props combinator
   , vprops
   , withProps
+  -- ** Model combinator
+  , vmodel
+  , withModel
   -- ** Utils
   , getMountPoint
   , optionalAttrs
@@ -482,6 +486,11 @@ data View context props model action
     -- node. The function is applied, and this wrapper discarded, at the point
     -- the enclosing 'View' is built or rendered, letting a helper read
     -- @props@ without threading it through as an extra argument. See 'vprops'.
+  | VModel (model -> View context props model action)
+    -- ^ Ambient accessor for the enclosing t'Component'\'s @model@ — not a
+    -- node. The function is applied, and this wrapper discarded, at the point
+    -- the enclosing 'View' is built or rendered, letting a helper read
+    -- @model@ without threading it through as an extra argument. See 'vmodel'.
 -----------------------------------------------------------------------------
 -- | The dictionaries a t'Component' must carry to be mounted as a child:
 -- equality for dirty-checking, plus (under the @native@ flag) JSON for
@@ -862,6 +871,45 @@ vprops = VProps
 -- @since 1.14.0.0
 withProps :: (props -> View context props model action) -> View context props model action
 withProps = vprops
+
+-----------------------------------------------------------------------------
+-- | Create a new 'Miso.Types.VModel'.
+--
+-- Embeds a subtree that is resolved against the enclosing t'Component'\'s
+-- @model@ at the point the enclosing 'View' is built or rendered, so a helper
+-- deep in a view tree can read @model@ without needing it threaded through as
+-- an explicit argument — unlike 'view' itself, which already receives @model@
+-- as its third parameter.
+--
+-- @
+-- vmodel $ \\Model { count } -> span_ [] [ text (ms count) ]
+-- @
+--
+-- Because @model@ is a type parameter of 'View', the @model@ seen here is
+-- statically the @model@ of the t'Component' whose 'view' contains this
+-- node — a mismatch is a compile-time error. A child mounted with 'mount_' \/
+-- 'vcomp' sees /its own/ @model@, not its parent's.
+--
+-- __Note:__ a 'VModel' node adds no redraw logic of its own. A component is
+-- redrawn when its @model@ changes after an 'update', and the node is
+-- re-resolved against the new @model@ as part of that redraw.
+--
+-- When serialising with 'Miso.Html.Render.toHtml', a bare 'View' has no
+-- enclosing component to supply a @model@, so a 'VModel' at that level
+-- cannot be resolved and raises an exception if forced; pass the @model@
+-- with 'Miso.Html.Render.toHtmlWith' instead. One nested inside a mounted
+-- component always sees that component's initial (or hydrated) @model@.
+--
+-- @since 1.14.0.0
+vmodel :: (model -> View context props model action) -> View context props model action
+vmodel = VModel
+
+-----------------------------------------------------------------------------
+-- | Synonym for 'vmodel'.
+--
+-- @since 1.14.0.0
+withModel :: (model -> View context props model action) -> View context props model action
+withModel = vmodel
 -----------------------------------------------------------------------------
 -- | DOM element namespace.
 data Namespace

--- a/tests/app/Main.hs
+++ b/tests/app/Main.hs
@@ -1926,8 +1926,68 @@ main = withJS $ do
         count `shouldBe` (2 :: Int)
 
       it "toHtmlWith resolves vprops against the supplied props" $ do
-        toHtmlWith (7 :: Int) (div_ [] [ vprops (text . ms) ])
+        toHtmlWith (7 :: Int) () (div_ [] [ vprops (text . ms) ])
           `shouldBe` "<div>7</div>"
+
+    describe "VModel tests" $ do
+      let -- A root whose 'Int' model is displayed via 'vmodel' rather than
+          -- through the 'view' argument.
+          modelRoot :: App Int Action
+          modelRoot = component (1 :: Int) (\AddOne -> this += 1) $ \_ _ _ ->
+            div_ [ id_ "model-probe" ] [ vmodel (text . ms) ]
+
+      it "vmodel resolves the component's model at initial mount" $ do
+        liftIO $ startApp mempty modelRoot
+        txt <- liftIO (readText "model-probe")
+        txt `shouldBe` ("1" :: MisoString)
+
+      it "vmodel re-resolves when the model changes" $ do
+        liftIO $ startApp mempty modelRoot
+        ComponentState {..} <- liftIO $
+          ((IM.! 1) <$> readIORef components :: IO (ComponentState () () Int Action))
+        liftIO (_componentSink AddOne)
+        updated <- liftIO $ pollFor propagationAttempts ((== ("2" :: MisoString)) <$> readText "model-probe")
+        updated `shouldBe` True
+
+      it "nested components each see their own model type" $ do
+        -- The mount boundary forgets the child's @model@, so an 'Int'-model
+        -- parent can host a 'MisoString'-model child and each 'vmodel' /
+        -- 'withModel' resolves against its own component.
+        let inner :: Component () () MisoString Action
+            inner = component ("inner" :: MisoString) noop $ \_ _ _ ->
+              span_ [ id_ "model-inner" ] [ withModel text ]
+            outer :: Component () () Int Action
+            outer = component (7 :: Int) noop $ \_ _ _ ->
+              div_ [ id_ "model-outer" ]
+                [ span_ [] [ vmodel (text . ms) ]
+                , mount_ inner
+                ]
+        liftIO $ startApp mempty outer
+        outerTxt <- liftIO (readText "model-outer")
+        innerTxt <- liftIO (readText "model-inner")
+        outerTxt `shouldBe` ("7inner" :: MisoString)
+        innerTxt `shouldBe` ("inner" :: MisoString)
+
+      it "toHtml resolves vmodel against the mounted component's initial model" $ do
+        toHtml (div_ [] [ mount_ modelRoot ])
+          `shouldBe` "<div><div id=\"model-probe\">1</div></div>"
+
+      it "a vmodel resolving to an empty fragment contributes no child" $ do
+        let root :: App () Action
+            root = component () noop $ \_ _ _ ->
+              div_ [ id_ "model-wrap" ] [ "a", vmodel (\() -> vfrag []), "b" ]
+        liftIO $ startApp mempty root
+        count <- liftIO $ fromJSValUnchecked =<< eval
+          ("document.getElementById('model-wrap').childNodes.length" :: MisoString)
+        count `shouldBe` (2 :: Int)
+
+      it "toHtmlWith resolves vmodel against the supplied model" $ do
+        toHtmlWith () (7 :: Int) (div_ [] [ vmodel (text . ms) ])
+          `shouldBe` "<div>7</div>"
+
+      it "toHtmlWith collapses a vmodel text node with its neighbours" $ do
+        toHtmlWith () ("b" :: MisoString) (div_ [] [ "a", withModel text, "c" ])
+          `shouldBe` "<div>abc</div>"
 
     describe "Miso.DSL `await` tests" $ do
       it "Successful Promise resolution should result in a value" $ do

--- a/tests/app/Main.hs
+++ b/tests/app/Main.hs
@@ -1989,6 +1989,16 @@ main = withJS $ do
         toHtmlWith () ("b" :: MisoString) (div_ [] [ "a", withModel text, "c" ])
           `shouldBe` "<div>abc</div>"
 
+      it "toHtmlWith collapses text nodes inside a fragment, matching the client" $ do
+        -- An empty model string behind 'withModel' must not become a lone
+        -- space: hydrate.ts recurses into fragments before comparing text.
+        toHtmlWith () ("" :: MisoString) (div_ [] [ vfrag [ "a", withModel text, "c" ] ])
+          `shouldBe` "<div>ac</div>"
+
+      it "toHtml collapses text nodes across a [View]" $ do
+        toHtml ([ "a", "", "c" ] :: [View () () () Action])
+          `shouldBe` "ac"
+
     describe "Miso.DSL `await` tests" $ do
       it "Successful Promise resolution should result in a value" $ do
         -- Create a Promise and immediately resolve it with `42`


### PR DESCRIPTION
## Summary

Adds `VModel`, the `model` counterpart of `VProps` / `VContext`: an ambient accessor (not a node) wrapping a `model -> View context props model action` function, with `vmodel` and `withModel` smart constructors. Like `withContext` and `withProps`, `withModel` gives any helper in the view tree ambient access to the component's `model` without threading it down explicitly.

- **Types**: new `VModel` constructor on `View`, `vmodel` / `withModel`, exported from `Miso` and `Miso.Types`.
- **Runtime**: `buildVTree` resolves `VModel` through the same wrapper path as `VProps` / `VContext`, so an empty-fragment result is skipped and JS handles are freed as usual.
- **Render**: `Miso.Html.Render` threads `model` alongside `props`; `toHtmlWith` is now `props -> model -> View -> ByteString`. A bare `View` under `toHtml` leaves `model` free (so existing `toHtml (view ctx () m)` code keeps compiling) and a top-level `vmodel` raises a descriptive error only when forced. Mounted components resolve against their initial (or hydrated) model. Verified under both `-fssr` and default flags.
- **Docs**: `Miso`, `Miso.Types`, `Miso.Html.Render` and the native SVG `content_` docs updated in the "ambient accessor" framing from #1638; CHANGELOG entry added.
- **Tests**: seven new `VModel` cases in `tests/app/Main.hs` (initial mount, redraw on model change, nested components with distinct model types, empty fragment, `toHtml`, `toHtmlWith`, text-node collapsing).

Not in scope (deferred to a separate branch): restoring a `ToHtml (Component ...)` instance.

## Test plan

- [x] `nix develop --command bash -c 'cabal build'`
- [x] `cabal build all` (library, tests, sample apps)
- [x] `cabal build lib:miso -fssr`
- [x] `cabal haddock lib:miso`
- [x] WASM browser test suite (`tests/`) — not run locally
