### PR TITLE
refactor: VCompStatic carries a StaticMount existential

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,11 @@ All notable changes to `miso` are documented here.
   handle freed after linking like any other node. `toHtml` likewise
   resolves them before collapsing adjacent text nodes, matching the
   client's hydration-time tree.
+- **`VCompStatic` now carries a `StaticMount context`.** The
+  `StaticPtr (SomeStaticComponent props context)` / `props` pair that
+  `VCompStatic` held inline is now the `StaticMount` existential, mirroring
+  `VComp (SomeComponent context)`. `vcomp` / `vcomp_` are unchanged; only
+  code pattern-matching on `VCompStatic` directly needs updating.
 - **Breaking: `View` gained a `props` type parameter.** `View context model
   action` is now `View context props model action`, matching the order of
   `Component context props model action`. Unlike `context`, `props` are

--- a/src/Miso.hs
+++ b/src/Miso.hs
@@ -217,7 +217,7 @@
 --   = 'VNode' 'Namespace' 'Tag' ['Attribute' model action] ['View' context props model action] 'DirectEvents'
 --   | 'VText' (Maybe t'Key') 'MisoString'
 --   | 'VComp' ('SomeComponent' context)
---   | forall childProps . 'VCompStatic' (StaticPtr ('SomeStaticComponent' childProps context)) childProps
+--   | 'VCompStatic' ('StaticMount' context)
 --   | 'VFrag' (Maybe t'Key') ['View' context props model action]
 --   | 'VContext' (context -> 'View' context props model action)
 --   | 'VProps' (props -> 'View' context props model action)
@@ -229,6 +229,9 @@
 -- data t'SomeComponent' context
 --   = forall model action props . ('Eq' context, 'Eq' model, 'Eq' props)
 --   => t'SomeComponent' (Maybe t'Key') props ('Miso.Types.Component' context props model action)
+--
+-- data t'StaticMount' context
+--   = forall props . t'StaticMount' (StaticPtr (t'SomeStaticComponent' props context)) props
 -- @
 --
 -- The smart constructors:

--- a/src/Miso/Html/Render.hs
+++ b/src/Miso/Html/Render.hs
@@ -219,7 +219,7 @@ renderBuilder props_ (VNode ns tag attrs children _) = mconcat
               , x <- ["mglyph", "mprescripts", "none", "maligngroup", "malignmark" ]
               ]
 renderBuilder _ (VComp someComp) = renderComp someComp
-renderBuilder _ (VCompStatic ptr props0) =
+renderBuilder _ (VCompStatic (StaticMount ptr props0)) =
   case deRefStaticPtr ptr of
     SomeStaticComponent mk -> renderComp (mk props0)
 renderBuilder props_ (VFrag _ kids) = foldMap (renderBuilder props_) kids

--- a/src/Miso/Runtime.hs
+++ b/src/Miso/Runtime.hs
@@ -1250,7 +1250,7 @@ buildVTree
 buildVTree events_ parentId_ vcompId hydrate live snk logLevel_ props_ model_ = \case
   VComp someComp -> buildComp Nothing someComp
 
-  VCompStatic ptr props -> case deRefStaticPtr ptr of
+  VCompStatic (StaticMount ptr props) -> case deRefStaticPtr ptr of
     SomeStaticComponent mk -> buildComp (Just (staticKey ptr)) (mk props)
 
   VNode ns tag attrs kids _directEvents -> do

--- a/src/Miso/Types.hs
+++ b/src/Miso/Types.hs
@@ -164,6 +164,7 @@ module Miso.Types
   , ComponentId
   , SomeComponent (..)
   , SomeStaticComponent         (..)
+  , StaticMount                 (..)
   , EventHandler  (..)
   , View          (..)
   , Key           (..)
@@ -461,7 +462,7 @@ data View context props model action
     -- elements. See 'nodeDirectEvents'.
   | VText (Maybe Key) MisoString
   | VComp (SomeComponent context)
-  | forall childProps . VCompStatic (StaticPtr (SomeStaticComponent childProps context)) childProps
+  | VCompStatic (StaticMount context)
     -- ^ An embedded child t'Component'. The 'StaticPtr' holds only the closed
     -- @props -> component@ constructor ('SomeStaticComponent'); the @props@ value — often
     -- derived from the parent's @model@ — rides alongside and crosses the
@@ -492,6 +493,21 @@ data SomeComponent context
    = forall model action props . (Eq context, Eq model, Eq props)
 #endif
   => SomeComponent (Maybe Key) props (Component context props model action)
+-----------------------------------------------------------------------------
+-- | A 'StaticPtr' to a closed @props -> component@ constructor
+-- ('SomeStaticComponent'), paired with the runtime @props@ value to apply it
+-- to. The pairing is what a @VCompStatic@ node carries, mirroring how
+-- @VComp@ carries a t'SomeComponent'.
+--
+-- The existential hides the child's @props@ type; within it the @props@
+-- value and the constructor are guaranteed to agree, because 'vcomp' (the
+-- only public way to build one) requires them to. Only the constructor is
+-- behind @static@ — the @props@ value is ordinary runtime data, so it may
+-- depend on the parent's @model@.
+--
+-- @since 1.14.0.0
+data StaticMount context
+  = forall props . StaticMount (StaticPtr (SomeStaticComponent props context)) props
 -----------------------------------------------------------------------------
 -- | A closed @props -> component@ constructor, bundled with the serialization
 -- dictionaries needed to move @props@ across the dual-thread (Lynx) boundary.
@@ -754,7 +770,7 @@ vcomp
   :: childProps
   -> StaticPtr (SomeStaticComponent childProps context)
   -> View context props model action
-vcomp = flip VCompStatic
+vcomp props ptr = VCompStatic (StaticMount ptr props)
 -----------------------------------------------------------------------------
 -- | Like 'vcomp', but for a t'Miso.Types.Component' that takes no @props@.
 --


### PR DESCRIPTION
## Summary

Move the `StaticPtr (SomeStaticComponent props context)` / `props` pair out of the `View` declaration into its own `StaticMount context` existential, so `VCompStatic (StaticMount context)` mirrors `VComp (SomeComponent context)`.

- `vcomp` / `vcomp_` are unchanged; only direct pattern matches on `VCompStatic` (Runtime `buildVTree`, Render `renderBuilder`) needed updating.
- The `static` boundary is untouched: the props value is paired with the pointer outside `static`, as before.
- `StaticMount (..)` is exported from `Miso.Types`; docs in `Miso` and `Miso.Types` and a CHANGELOG entry under Changed.

This was originally part of #1638 and reverted there to keep that PR focused; this is the same change rebased onto master.

## Test plan

- [x] `nix develop --command bash -c 'cabal build'`
- [x] `cabal build all` (library, tests, sample apps)
- [x] `cabal haddock lib:miso`
- [ ] WASM browser test suite (`tests/`) — not run locally
