### PR TITLE
refactor: `SomeStaticComponent` holds `Component`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,23 @@ All notable changes to `miso` are documented here.
 
 ### Changed
 
+- **`SomeStaticComponent` now holds the component; `propsTypeOnly` is
+  gone.** A static mount is the component itself bundled with its
+  dictionaries, `SomeStaticComponent props context` (existential over `model`
+  / `action`, `props` kept visible), rather than a `props -> SomeComponent`
+  function. `VCompStatic` holds `StaticPtr (SomeStaticComponent props context)`
+  next to the `props` value and the runtime builds the `SomeComponent` at
+  mount time. Because the dictionaries now sit in the value a `StaticKey`
+  resolves to, the Lynx main thread recovers the child's `action` and
+  `props` types from the key alone, so the lazy `propsTypeOnly` placeholder
+  and the "every constructor is lazy in props" invariant are gone.
+  `mountStatic` now accepts components with or without `props`;
+  `mountStaticWithProps` remains as a deprecated alias until 1.15. Code that
+  pattern-matches the `SomeStaticComponent` constructor directly sees its
+  payload change from a function to a `Component`. A new `MountConstraints`
+  synonym declares the shared dictionary set once for `SomeComponent` and
+  `SomeStaticComponent`. Call sites such as
+  `vcomp_ (static (mountStatic comp))` are unchanged.
 - **`vcontext` / `vprops` children are resolved before being built.** The
   runtime now looks through these wrappers before deciding what to do with
   a child, so one that resolves to an empty fragment is skipped like an

--- a/sample-app-native/Conformance.hs
+++ b/sample-app-native/Conformance.hs
@@ -290,7 +290,7 @@ childSection count =
       , CSS.flexShrink 0
       ]
     ]
-    [ vcomp (ChildProps count) (static (mountStaticWithProps childComponent)) ]
+    [ vcomp (ChildProps count) (static (mountStatic childComponent)) ]
 
 opacityForCount :: Int -> MisoString
 opacityForCount n =

--- a/sample-app-native/Main.hs
+++ b/sample-app-native/Main.hs
@@ -827,6 +827,6 @@ mountedComponentSection theme eventCount = section "vcomp \8212 statically-mount
     ]
     [ text_ [ CSS.style_ [ CSS.color CSS.white, txtLine ] ]
         [ text (ms ("tap to toggle theme (currently " <> show theme <> ")")) ] ]
-  , vcomp (BadgeProps eventCount) (static (mountStaticWithProps badgeComponent))
+  , vcomp (BadgeProps eventCount) (static (mountStatic badgeComponent))
   ]
 -----------------------------------------------------------------------------

--- a/src/Miso.hs
+++ b/src/Miso.hs
@@ -217,7 +217,7 @@
 --   = 'VNode' 'Namespace' 'Tag' ['Attribute' model action] ['View' context props model action] 'DirectEvents'
 --   | 'VText' (Maybe t'Key') 'MisoString'
 --   | 'VComp' ('SomeComponent' context)
---   | forall childProps . 'VCompStatic' (StaticPtr ('SomeStaticComponent' childProps context)) childProps
+--   | forall childProps . 'VCompStatic' (StaticPtr (t'SomeStaticComponent' childProps context)) childProps
 --   | 'VFrag' (Maybe t'Key') ['View' context props model action]
 --   | 'VContext' (context -> 'View' context props model action)
 --   | 'VProps' (props -> 'View' context props model action)
@@ -227,9 +227,17 @@
 --
 -- @
 -- data t'SomeComponent' context
---   = forall model action props . ('Eq' context, 'Eq' model, 'Eq' props)
+--   = forall model action props . 'MountConstraints' context props model action
 --   => t'SomeComponent' (Maybe t'Key') props ('Miso.Types.Component' context props model action)
+--
+-- data t'SomeStaticComponent' props context
+--   = forall model action . 'MountConstraints' context props model action
+--   => t'SomeStaticComponent' ('Miso.Types.Component' context props model action)
 -- @
+--
+-- t'SomeStaticComponent' is the closed value a static mount places behind
+-- @static@: the component plus its dictionaries, with @props@ left visible
+-- so 'vcomp' can check the runtime @props@ value against it.
 --
 -- The smart constructors:
 --
@@ -444,9 +452,7 @@
 --
 -- The 'GHC.StaticPtr.StaticKey' itself serves as the mount's identity, so
 -- there's no need for ('+>') or a manually-supplied t'Key' — use 'vcomp' \/
--- 'vcomp_' together with 'Miso.Types.mountStatic' (or
--- 'Miso.Types.mountStaticWithProps') to
--- build a 'VCompStatic'.
+-- 'vcomp_' together with 'Miso.Types.mountStatic' to build a 'VCompStatic'.
 --
 -- See "Miso.Native" for the entry points ('Miso.Native.native',
 -- 'Miso.Native.nativeWithContext') and full documentation of the dual-thread

--- a/src/Miso/Html/Render.hs
+++ b/src/Miso/Html/Render.hs
@@ -221,7 +221,7 @@ renderBuilder props_ (VNode ns tag attrs children _) = mconcat
 renderBuilder _ (VComp someComp) = renderComp someComp
 renderBuilder _ (VCompStatic ptr props0) =
   case deRefStaticPtr ptr of
-    SomeStaticComponent mk -> renderComp (mk props0)
+    SomeStaticComponent comp_ -> renderComp (SomeComponent Nothing props0 comp_)
 renderBuilder props_ (VFrag _ kids) = foldMap (renderBuilder props_) kids
 renderBuilder props_ (VContext f) =
   let ctx = unsafePerformIO (readIORef globalContext) in

--- a/src/Miso/Native.hs
+++ b/src/Miso/Native.hs
@@ -396,7 +396,6 @@ module Miso.Native
    , nativeWithContext
      -- * t'Miso.Types.Component' mounting
    , mountStatic
-   , mountStaticWithProps
      -- * Element
    , module Miso.Native.Element
      -- * FFI
@@ -406,8 +405,8 @@ module Miso.Native
    ) where
 -----------------------------------------------------------------------------
 import Miso.Runtime (initComponent)
-import Miso.Types (Events, SomeStaticComponent(..), SomeComponent(..), Hydrate(..))
-import Miso.Types (mountStatic, mountStaticWithProps)
+import Miso.Types (Events, SomeStaticComponent(..), Hydrate(..))
+import Miso.Types (mountStatic)
 -----------------------------------------------------------------------------
 import Miso.Native.Element
 import Miso.Native.FFI
@@ -436,10 +435,9 @@ native
   -> IO ()
 native events ptr =
   case deRefStaticPtr ptr of
-    SomeStaticComponent mk -> case mk () of
-      SomeComponent key props_ vcomp_ ->
-        initComponent events Draw False () vcomp_
-          key props_ (Just (staticKey ptr))
+    SomeStaticComponent vcomp_ ->
+      initComponent events Draw False () vcomp_
+        Nothing () (Just (staticKey ptr))
 -----------------------------------------------------------------------------
 -- | Like 'native', but the user can specify a global 'Miso.Effect.context' object.
 --
@@ -462,8 +460,7 @@ nativeWithContext
   -> IO ()
 nativeWithContext events context ptr =
   case deRefStaticPtr ptr of
-    SomeStaticComponent mk -> case mk () of
-      SomeComponent key props_ vcomp_ ->
-        initComponent events Draw False context vcomp_
-          key props_ (Just (staticKey ptr))
+    SomeStaticComponent vcomp_ ->
+      initComponent events Draw False context vcomp_
+        Nothing () (Just (staticKey ptr))
 -----------------------------------------------------------------------------

--- a/src/Miso/Runtime.hs
+++ b/src/Miso/Runtime.hs
@@ -329,7 +329,7 @@ initialize events _componentParentId hydrate isRoot live initialProps maybeKey _
   forM_ mount _componentSink
 #ifdef NATIVE
   -- Ship the child's initial @props@ so the MTS can rebuild the mirror
-  -- component by applying the @Props@ constructor recovered from the
+  -- component by pairing them with the 'SomeStaticComponent' recovered from the
   -- 'StaticKey'. The no-props case serializes @()@ (JSON @null@).
   when (bts && not isRoot) $ do
     -- 'mount()' runs synchronously mid-diff (see @ts/miso/dom.ts@
@@ -1251,7 +1251,7 @@ buildVTree events_ parentId_ vcompId hydrate live snk logLevel_ props_ model_ = 
   VComp someComp -> buildComp Nothing someComp
 
   VCompStatic ptr props -> case deRefStaticPtr ptr of
-    SomeStaticComponent mk -> buildComp (Just (staticKey ptr)) (mk props)
+    SomeStaticComponent comp -> buildComp (Just (staticKey ptr)) (SomeComponent Nothing props comp)
 
   VNode ns tag attrs kids _directEvents -> do
     vnode_ <- createNode "vnode" ns tag
@@ -2329,15 +2329,7 @@ initComponent events hydrate live initialContext comp_@Component {..} key props 
 #endif
         atomicWriteIORef schedulerThread =<< forkIO (scheduler proxy)
 ----------------------------------------------------------------------------
--- | Placeholder passed to a @Props@ constructor when only the resulting
--- t'SomeComponent'\'s /types/ (@model@ \/ @props@ \/ @action@) are needed, not a
--- real @props@ value — e.g. to recover the @action@ type for decoding. Safe
--- because every @Props@ built by @mount_@ \/ @mountWithProps@ \/ @(+>)@ is lazy
--- in its @props@ argument, so applying it never forces this.
 #ifdef NATIVE
-propsTypeOnly :: props
-propsTypeOnly = error "Miso.Runtime: props forced during type-only Props application"
------------------------------------------------------------------------------
 -- | Used for bidirectional cross-thread communication.
 effectListener :: forall context jsval . (Eq context, ToJSVal jsval) => Proxy context -> jsval -> IO ()
 effectListener Proxy jsval = void $ do
@@ -2354,9 +2346,10 @@ effectListener Proxy jsval = void $ do
             Nothing ->
               FFI.consoleError "[effectListener]: staticPtr NOT found for effectStaticKey"
             Just ptr ->
+              -- The 'SomeStaticComponent' carries the child's dictionaries, so the
+              -- @action@ type (and its 'FromJSON') is in scope from the key alone.
               case deRefStaticPtr ptr of
-               SomeStaticComponent mk -> case mk propsTypeOnly of
-                SomeComponent _key _props (_ :: Component context props model action) ->
+                SomeStaticComponent (_ :: Component context props model action) ->
                   case fromJSON effectAction :: Result action of
                     Success action -> do
                       comps <- readIORef components
@@ -2480,8 +2473,7 @@ componentListener Proxy live (BTS ctx) = void $ do
                 FFI.consoleError "[COMPONENT]: staticPtr NOT found for componentStaticKey"
               Just ptr ->
                 case deRefStaticPtr ptr of
-                 SomeStaticComponent mk -> case mk propsTypeOnly of
-                  SomeComponent _key _props (comp_ :: Component context props model action) ->
+                  SomeStaticComponent (comp_ :: Component context props model action) ->
                     case componentComponentType of
                       MOUNT ->
                         -- The MTS paints the initial frame itself, so any child that is part

--- a/src/Miso/Types.hs
+++ b/src/Miso/Types.hs
@@ -1,6 +1,7 @@
 -----------------------------------------------------------------------------
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE ExistentialQuantification  #-}
+{-# LANGUAGE ConstraintKinds            #-}
 {-# LANGUAGE MultiParamTypeClasses      #-}
 {-# LANGUAGE ScopedTypeVariables        #-}
 {-# LANGUAGE DerivingStrategies         #-}
@@ -164,6 +165,7 @@ module Miso.Types
   , ComponentId
   , SomeComponent (..)
   , SomeStaticComponent         (..)
+  , MountConstraints
   , EventHandler  (..)
   , View          (..)
   , Key           (..)
@@ -463,12 +465,12 @@ data View context props model action
   | VComp (SomeComponent context)
   | forall childProps . VCompStatic (StaticPtr (SomeStaticComponent childProps context)) childProps
     -- ^ An embedded child t'Component'. The 'StaticPtr' holds only the closed
-    -- @props -> component@ constructor ('SomeStaticComponent'); the @props@ value — often
-    -- derived from the parent's @model@ — rides alongside and crosses the
-    -- dual-thread (Lynx) boundary as JSON. The no-props case uses @props ~ ()@
-    -- (see 'mountStatic'). This split is what lets a mount escape @static@\'s
-    -- closedness restriction. See 'vcomp'. This is necessary for lynx dual-thread
-    -- in order to transfer context, props, event handlers etc.
+    -- t'SomeStaticComponent' (the component plus its dictionaries, built by
+    -- 'mountStatic'); the @props@ value — often derived from the parent's
+    -- @model@ — rides alongside and crosses the dual-thread (Lynx) boundary
+    -- as JSON. The no-props case uses @props ~ ()@. This split is what lets a
+    -- mount escape @static@\'s closedness restriction: the component is
+    -- closed, the value need not be. See 'vcomp'.
   | VFrag (Maybe Key) [View context props model action]
   | VContext (context -> View context props model action)
     -- ^ Ambient accessor for the app-global @context@ — not a node. The
@@ -481,39 +483,49 @@ data View context props model action
     -- the enclosing 'View' is built or rendered, letting a helper read
     -- @props@ without threading it through as an extra argument. See 'vprops'.
 -----------------------------------------------------------------------------
+-- | The dictionaries a t'Component' must carry to be mounted as a child:
+-- equality for dirty-checking, plus (under the @native@ flag) JSON for
+-- shipping @model@, @props@ and @action@ across the Lynx dual-thread
+-- boundary. Shared by t'SomeComponent' and t'SomeStaticComponent' so the two
+-- can never drift apart.
+--
+-- @since 1.14.0.0
+#ifdef NATIVE
+type MountConstraints context props model action =
+  (Eq context, Eq props, Eq model, FromJSON props, ToJSON props, FromJSON model, ToJSON model, FromJSON action, ToJSON action)
+#else
+type MountConstraints context props model action =
+  (Eq context, Eq props, Eq model)
+#endif
+-----------------------------------------------------------------------------
 -- | Existential wrapper allowing nesting of t'Miso.Types.Component' in t'Miso.Types.Component'.
 --
 -- The @context@ type parameter is shared with the enclosing 'View', so every
 -- nested t'Miso.Types.Component' participates in the same app-global context.
 data SomeComponent context
-#ifdef NATIVE
-   = forall model action props . (FromJSON model, ToJSON model, FromJSON action, ToJSON action, FromJSON props, ToJSON props, Eq context, Eq model, Eq props)
-#else
-   = forall model action props . (Eq context, Eq model, Eq props)
-#endif
+  = forall model action props . MountConstraints context props model action
   => SomeComponent (Maybe Key) props (Component context props model action)
 -----------------------------------------------------------------------------
--- | A closed @props -> component@ constructor, bundled with the serialization
--- dictionaries needed to move @props@ across the dual-thread (Lynx) boundary.
+-- | A closed t'Component' bundled with its 'MountConstraints' dictionaries,
+-- ready to be placed behind @static@ and mounted with 'vcomp'.
 --
 -- Unlike t'SomeComponent', the @props@ type parameter is /preserved/ (not
--- existential). This lets @vcompWith@ statically require the runtime @props@
--- value to match the constructor, while the packed 'FromJSON' \/ 'ToJSON'
--- dictionaries are recovered on the MTS after 'unsafeLookupStaticPtr' derefs
--- the 'StaticPtr' — so the MTS can decode the wire @props@ at exactly this
--- type and rebuild the t'SomeComponent'.
+-- existential) so 'vcomp' can statically require the runtime @props@ value
+-- to match the component. Only @model@ and @action@ are hidden. Because the
+-- dictionaries sit here, in the value a 'StaticKey' resolves to, the Lynx
+-- main thread can decode a wire @props@ payload or an @action@ at the right
+-- type from the key alone — no @props@ value is needed first.
 --
--- Built with 'mount_' \/ 'mountWithProps' \/ '(+>)'; consumed by 'vcomp'.
+-- Built with 'mountStatic'; consumed by 'vcomp' \/ 'vcomp_'.
+--
+-- Up to 1.13 this held a @props -> 'SomeComponent' context@ function instead
+-- of the component itself, which forced the main thread to apply it to a
+-- placeholder just to reach the dictionaries; see 'mountStatic'.
 --
 -- @since 1.13.0.0
 data SomeStaticComponent props context
-#ifdef NATIVE
-  = (Eq props, FromJSON props, ToJSON props)
-  => SomeStaticComponent (props -> SomeComponent context)
-#else
-  = Eq props
-  => SomeStaticComponent (props -> SomeComponent context)
-#endif
+  = forall model action . MountConstraints context props model action
+  => SomeStaticComponent (Component context props model action)
 -----------------------------------------------------------------------------
 -- | Create a fragment (keyless).
 --
@@ -589,35 +601,18 @@ infixr 0 +>
 #endif
 key +> child = VComp (SomeComponent (Just (toKey key)) () child)
 -----------------------------------------------------------------------------
--- | t'Miso.Types.Component' mounting combinator.
---
--- Note: only use this if you're certain you won't be diffing two t'Miso.Types.Component'
--- against each other. Otherwise, you will need a key to distinguish between
--- the two t'Miso.Types.Component', to ensure unmounting and mounting occurs.
---
--- It takes only the @component@ and yields a closed @props -> component@
--- constructor ('SomeStaticComponent') suitable for @static@ — the @props@ value
--- is /not/ supplied here, but later at the 'vcomp' site, so a parent can pass
--- runtime @props@ (e.g. derived from its own @model@) without an explicit lambda:
---
--- Static mounting automatically provides the @key_@ at compile time (via 'GHC.StaticPtr.staticKey').
--- So the user doesn't need to use the '+>' combinators.
---
--- @
--- vcomp (model ^. field) (static (mountStaticWithProps child))
--- @
+-- | __Deprecated.__ Synonym for 'mountStatic', which now handles components
+-- with and without @props@ alike (the @props@ value is supplied at the
+-- 'vcomp' site either way). Will be removed in 1.15.
 --
 -- @since 1.13.0.0
 mountStaticWithProps
-#ifdef NATIVE
-  :: (Eq context, Eq props, Eq model, FromJSON model, ToJSON model, FromJSON action, ToJSON action, FromJSON props, ToJSON props)
-#else
-  :: (Eq context, Eq props, Eq model)
-#endif
+  :: MountConstraints context props model action
   => Component context props model action
   -- ^ t'Component' to mount
   -> SomeStaticComponent props context
-mountStaticWithProps child = SomeStaticComponent (\props -> SomeComponent Nothing props child)
+mountStaticWithProps = SomeStaticComponent
+{-# DEPRECATED mountStaticWithProps "Use mountStatic; it now accepts components with props. This alias will be removed in 1.15." #-}
 -----------------------------------------------------------------------------
 -- | t'Miso.Types.Component' mounting combinator, with @props@ supplied directly.
 --
@@ -670,32 +665,32 @@ mountWithProps_
 #endif
 mountWithProps_ key props child = VComp (SomeComponent (Just (Key key)) props child)
 -----------------------------------------------------------------------------
--- | Static t'Miso.Types.Component' mounting combinator, for a component
--- that takes no @props@.
+-- | Static t'Miso.Types.Component' mounting combinator.
 --
--- Produces a @'SomeStaticComponent' () context@ to be wrapped in @static@ and
--- turned into a 'View' by 'vcomp_'. Unlike 'mount_', no key is needed: the
--- compile-time 'GHC.StaticPtr.StaticKey' already supplies identity, so this is
--- safe to diff against another t'Miso.Types.Component'.
+-- Wraps the component in a t'SomeStaticComponent' — the closed value to place
+-- behind @static@ — and discharges its 'MountConstraints' dictionaries
+-- there. The @props@ value is /not/ supplied here but later, at the 'vcomp'
+-- site, so a parent can pass runtime @props@ (e.g. derived from its own
+-- @model@) without an explicit lambda; a component with @props ~ ()@ pairs
+-- with 'vcomp_'. Unlike 'mount_', no key is needed: the compile-time
+-- 'GHC.StaticPtr.StaticKey' already supplies identity, so this is safe to
+-- diff against another t'Miso.Types.Component'.
 --
 -- To opt the child into app-global @context@ updates, set the field directly:
 -- @mountStatic comp { useContext = True }@.
 --
 -- @
 -- div_ [] [ vcomp_ (static (mountStatic myComp)) ]
+-- div_ [] [ vcomp (model ^. field) (static (mountStatic child)) ]
 -- @
 --
 -- @since 1.13.0.0
 mountStatic
-#ifdef NATIVE
-  :: (Eq context, Eq model, FromJSON model, ToJSON model, FromJSON action, ToJSON action)
-#else
-  :: (Eq context, Eq model)
-#endif
-  => Component context () model action
+  :: MountConstraints context props model action
+  => Component context props model action
   -- ^ t'Component' to mount
-  -> SomeStaticComponent () context
-mountStatic child = SomeStaticComponent (const (SomeComponent Nothing () child))
+  -> SomeStaticComponent props context
+mountStatic = SomeStaticComponent
 -----------------------------------------------------------------------------
 -- | t'Miso.Types.Component' mounting combinator.
 --
@@ -735,15 +730,15 @@ mount_ comp = VComp (SomeComponent Nothing () comp)
 --
 -- Smart constructor for @VComp@, mirroring 'vnode' \/ 'vtext' \/ 'vfrag'.
 --
--- The 'StaticPtr' wraps only the closed @props -> component@ constructor (built
--- with 'mountStatic' or 'mountStaticWithProps'); it must use the @static@ keyword
--- and refer to a closed, top-level binding. The @props@ value is supplied
--- /separately/ — so it may depend on the parent's @model@ — and is serialized
--- across the dual-thread boundary. The no-props case passes @()@.
+-- The 'StaticPtr' wraps only the closed t'SomeStaticComponent' (built with
+-- 'mountStatic'); it must use the @static@ keyword and refer to a closed,
+-- top-level binding. The @props@ value is supplied /separately/ — so it may
+-- depend on the parent's @model@ — and is serialized across the dual-thread
+-- boundary. The no-props case passes @()@.
 --
--- No class constraints appear here: the serialization dictionaries are
--- discharged at the @static (mount_ child)@ site and recovered on the MTS from
--- the @Props@.
+-- No class constraints appear here: the dictionaries are discharged at the
+-- @static (mountStatic child)@ site and travel inside the t'SomeStaticComponent',
+-- which is where the MTS recovers them from the 'GHC.StaticPtr.StaticKey'.
 --
 -- @
 -- div_ [] [ vcomp_ (static (mountStatic myComp)) ]
@@ -758,8 +753,8 @@ vcomp = flip VCompStatic
 -----------------------------------------------------------------------------
 -- | Like 'vcomp', but for a t'Miso.Types.Component' that takes no @props@.
 --
--- @'vcomp_' = 'vcomp' ()@ — pair it with 'mountStatic', which produces a
--- @'SomeStaticComponent' () context@.
+-- @'vcomp_' = 'vcomp' ()@ — pair it with 'mountStatic' on a component whose
+-- @props@ are @()@, which produces a @'SomeStaticComponent' () context@.
 --
 -- @
 -- div_ [] [ vcomp_ (static (mountStatic myComp)) ]


### PR DESCRIPTION
A static mount is now the component itself bundled with its `MountConstraints` dictionaries, `SomeStaticComponent props context`, rather than a `props -> SomeComponent context` function. `VCompStatic` holds a `StaticPtr` to it next to the props value, and the runtime builds the `SomeComponent` at mount time.

Because the dictionaries sit in the value a `StaticKey` resolves to, the Lynx main thread recovers the child's `action` and `props` types from the key alone. The lazy `propsTypeOnly` placeholder, and the unwritten invariant that every mount constructor be lazy in props, are gone.

- `mountStatic` accepts components with or without props. `mountStaticWithProps` is a deprecated alias until 1.15.
- `MountConstraints` declares the shared dictionary set once for `SomeComponent` and `SomeStaticComponent`.
- `native` / `nativeWithContext` take `StaticPtr (SomeStaticComponent () ctx)`.
- Call sites such as `vcomp_ (static (mountStatic comp))` are unchanged. The only break is a direct pattern match on the `SomeStaticComponent` constructor, of which there are none outside miso.

Suggested merge order: this, then `feat/vmodel`, then `refactor/context-state`.
