### PR TITLE
fix: use the `StaticKey` as a static mount's diff `key`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,18 @@ All notable changes to `miso` are documented here.
   `View context () model action`; lift `withProps` above the element to
   draw from the component's `props`.
 
+### Fixed
+
+- **Static mounts now carry their `StaticKey` as the diff key.** A
+  `VCompStatic` node had no `key`, so two different `static` sites at the
+  same position compared equal in the differ: the first component stayed
+  mounted and the second's `diffProps` ran against it with props of an
+  unrelated type. `buildComp` now sets `key` to the mount's `StaticKey`
+  (unique per `static` site) when no explicit key is given, so swapping
+  `vcomp_ (static (mountStatic A))` for `vcomp_ (static (mountStatic B))`
+  replaces the child. Siblings built from one `static` site still diff
+  positionally.
+
 ## 1.13.0.0
 
 ### Added

--- a/src/Miso/Runtime.hs
+++ b/src/Miso/Runtime.hs
@@ -140,6 +140,7 @@ import           Miso.Event.Decoder (Decoder(decoder, decodeAt))
 #if __GLASGOW_HASKELL__ < 910
 import           Data.Foldable (foldl')
 #endif
+import           Control.Applicative ((<|>))
 import           Data.Maybe
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as M
@@ -1407,7 +1408,14 @@ buildVTree events_ parentId_ vcompId hydrate live snk logLevel_ props_ model_ = 
             enqueueSchedule componentId_
       FFI.set "diffProps" diffPropsCallback comp
       FFI.set "child" jsNull comp
-      forM_ maybeKey (\key -> FFI.set "key" key comp)
+      -- Identity for the differ (@n.key === c.key@ in @ts/miso/dom.ts@): an
+      -- explicit key wins; otherwise a static mount uses its 'StaticKey',
+      -- which is unique per @static@ site. Without this every static mount
+      -- had @key = undefined@, so two different static components at one
+      -- position compared equal and the old instance was kept — with the new
+      -- node's @diffProps@ run against props of an unrelated type.
+      forM_ (maybeKey <|> (Key . ms <$> maybeStaticKey)) $ \key ->
+        FFI.set "key" key comp
       FFI.set "mount" mountCallback comp
       FFI.set "unmount" unmountCallback comp
       FFI.set "eventPropagation" (eventPropagation app) comp

--- a/src/Miso/Types.hs
+++ b/src/Miso/Types.hs
@@ -745,6 +745,10 @@ mount_ comp = VComp (SomeComponent Nothing () comp)
 -- discharged at the @static (mount_ child)@ site and recovered on the MTS from
 -- the @Props@.
 --
+-- The 'GHC.StaticPtr.StaticKey' also serves as the node's diff key: two
+-- different @static@ sites at the same position are replaced, not reused,
+-- while siblings built from one site still diff positionally.
+--
 -- @
 -- div_ [] [ vcomp_ (static (mountStatic myComp)) ]
 -- @

--- a/tests/app/Main.hs
+++ b/tests/app/Main.hs
@@ -156,6 +156,21 @@ data Action = AddOne
   deriving stock (Show, Eq, Generic)
   deriving anyclass (JSON.FromJSON, JSON.ToJSON)
 -----------------------------------------------------------------------------
+-- | Two distinct components mounted statically at the same position by
+-- 'staticSwapRoot'; the differ must replace one with the other, not keep the
+-- first and run the second's @diffProps@ against it.
+staticProbeA, staticProbeB :: Component () () () Action
+staticProbeA = component () noop $ \_ _ _ -> div_ [ id_ "static-a" ] [ "A" ]
+staticProbeB = component () noop $ \_ _ _ -> div_ [ id_ "static-b" ] [ "B" ]
+-----------------------------------------------------------------------------
+staticSwapRoot :: Component () () Bool Action
+staticSwapRoot = component False (\AddOne -> this %= not) $ \_ _ swapped ->
+  div_ []
+    [ if swapped
+        then vcomp_ (static (mountStatic staticProbeB))
+        else vcomp_ (static (mountStatic staticProbeA))
+    ]
+-----------------------------------------------------------------------------
 -- | Increments the app-global @context@ (an 'Int'); used to test that
 -- 'useContext' gates whether a 'vcontext' subtree observes the change.
 data ContextAction = BumpContext
@@ -1812,6 +1827,26 @@ main = withJS $ do
         clickStaticKey <- liftIO (clickHandler ! "staticKey")
         clickStaticKeyUndefined <- liftIO (isUndefined clickStaticKey)
         clickStaticKeyUndefined `shouldBe` False
+
+    describe "Static mount identity tests" $ do
+      it "swapping two static mounts at one position replaces the child" $ do
+        liftIO $ startApp mempty staticSwapRoot
+        ComponentState {..} <- liftIO $
+          ((IM.! 1) <$> readIORef components :: IO (ComponentState () () Bool Action))
+        let childIds = filter (/= 1) . IM.keys <$> readIORef components
+        before <- liftIO childIds
+        length before `shouldBe` 1
+        liftIO (_componentSink AddOne)
+        replaced <- liftIO $ pollFor propagationAttempts $ do
+          ids <- childIds
+          pure (length ids == 1 && ids /= before)
+        replaced `shouldBe` True
+        hasB <- liftIO $ fromJSValUnchecked =<< eval
+          ("document.getElementById('static-b') !== null" :: MisoString)
+        hasB `shouldBe` True
+        hasA <- liftIO $ fromJSValUnchecked =<< eval
+          ("document.getElementById('static-a') !== null" :: MisoString)
+        hasA `shouldBe` False
 
     describe "VContext tests" $ do
       let contextProbe :: Component Int () () Action


### PR DESCRIPTION
Only relevant to using keyed components w/ the native backend. 

A `VCompStatic` node carried no `key`, so two different `static` sites at the same position compared equal in the diff (`undefined === undefined`): the first component stayed mounted and the new node's `diffProps` ran against it with props of an unrelated type. buildComp now falls back to the mount's StaticKey (unique per `static` site) when no explicit key is given, so swapping one static mount for another replaces the child. Siblings built from one `static` site still diff positionally.

Adds a test that swaps two static mounts and checks the child component is replaced.