### PR TITLE
refactor: `view` takes only `model`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,19 @@ All notable changes to `miso` are documented here.
 
 ### Changed
 
+- **Breaking: `view` takes only the `model`.** The `view` field of a
+  `Component` was `context -> props -> model -> View context props model
+  action`; it is now `model -> View context props model action`. The
+  `context` and `props` are read where they are actually needed with the
+  ambient accessors `withContext` / `vcontext` and `withProps` / `vprops`,
+  which resolve at the point the enclosing `View` is built or rendered. A
+  `view` that ignored them no longer has to name them (`\_ _ _ -> …` becomes
+  `\_ -> …`), and one that used them reads them at the point of use instead
+  of threading them down through every helper. `toHtmlWith` still takes the
+  `context`, `props` and `model` — they are what the accessors in the
+  rendered tree resolve against — but the `view` it is applied to now takes
+  only the `model`: `toHtmlWith ctx props model (view comp model)`.
+
 - **Breaking: the app-global `context` cell is owned by the app, not by a
   top-level CAF.** The `globalContext` `IORef` is gone. `initComponent` now
   creates the cell and every mounted component holds a *reference* to it as

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,12 @@ All notable changes to `miso` are documented here.
   rendered tree resolve against — but the `view` it is applied to now takes
   only the `model`: `toHtmlWith ctx props model (view comp model)`.
 
+  The `model` stays an argument purely for convenience — it is the one of the
+  three a `view` almost always needs. It is available ambiently too, so
+  `view _ = withModel $ \m -> …` is equivalent to taking it as an argument;
+  `withModel` / `vmodel` remain the better choice for a helper deep in the
+  tree that the `model` is not otherwise passed to.
+
 - **Breaking: the app-global `context` cell is owned by the app, not by a
   top-level CAF.** The `globalContext` `IORef` is gone. `initComponent` now
   creates the cell and every mounted component holds a *reference* to it as

--- a/README.md
+++ b/README.md
@@ -211,8 +211,8 @@ updateModel = \case
     consoleLog "Hello World"
 ----------------------------------------------------------------------------
 -- | Constructs a virtual DOM from a model
-viewModel :: context -> props -> Int -> View context props Int Action
-viewModel _context _props x = vfrag
+viewModel :: Int -> View context props Int Action
+viewModel x = vfrag
     [ H.button_ [ H.onClick AddOne ] [ text "+" ]
     , text (ms x)
     , H.button_ [ H.onClick SubtractOne ] [ text "-" ]

--- a/sample-app-native/Conformance.hs
+++ b/sample-app-native/Conformance.hs
@@ -67,8 +67,8 @@ updateModel = \case
   ReadMTS domRef n ->
     io_ (setStyleProperty domRef "opacity" (opacityForCount n))
 
-viewModel :: () -> () -> Model -> View () () Model Action
-viewModel _ _ Model{..} =
+viewModel :: Model -> View () () Model Action
+viewModel Model{..} =
   view_
     [ id_ "probe-root"
     , CSS.style_
@@ -258,8 +258,9 @@ childUpdate :: ChildAction -> Effect () ChildProps ChildModel ChildAction
 childUpdate IncrementChild =
   modify $ \m -> m { childCount = childCount m + 1 }
 
-childView :: () -> ChildProps -> ChildModel -> View () ChildProps ChildModel ChildAction
-childView _ ChildProps{..} ChildModel{..} =
+childView :: ChildModel -> View () ChildProps ChildModel ChildAction
+childView ChildModel{..} =
+  withProps $ \ChildProps{..} ->
   view_
     [ id_ "child-button"
     , VE.onTap IncrementChild

--- a/sample-app-native/Main.hs
+++ b/sample-app-native/Main.hs
@@ -178,8 +178,8 @@ updateModel = \case
 animId :: MisoString
 animId = "#anim-gif"
 -----------------------------------------------------------------------------
-viewModel :: Theme -> () -> Model -> View Theme () Model Action
-viewModel theme _ Model{..} = view_
+viewModel :: Model -> View Theme () Model Action
+viewModel Model{..} = view_
   [ CSS.style_
     [ CSS.height "100vh"
     , CSS.width "100%"
@@ -218,7 +218,7 @@ viewModel theme _ Model{..} = view_
     , webviewSection
     , overlaySection overlayOpen
     , mainThreadSection
-    , mountedComponentSection theme (length eventLog)
+    , mountedComponentSection (length eventLog)
     ]
   ]
 -----------------------------------------------------------------------------
@@ -800,8 +800,11 @@ badgeComponent = (component (BadgeModel 0) badgeUpdate badgeView) { useContext =
 badgeUpdate :: BadgeAction -> Effect Theme BadgeProps BadgeModel BadgeAction
 badgeUpdate BadgeTap = modify $ \m -> m { badgeTaps = badgeTaps m + 1 }
 -----------------------------------------------------------------------------
-badgeView :: Theme -> BadgeProps -> BadgeModel -> View Theme BadgeProps BadgeModel BadgeAction
-badgeView theme BadgeProps{..} BadgeModel{..} = view_
+badgeView :: BadgeModel -> View Theme BadgeProps BadgeModel BadgeAction
+badgeView BadgeModel{..} =
+  withContext $ \theme ->
+  withProps $ \BadgeProps{..} ->
+  view_
   [ VE.onTap BadgeTap
   , CSS.style_
     [ CSS.width "100%", CSS.height "56px"
@@ -817,9 +820,9 @@ badgeView theme BadgeProps{..} BadgeModel{..} = view_
 -- | Mounts 'badgeComponent' statically with props derived from the parent
 -- model, and a "toggle theme" control above it so context propagation into
 -- the child is visible: tapping it flips the badge's own colors.
-mountedComponentSection :: Theme -> Int -> View Theme () Model Action
-mountedComponentSection theme eventCount = section "vcomp \8212 statically-mounted child (props / context / model)"
-  [ view_
+mountedComponentSection :: Int -> View Theme () Model Action
+mountedComponentSection eventCount = section "vcomp \8212 statically-mounted child (props / context / model)"
+  [ withContext $ \theme -> view_
     [ VE.onTap ToggleTheme
     , CSS.style_
       [ CSS.height "36px", CSS.marginBottom "6px"

--- a/sample-app/Main.hs
+++ b/sample-app/Main.hs
@@ -64,8 +64,8 @@ updateModel = \case
   SayHelloWorld -> io_ (consoleLog "Hello world")
 ----------------------------------------------------------------------------
 -- | Constructs a virtual DOM from a model
-viewModel :: () -> () -> Model -> View () () Model Action
-viewModel _ _ (Model x) =
+viewModel :: Model -> View () () Model Action
+viewModel (Model x) =
   vfrag
   [ H.button_ [ H.onClick AddOne ] [ "+" ]
   , text (ms x)

--- a/src/Miso.hs
+++ b/src/Miso.hs
@@ -286,13 +286,14 @@
 --
 -- __Reading__ (in 'Miso.Types.view'):
 --
--- The current @context@ is delivered as the __first argument__ to every
--- t'Component'\'s 'Miso.Types.view' function, so any component — however deeply
--- nested — can read it synchronously during render:
+-- 'Miso.Types.view' takes only the @model@. The current @context@ is read
+-- /ambiently/, with 'withContext' \/ 'vcontext', at the point in the tree
+-- that needs it — so any component, however deeply nested, can read it
+-- synchronously during render without threading it down:
 --
 -- @
--- view :: context -> props -> model -> 'View' context props model action
--- view ctx _props _model = ...
+-- view :: model -> 'View' context props model action
+-- view _model = 'withContext' $ \\ctx -> ...
 -- @
 --
 -- __Reading__ (in 'Miso.Types.update'):
@@ -340,10 +341,10 @@
 -- 'VContext' is an /ambient accessor/ for the app-global @context@, not a
 -- node: it wraps a @context -> 'View' context props model action@ function
 -- that is applied, and the wrapper discarded, whenever the enclosing 'View'
--- is built or rendered. It lets a helper deep in a view tree read @context@
--- without needing it threaded through as an explicit argument — unlike
--- 'Miso.Types.view' itself, which already receives @context@ as its first
--- parameter.
+-- is built or rendered. It lets any part of a view tree read @context@
+-- without needing it threaded through as an explicit argument. Since
+-- 'Miso.Types.view' takes only the @model@, this is /the/ way to read the
+-- @context@ during render.
 --
 -- @
 -- 'vcontext' $ \\theme -> 'Miso.Html.Element.span_' [] [ 'Miso.Types.text' (themeLabel theme) ]
@@ -363,9 +364,9 @@
 -- for the enclosing t'Miso.Types.Component'\'s @props@. It wraps a
 -- @props -> 'View' context props model action@ function that is applied, and
 -- the wrapper discarded, whenever the enclosing 'View' is built or rendered,
--- so a helper deep in a view tree can read @props@ without needing it
--- threaded through as an explicit argument — unlike 'Miso.Types.view'
--- itself, which already receives @props@ as its second parameter.
+-- so any part of a view tree can read @props@ without needing it threaded
+-- through as an explicit argument. Since 'Miso.Types.view' takes only the
+-- @model@, this is /the/ way to read the @props@ during render.
 --
 -- @
 -- 'vprops' $ \\Props { title } -> 'Miso.Html.Element.h1_' [] [ 'Miso.Types.text' title ]
@@ -407,7 +408,7 @@
 -- the wrapper discarded, whenever the enclosing 'View' is built or rendered,
 -- so a helper deep in a view tree can read @model@ without needing it
 -- threaded through as an explicit argument — unlike 'Miso.Types.view'
--- itself, which already receives @model@ as its third parameter.
+-- itself, which receives the @model@ as its only parameter.
 --
 -- @
 -- 'vmodel' $ \\Model { count } -> 'Miso.Html.Element.span_' [] [ 'Miso.Types.text' ('Miso.String.ms' count) ]
@@ -556,8 +557,8 @@
 --   Highlight domRef -> 'io_' $ do
 --     ['Miso.FFI.QQ.js'| hljs.highlight(${domRef}) |]
 --
--- view :: context -> props -> model -> 'View' context props model Action
--- view _ _ x =
+-- view :: model -> 'View' context props model Action
+-- view _ =
 --   'Miso.Html.Element.code_'
 --   [ 'onCreatedWith' Highlight
 --   ]
@@ -911,18 +912,21 @@
 --
 -- === Props in 'Miso.Types.view'
 --
--- The 'Miso.Types.view' field of a t'Miso.Types.Component' takes the app-global @context@ as
--- its first argument and the @props@ as its second:
+-- The 'Miso.Types.view' field of a t'Miso.Types.Component' takes only the
+-- @model@; the @props@ are read where they are needed with 'withProps' \/
+-- 'vprops':
 --
 -- @
--- view :: context -> props -> model -> 'View' context props model action
+-- view :: model -> 'View' context props model action
+-- view model = 'withProps' $ \\props -> …
 -- @
 --
--- Top-level applications have no parent, so @props@ is always @()@:
+-- Top-level applications have no parent, so @props@ is always @()@ and there
+-- is nothing to read:
 --
 -- @
--- view :: () -> () -> model -> 'View' () () model action
--- view _context _props model = …
+-- view :: model -> 'View' () () model action
+-- view model = …
 -- @
 --
 -- === Props in 'Effect' \/ 'Miso.Types.update'
@@ -1312,7 +1316,7 @@
 -- 'vcontext' \/ 'vprops' \/ 'vmodel' — pass the values with 'Miso.Html.Render.toHtmlWith':
 --
 -- @
--- 'Miso.Html.Render.toHtmlWith' ctx props model ('Miso.Types.view' comp ctx props model)
+-- 'Miso.Html.Render.toHtmlWith' ctx props model ('Miso.Types.view' comp model)
 -- @
 --
 -- This is typically wired into a Servant handler on the server using the

--- a/src/Miso.hs
+++ b/src/Miso.hs
@@ -296,6 +296,11 @@
 -- view _model = 'withContext' $ \\ctx -> ...
 -- @
 --
+-- The @model@ is the one of the three that /is/ an argument, purely for
+-- convenience — it is what a @view@ almost always needs. It is also available
+-- ambiently through 'withModel' \/ 'vmodel', so @view _ = 'withModel' $
+-- \\m -> …@ is equivalent to taking it as an argument.
+--
 -- __Reading__ (in 'Miso.Types.update'):
 --
 -- The current @context@ is also readable inside the 'Effect' monad, just like
@@ -407,8 +412,10 @@
 -- @model -> 'View' context props model action@ function that is applied, and
 -- the wrapper discarded, whenever the enclosing 'View' is built or rendered,
 -- so a helper deep in a view tree can read @model@ without needing it
--- threaded through as an explicit argument — unlike 'Miso.Types.view'
--- itself, which receives the @model@ as its only parameter.
+-- threaded through as an explicit argument. Unlike @context@ and @props@,
+-- the @model@ is /also/ handed to 'Miso.Types.view' as its only parameter —
+-- a convenience, not a restriction: @view _ = 'vmodel' $ \\m -> …@ is
+-- equivalent to taking it as an argument.
 --
 -- @
 -- 'vmodel' $ \\Model { count } -> 'Miso.Html.Element.span_' [] [ 'Miso.Types.text' ('Miso.String.ms' count) ]

--- a/src/Miso/Effect.hs
+++ b/src/Miso/Effect.hs
@@ -616,8 +616,9 @@ withSink f = tell [ async f ]
 -- value changes (per its 'Eq' instance), every t'Miso.Types.Component' with @useContext@
 -- enabled is re-rendered.
 --
--- Note that @context@ is __write-only__ inside @update@; to read it, use the
--- @context@ argument threaded into the 'Miso.Types.view' function.
+-- To read the @context@ inside @update@, use 'getContext'; to read it during
+-- render, use 'Miso.Types.withContext' \/ 'Miso.Types.vcontext' — the
+-- 'Miso.Types.view' function itself takes only the @model@.
 --
 -- @
 -- @update@ Toggle = 'modifyContext' (\\theme -> if theme == Light then Dark else Light)

--- a/src/Miso/Html/Render.hs
+++ b/src/Miso/Html/Render.hs
@@ -147,10 +147,12 @@ renderView = toHtmlWith () () ()
 --
 -- This is the general form of 'toHtml', for a 'View' whose @context@, @props@
 -- or @model@ type is not @()@ — e.g. a component's 'Miso.Types.view' applied
--- directly:
+-- directly. The @view@ itself takes only the @model@; the @context@ and
+-- @props@ given here are what its 'Miso.Types.VContext' \/
+-- 'Miso.Types.VProps' accessors resolve against:
 --
 -- @
--- toHtmlWith ctx props model (view comp ctx props model)
+-- toHtmlWith ctx props model (view comp model)
 -- @
 --
 -- @since 1.14.0.0
@@ -248,17 +250,18 @@ renderBuilder ctx_ props_ model_ (VContext f) = renderBuilder ctx_ props_ model_
 renderBuilder ctx_ props_ model_ (VProps f) = renderBuilder ctx_ props_ model_ (f props_)
 renderBuilder ctx_ props_ model_ (VModel f) = renderBuilder ctx_ props_ model_ (f model_)
 ----------------------------------------------------------------------------
--- | Render a mounted child component: its 'view' applied to the app-global
--- @context@, the @props@ it was mounted with, and its initial (or hydrated)
--- @model@. The enclosing component's @props@ play no part, which is why the
--- @VComp@ \/ @VCompStatic@ arms of 'renderBuilder' ignore theirs; the
--- @context@ is shared by every component and is passed straight through.
+-- | Render a mounted child component: its 'view' applied to its initial (or
+-- hydrated) @model@, rendered against the app-global @context@ and the
+-- @props@ it was mounted with. The enclosing component's @props@ play no
+-- part, which is why the @VComp@ \/ @VCompStatic@ arms of 'renderBuilder'
+-- ignore theirs; the @context@ is shared by every component and is passed
+-- straight through.
 renderComp :: context -> SomeComponent context -> Builder
 renderComp ctx (SomeComponent _key props comp_) =
 #ifdef SSR
-  let m = getInitialComponentModel comp_ in renderBuilder ctx props m (view comp_ ctx props m)
+  let m = getInitialComponentModel comp_ in renderBuilder ctx props m (view comp_ m)
 #else
-  renderBuilder ctx props (model comp_) (view comp_ ctx props (model comp_))
+  renderBuilder ctx props (model comp_) (view comp_ (model comp_))
 #endif
 ----------------------------------------------------------------------------
 renderAttrs :: Attribute model action -> Builder

--- a/src/Miso/Native.hs
+++ b/src/Miso/Native.hs
@@ -151,7 +151,7 @@
 -- Child components are embedded in a 'Miso.Lens.view' the same way, with 'Miso.Types.vcomp':
 --
 -- @
--- view _ _ _ = view_ [] [ 'Miso.Types.vcomp' () (static ('Miso.Types.mountStatic' childComponent)) ]
+-- view _ = view_ [] [ 'Miso.Types.vcomp' () (static ('Miso.Types.mountStatic' childComponent)) ]
 -- @
 --
 -- __Static-pointer limitation.__ A @static@ form may only close over
@@ -236,7 +236,7 @@
 -- @
 -- {-# LANGUAGE StaticPointers #-}
 --
--- view _ _ _ =
+-- view _ =
 --   @view_@ [ 'Miso.Types.event' (static ('Miso.Native.Element.View.Event.onTapMain' HandleTap)) ] []
 -- @
 --
@@ -375,8 +375,8 @@
 -- import "Miso" hiding (text_)
 -- import "Miso.Native"
 -- -----------------------------------------------------------------------------
--- view :: context -> props -> Model -> 'Miso.Types.View' context Model Action
--- view _ _ m =
+-- view :: Model -> 'Miso.Types.View' context props Model Action
+-- view m =
 --   'Miso.Types.vfrag'
 --   [ @view_@ [ 'Miso.Native.Element.View.Event.onTap' Increment ] [ 'text_' [] [ \"+\" ] ]
 --   , 'text_' [] [ 'Miso.Types.text' $ 'Miso.String.ms' ('show' m) ]

--- a/src/Miso/Native/Element/Frame/Event.hs
+++ b/src/Miso/Native/Element/Frame/Event.hs
@@ -113,8 +113,8 @@ frameLoadMetricsDecoder = ["detail"] `at` details
 --
 -- data Action = HandleLoad FrameLoadEvent
 --
--- view :: context -> props -> Model -> View context Action
--- view _ _ model = frame_ [ src_ "http://url", onLoad HandleLoad ] []
+-- view :: Model -> View context props Model Action
+-- view model = frame_ [ src_ "http://url", onLoad HandleLoad ] []
 --
 -- update :: Action -> Effect props Model Action
 -- update (HandleLoad FrameLoadEvent {..}) =
@@ -157,8 +157,8 @@ onLoadMainWith action = onMain "load" frameLoadDecoder action
 --
 -- data Action = HandleMetrics FrameLoadMetricsEvent
 --
--- view :: context -> props -> Model -> View context Action
--- view _ _ model = frame_ [ src_ "http://url", onLoadMetrics HandleMetrics ] []
+-- view :: Model -> View context props Model Action
+-- view model = frame_ [ src_ "http://url", onLoadMetrics HandleMetrics ] []
 --
 -- update :: Action -> Effect props Model Action
 -- update (HandleMetrics FrameLoadMetricsEvent {..}) =

--- a/src/Miso/Native/Element/Image/Event.hs
+++ b/src/Miso/Native/Element/Image/Event.hs
@@ -74,7 +74,7 @@ imageEvents
 --
 -- data Action = HandleImageLoad ImageLoadEvent
 --
--- view :: context -> props -> Model -> View context Action
+-- view :: Model -> View context props Model Action
 -- view model = image_ "url" [ onLoad HandleImageLoad ]
 --
 -- update :: Action -> Effect context props Model Action
@@ -120,8 +120,8 @@ onLoadMainWith action = onMain "load" imageLoadDecoder action
 --
 -- data Action = HandleImageError ImageErrorEvent
 --
--- view :: context -> props -> Model -> View context Action
--- view _ _ model = image_ "url" [ onError HandleImageError ]
+-- view :: Model -> View context props Model Action
+-- view model = image_ "url" [ onError HandleImageError ]
 --
 -- update :: Action -> Effect context props Model Action
 -- update (HandleImageError ImageErrorEvent {..}) = do
@@ -166,8 +166,8 @@ onErrorMainWith action = onMain "error" imageErrorDecoder action
 --
 -- data Action = HandleStartPlay
 --
--- view :: context -> props -> Model -> View context Action
--- view _ _ model = image_ "url" [ onStartPlay HandleStartPlay ]
+-- view :: Model -> View context props Model Action
+-- view model = image_ "url" [ onStartPlay HandleStartPlay ]
 --
 -- @
 --
@@ -208,8 +208,8 @@ onStartPlayMainWith action = onMain "startplay" emptyDecoder (\() m ref -> actio
 --
 -- data Action = HandleCurrentLoopComplete
 --
--- view :: context -> props -> Model -> View context Action
--- view _ _ model = image_ "url" [ onCurrentLoopComplete HandleCurrentLoopComplete ]
+-- view :: Model -> View context props Model Action
+-- view model = image_ "url" [ onCurrentLoopComplete HandleCurrentLoopComplete ]
 --
 -- @
 --
@@ -251,8 +251,8 @@ onCurrentLoopCompleteMainWith action = onMain "currentloopcomplete" emptyDecoder
 --
 -- data Action = HandleFinalLoopComplete
 --
--- view :: context -> props -> Model -> View context Action
--- view _ _ model = image_ "url" [ onFinalLoopComplete HandleFinalLoopComplete ]
+-- view :: Model -> View context props Model Action
+-- view model = image_ "url" [ onFinalLoopComplete HandleFinalLoopComplete ]
 --
 -- @
 --

--- a/src/Miso/Native/Element/List/Event.hs
+++ b/src/Miso/Native/Element/List/Event.hs
@@ -332,8 +332,8 @@ layoutCompleteDecoder = ["detail"] `at` do
 --
 -- data Action = HandleScroll ScrollEvent
 --
--- view :: context -> props -> Model -> View context Action
--- view _ _ model = list_ defaultListOptions [ onScroll HandleScroll ] [ ]
+-- view :: Model -> View context props Model Action
+-- view model = list_ defaultListOptions [ onScroll HandleScroll ] [ ]
 --
 -- update :: Action -> Effect props Model Action
 -- update (HandleScroll ScrollEvent {..}) =
@@ -379,8 +379,8 @@ onScrollMainWith action = onMain "scroll" scrollDecoder action
 --
 -- data Action = HandleScroll ScrollEvent
 --
--- view :: context -> props -> Model -> View context Action
--- view _ _ model = list_ defaultListOptions [ onScrollToUpper HandleScroll ] [ ]
+-- view :: Model -> View context props Model Action
+-- view model = list_ defaultListOptions [ onScrollToUpper HandleScroll ] [ ]
 --
 -- update :: Action -> Effect props Model Action
 -- update (HandleScroll ScrollEvent {..}) =
@@ -426,8 +426,8 @@ onScrollToUpperMainWith action = onMain "scrolltoupper" scrollDecoder action
 --
 -- data Action = HandleScroll ScrollEvent
 --
--- view :: context -> props -> Model -> View context Action
--- view _ _ model = list_ defaultListOptions [ onScrollToLower HandleScroll ] [ ]
+-- view :: Model -> View context props Model Action
+-- view model = list_ defaultListOptions [ onScrollToLower HandleScroll ] [ ]
 --
 -- update :: Action -> Effect props Model Action
 -- update (HandleScroll ScrollEvent {..}) =
@@ -477,8 +477,8 @@ onScrollToLowerMainWith action = onMain "scrolltolower" scrollDecoder action
 --
 -- data Action = HandleScrollState ScrollStateChange
 --
--- view :: context -> props -> Model -> View context Action
--- view _ _ model = list_ defaultListOptions [ onScrollStateChange HandleScrollState ] [ ]
+-- view :: Model -> View context props Model Action
+-- view model = list_ defaultListOptions [ onScrollStateChange HandleScrollState ] [ ]
 --
 -- update :: Action -> Effect props Model Action
 -- update (HandleScroll Stationary) =
@@ -525,8 +525,8 @@ onScrollStateChangeMainWith action = onMain "scrollstatechange" scrollStateDecod
 --
 -- data Action = HandleLayout LayoutCompleteEvent
 --
--- view :: context -> props -> Model -> View context Action
--- view _ _ model = list_ defaultListOptions [ onLayoutComplete HandleLayout ] [ ]
+-- view :: Model -> View context props Model Action
+-- view model = list_ defaultListOptions [ onLayoutComplete HandleLayout ] [ ]
 --
 -- update :: Action -> Effect props Model Action
 -- update (HandleLayout LayoutCompleteEvent {..}) =
@@ -571,8 +571,8 @@ onLayoutCompleteMainWith action = onMain "layoutcomplete" layoutCompleteDecoder 
 --
 -- data Action = HandleSnap SnapEvent
 --
--- view :: context -> props -> Model -> View context Action
--- view _ _ model = list_ defaultListOptions [ onSnap HandleSnap ] [ ]
+-- view :: Model -> View context props Model Action
+-- view model = list_ defaultListOptions [ onSnap HandleSnap ] [ ]
 --
 -- update :: Action -> Effect props Model Action
 -- update (HandleSnap SnapEvent {..}) =

--- a/src/Miso/Native/Element/ScrollView/Event.hs
+++ b/src/Miso/Native/Element/ScrollView/Event.hs
@@ -101,8 +101,8 @@ data ScrollEvent
 --
 -- data Action = HandleScroll ScrollEvent
 --
--- view :: context -> props -> Model -> View context Action
--- view _ _ model = scrollView_ [ onScroll HandleScroll ] [ ]
+-- view :: Model -> View context props Model Action
+-- view model = scrollView_ [ onScroll HandleScroll ] [ ]
 --
 -- update :: Action -> Effect props Model Action
 -- update (HandleScroll ScrollEvent {..}) =
@@ -145,8 +145,8 @@ onScrollMainWith action = onMain "scroll" scrollDecoder action
 --
 -- data Action = HandleScroll ScrollEvent
 --
--- view :: context -> props -> Model -> View context Action
--- view _ _ model = scrollView_ [ onScrollToUpper HnadleScroll ] [ ]
+-- view :: Model -> View context props Model Action
+-- view model = scrollView_ [ onScrollToUpper HnadleScroll ] [ ]
 --
 -- update :: Action -> Effect props Model Action
 -- update (HandleScroll ScrollEvent {..}) =
@@ -189,8 +189,8 @@ onScrollToUpperMainWith action = onMain "scrolltoupper" scrollDecoder action
 --
 -- data Action = HandleScroll ScrollEvent
 --
--- view :: context -> props -> Model -> View context Action
--- view _ _ model = scrollView_ [ onScrollToLower HandleScroll ] [ ]
+-- view :: Model -> View context props Model Action
+-- view model = scrollView_ [ onScrollToLower HandleScroll ] [ ]
 --
 -- update :: Action -> Effect props Model Action
 -- update (HandleScroll ScrollEvent {..}) =
@@ -233,8 +233,8 @@ onScrollToLowerMainWith action = onMain "scrolltolower" scrollDecoder action
 --
 -- data Action = HandleScroll ScrollEvent
 --
--- view :: context -> props -> Model -> View context Action
--- view _ _ model = scrollView_ [ onScrollToLower HandleScroll ] [ ]
+-- view :: Model -> View context props Model Action
+-- view model = scrollView_ [ onScrollToLower HandleScroll ] [ ]
 --
 -- update :: Action -> Effect props Model Action
 -- update (HandleScroll ScrollEvent {..}) =
@@ -282,8 +282,8 @@ onScrollEndMainWith action = onMain "scrollend" scrollDecoder action
 --
 -- data Action = HandleContentSizeChanged ScrollEvent
 --
--- view :: context -> props -> Model -> View context Action
--- view _ _ model = scrollView_ [ onContentSizeChanged HandleContentSizeChanged ] [ ]
+-- view :: Model -> View context props Model Action
+-- view model = scrollView_ [ onContentSizeChanged HandleContentSizeChanged ] [ ]
 --
 -- update :: Action -> Effect props Model Action
 -- update (HandleContentSizeChanged ScrollEvent {..}) =

--- a/src/Miso/Native/Element/Text/Event.hs
+++ b/src/Miso/Native/Element/Text/Event.hs
@@ -64,8 +64,8 @@ textEvents
 --
 -- data Action = HandleLayout LayoutEvent
 --
--- view :: context -> props -> Model -> View context Action
--- view _ _ model = text_ [ onLayout HandleLayout ] [ text "hi" ]
+-- view :: Model -> View context props Model Action
+-- view model = text_ [ onLayout HandleLayout ] [ text "hi" ]
 --
 -- update :: Action -> Effect context props Model Action
 -- update (HandleLayout LayoutEvent {..}) = io_ (consoleLog "layout event received")
@@ -109,8 +109,8 @@ onLayoutMainWith action = onMain "layout" layoutDecoder action
 --
 -- data Action = HandleSelectionChange SelectionChangeEvent
 --
--- view :: context -> props -> Model -> View context Action
--- view _ _ model = text_ [ onSelectionChange HandleSelectionChange ] [ text "hi" ]
+-- view :: Model -> View context props Model Action
+-- view model = text_ [ onSelectionChange HandleSelectionChange ] [ text "hi" ]
 --
 -- update :: Action -> Effect context props Model Action
 -- update (HandleSelectionChange SelectionChangeEvent {..}) =

--- a/src/Miso/Native/Element/View/Event.hs
+++ b/src/Miso/Native/Element/View/Event.hs
@@ -342,8 +342,8 @@ onTouchStart action = on "touchstart" touchDecoder (\x _ _ -> action x)
 -- @
 -- data Action = HandleTouch TouchEvent
 --
--- view :: context -> props -> Model -> View context Action
--- view _ _ model = view_ [ onTouchMove HandleTouch ]
+-- view :: Model -> View context props Model Action
+-- view model = view_ [ onTouchMove HandleTouch ]
 --
 -- update :: Action -> Effect context props Model Action
 -- update (HandleTouch TouchEvent {..}) = do
@@ -362,8 +362,8 @@ onTouchMove action = on "touchmove" touchDecoder (\x _ _ -> action x)
 -- @
 -- data Action = HandleTouch TouchEvent
 --
--- view :: context -> props -> Model -> View context Action
--- view _ _ model = view_ [ onTouchEnd HandleTouch ]
+-- view :: Model -> View context props Model Action
+-- view model = view_ [ onTouchEnd HandleTouch ]
 --
 -- update :: Action -> Effect context props Model Action
 -- update (HandleTouch TouchEvent {..}) = do
@@ -383,8 +383,8 @@ onTouchEnd action = on "touchend" touchDecoder (\x _ _ -> action x)
 -- @
 -- data Action = HandleTouch TouchEvent
 --
--- view :: context -> props -> Model -> View context Action
--- view _ _ model = view_ [ onTouchCancel HandleTouch ]
+-- view :: Model -> View context props Model Action
+-- view model = view_ [ onTouchCancel HandleTouch ]
 --
 -- update :: Action -> Effect context props Model Action
 -- update (HandleTouch TouchEvent {..}) =
@@ -403,7 +403,7 @@ onTouchCancel action = on "touchcancel" touchDecoder (\x _ _ -> action x)
 -- @
 -- data Action = HandleTap
 --
--- view :: context -> props -> Model -> View context Action
+-- view :: Model -> View context props Model Action
 -- view model = view_ [ onTap HandleTap ]
 --
 -- update :: Action -> Effect context props Model Action
@@ -424,7 +424,7 @@ onTap action = on "tap" emptyDecoder (\() _ _ -> action)
 -- @
 -- data Action = HandleTap
 --
--- view :: context -> props -> Model -> View context Action
+-- view :: Model -> View context props Model Action
 -- view model = view_ [ event $ static (onTapMain HandleTap) ]
 --
 -- update :: Action -> Effect context props Model Action
@@ -445,7 +445,7 @@ onTapMain action = onMain "tap" emptyDecoder (\() _ _ -> action)
 -- @
 -- data Action = HandleTap
 --
--- view :: context -> props -> Model -> View context Action
+-- view :: Model -> View context props Model Action
 -- view model = view_ [ event $ static (onTapMain HandleTap) ]
 --
 -- update :: Action -> Effect context props Model Action
@@ -466,7 +466,7 @@ onTapMainWith action = onMain "tap" emptyDecoder (\() _ -> action)
 -- @
 -- data Action = HandleTap
 --
--- view :: context -> props -> Model -> View context Action
+-- view :: Model -> View context props Model Action
 -- view model = view_ [ event $ static (onTapMain HandleTap) ]
 --
 -- update :: Action -> Effect context props Model Action
@@ -485,7 +485,7 @@ onTapMainModel action = onMain "tap" emptyDecoder (\() m _ -> action m)
 -- @
 -- data Action = HandleTouch TouchEvent
 --
--- view :: context -> props -> Model -> View context Action
+-- view :: Model -> View context props Model Action
 -- view model = view_ [ onLongPress HandleTouch ]
 --
 -- update :: Action -> Effect context props Model Action
@@ -505,8 +505,8 @@ onLongPress action = on "longpress" touchDecoder (\x _ _ -> action x)
 -- @
 -- data Action = HandleLayout LayoutChangeDetailEvent
 --
--- view :: context -> props -> Model -> View context Action
--- view _ _ model = view_ [ onLayoutChange HandleLayout ]
+-- view :: Model -> View context props Model Action
+-- view model = view_ [ onLayoutChange HandleLayout ]
 --
 -- update :: Action -> Effect context props Model Action
 -- update (HandleLayout LayoutChangeDetailEvent {..}) =
@@ -530,8 +530,8 @@ onLayout action = on "layout" layoutChangeDetailDecoder (\x _ _ -> action x)
 -- @
 -- data Action = HandleUI UIAppearanceDetailEvent
 --
--- view :: context -> props -> Model -> View context Action
--- view _ _ model = view_ [ onAppear HandleUI ]
+-- view :: Model -> View context props Model Action
+-- view model = view_ [ onAppear HandleUI ]
 --
 -- update :: Action -> Effect context props Model Action
 -- update (HandleUI UIAppearanceDetailEvent {..}) = do
@@ -548,8 +548,8 @@ onAppear action = on "uiappear" uiAppearanceDetailDecoder (\x _ _ -> action x)
 -- @
 -- data Action = HandleUI UIAppearanceDetailEvent
 --
--- view :: context -> props -> Model -> View context Action
--- view _ _ model = view_ [ onDisappear HandleUI ]
+-- view :: Model -> View context props Model Action
+-- view model = view_ [ onDisappear HandleUI ]
 --
 -- update :: Action -> Effect props Model Action
 -- update (HandleUI UIAppearanceDetailEvent {..}) = do
@@ -566,8 +566,8 @@ onDisappear action = on "uidisappear" uiAppearanceDetailDecoder (\x _ _ -> actio
 -- @
 -- data Action = HandleAnimation AnimationEvent
 --
--- view :: context -> props -> Model -> View context Action
--- view _ _ model = view_ [ onAnimationStart HandleAnimation ]
+-- view :: Model -> View context props Model Action
+-- view model = view_ [ onAnimationStart HandleAnimation ]
 --
 -- update :: Action -> Effect context props Model Action
 -- update (HandleAnimation AnimationEvent {..}) =
@@ -584,7 +584,7 @@ onAnimationStart action = on "animationstart" animationDecoder $ (\x _ _ -> acti
 -- @
 -- data Action = HandleAnimation AnimationEvent
 --
--- view :: context -> props -> Model -> View context Action
+-- view :: Model -> View context props Model Action
 -- view model = view_ [ onAnimationEnd HandleAnimation ]
 --
 -- update :: Action -> Effect context props Model Action
@@ -602,8 +602,8 @@ onAnimationEnd action = on "animationend" animationDecoder (\x _ _ -> action x)
 -- @
 -- data Action = HandleAnimation AnimationEvent
 --
--- view :: context -> props -> Model -> View context Action
--- view _ _ model = view_ [ onAnimationCancel HandleAnimation ]
+-- view :: Model -> View context props Model Action
+-- view model = view_ [ onAnimationCancel HandleAnimation ]
 --
 -- update :: Action -> Effect context props Model Action
 -- update (HandleAnimation AnimationEvent {..}) =
@@ -620,8 +620,8 @@ onAnimationCancel action = on "animationcancel" animationDecoder (\x _ _ -> acti
 -- @
 -- data Action = HandleAnimation AnimationEvent
 --
--- view :: context -> props -> Model -> View context Action
--- view _ _ model = view_ [ onAnimationIteration HandleAnimation ]
+-- view :: Model -> View context props Model Action
+-- view model = view_ [ onAnimationIteration HandleAnimation ]
 --
 -- update :: Action -> Effect context props Model Action
 -- update (HandleAnimation AnimationEvent {..}) =
@@ -638,8 +638,8 @@ onAnimationIteration action = on "animationiteration" animationDecoder (\x _ _ -
 -- @
 -- data Action = HandleTransition AnimationEvent
 --
--- view :: context -> props -> Model -> View context Action
--- view _ _ model = view_ [ onTransitionStart HandleTransition ]
+-- view :: Model -> View context props Model Action
+-- view model = view_ [ onTransitionStart HandleTransition ]
 --
 -- update :: Action -> Effect context props Model Action
 -- update (HandleTransition TransitionEvent {..}) =
@@ -656,8 +656,8 @@ onTransitionStart action = on "transitionstart" animationDecoder (\x _ _ -> acti
 -- @
 -- data Action = HandleTransition AnimationEvent
 --
--- view :: context -> props -> Model -> View context Action
--- view _ _ model = view_ [ onTransitionEnd HandleTransition ]
+-- view :: Model -> View context props Model Action
+-- view model = view_ [ onTransitionEnd HandleTransition ]
 --
 -- update :: Action -> Effect context props Model Action
 -- update (HandleTransition TransitionEvent {..}) =
@@ -674,8 +674,8 @@ onTransitionEnd action = on "transitionend" animationDecoder (\x _ _ -> action x
 -- @
 -- data Action = HandleTransition AnimationEvent
 --
--- view :: context -> props -> Model -> View context Action
--- view _ _ model = view_ [ onTransitionCancel HandleTransition ]
+-- view :: Model -> View context props Model Action
+-- view model = view_ [ onTransitionCancel HandleTransition ]
 --
 -- update :: Action -> Effect context props Model Action
 -- update (HandleTransition TransitionEvent {..}) =

--- a/src/Miso/Native/MainThread.hs
+++ b/src/Miso/Native/MainThread.hs
@@ -27,7 +27,7 @@
 --
 -- @
 -- -- move an element with the finger, entirely on the main thread:
--- view _ _ _ = view_ [ onTouchMoveWith Drag ] []
+-- view _ = view_ [ onTouchMoveWith Drag ] []
 --
 -- update (Drag touch domRef) = io_ $
 --   setStyleProperty domRef \"transform\"

--- a/src/Miso/Runtime.hs
+++ b/src/Miso/Runtime.hs
@@ -268,7 +268,7 @@ initialize events _componentParentId hydrate isRoot live _componentContext initi
         currentContext <- readIORef contextRef
         newVTree <-
           buildVTree events _componentParentId _componentId Draw live
-            _componentSink logLevel contextRef currentContext currentProps newModel (view currentContext currentProps newModel)
+            _componentSink logLevel contextRef currentContext currentProps newModel (view newModel)
         newHandlers <- collectEventHandlers
         oldVTree <- readIORef _componentVTree
         _frame <- requestAnimationFrame rAFCallback
@@ -539,7 +539,7 @@ initialDraw initializedModel events hydrate isRoot live Component {..} Component
 #endif
   currentContext <- readIORef _componentContext
   vtree <- buildVTree events _componentParentId _componentId hydrate live _componentSink logLevel
-    _componentContext currentContext _componentProps initializedModel (view currentContext _componentProps initializedModel)
+    _componentContext currentContext _componentProps initializedModel (view initializedModel)
   vtreeHandlers0 <- collectEventHandlers
 #ifdef BENCH
   end <- FFI.now
@@ -561,7 +561,7 @@ initialDraw initializedModel events hydrate isRoot live Component {..} Component
             else do
               newTree <-
                 buildVTree events _componentParentId _componentId Draw live
-                  _componentSink logLevel _componentContext currentContext _componentProps initializedModel (view currentContext _componentProps initializedModel)
+                  _componentSink logLevel _componentContext currentContext _componentProps initializedModel (view initializedModel)
               newHandlers <- collectEventHandlers
               -- the discarded hydration tree's callbacks are unreachable
               mapM_ freeFunction vtreeHandlers0

--- a/src/Miso/Types.hs
+++ b/src/Miso/Types.hs
@@ -278,9 +278,18 @@ data Component context props model action
   --   @localStorage@ via 'Miso.Storage.getLocalStorage').
   , update :: action -> Effect context props model action
   -- ^ Updates model, optionally providing effects.
-  , view :: context -> props -> model -> View context props model action
-  -- ^ Draws 'View'. Receives the app-global @context@, the @props@ passed by the
-  --   parent, and the current @model@.
+  , view :: model -> View context props model action
+  -- ^ Draws 'View'. Receives the current @model@.
+  --
+  --   The app-global @context@ and the @props@ passed by the parent are /not/
+  --   arguments: read them where they are needed with the ambient accessors
+  --   'withContext' \/ 'vcontext' and 'withProps' \/ 'vprops'. A @view@ that
+  --   ignored them no longer has to name them, and one that uses them reads
+  --   them at the point of use rather than threading them down by hand.
+  --
+  --   @
+  --   view m = div_ [] [ withContext $ \\theme -> ... , text (ms m) ]
+  --   @
   , useContext :: Bool
   -- ^ Whether this t'Miso.Types.Component' should be re-rendered when the
   --   app-global @context@ changes (see 'Miso.Effect.modifyContext').
@@ -401,7 +410,7 @@ component
   -- ^ model
   -> (action -> Effect context props model action)
   -- ^ update
-  -> (context -> props -> model -> View context props model action)
+  -> (model -> View context props model action)
   -- ^ view
   -> Component context props model action
 component m u v = Component
@@ -819,9 +828,10 @@ mountUseContext comp = VComp (SomeComponent Nothing () comp { useContext = True 
 -- | Create a new 'Miso.Types.VContext'.
 --
 -- Embeds a subtree that is resolved against the app-global @context@ at the
--- point the enclosing 'View' is built or rendered, so a helper deep in a
--- view tree can read @context@ without needing it threaded through as an
--- explicit argument.
+-- point the enclosing 'View' is built or rendered, so any part of a view tree
+-- can read @context@ without needing it threaded through as an explicit
+-- argument. Since 'view' takes only the @model@, this is /the/ way to read
+-- the @context@ during render.
 --
 -- @
 -- vcontext $ \\theme -> div_ [] [ text (themeLabel theme) ]
@@ -847,10 +857,10 @@ withContext = vcontext
 -- | Create a new 'Miso.Types.VProps'.
 --
 -- Embeds a subtree that is resolved against the enclosing t'Component'\'s
--- @props@ at the point the enclosing 'View' is built or rendered, so a helper
--- deep in a view tree can read @props@ without needing it threaded through as
--- an explicit argument — unlike 'view' itself, which already receives @props@
--- as its second parameter.
+-- @props@ at the point the enclosing 'View' is built or rendered, so any part
+-- of a view tree can read @props@ without needing it threaded through as an
+-- explicit argument. Since 'view' takes only the @model@, this is /the/ way
+-- to read the @props@ during render.
 --
 -- @
 -- vprops $ \\Props { title } -> h1_ [] [ text title ]
@@ -882,8 +892,8 @@ withProps = vprops
 -- Embeds a subtree that is resolved against the enclosing t'Component'\'s
 -- @model@ at the point the enclosing 'View' is built or rendered, so a helper
 -- deep in a view tree can read @model@ without needing it threaded through as
--- an explicit argument — unlike 'view' itself, which already receives @model@
--- as its third parameter.
+-- an explicit argument — unlike 'view' itself, which receives the @model@ as
+-- its only parameter.
 --
 -- @
 -- vmodel $ \\Model { count } -> span_ [] [ text (ms count) ]

--- a/src/Miso/Types.hs
+++ b/src/Miso/Types.hs
@@ -290,6 +290,19 @@ data Component context props model action
   --   @
   --   view m = div_ [] [ withContext $ \\theme -> ... , text (ms m) ]
   --   @
+  --
+  --   __Note:__ the @model@ is an argument purely for convenience — it is the
+  --   one of the three a @view@ almost always needs, and the one that most
+  --   often drives the shape of the whole tree. It is /also/ available
+  --   ambiently through 'withModel' \/ 'vmodel', so
+  --
+  --   @
+  --   view _ = withModel $ \\m -> ...
+  --   @
+  --
+  --   is equivalent to taking it as an argument; use whichever reads better.
+  --   'withModel' is the better choice for a helper deep in the tree that
+  --   needs the @model@ but is not otherwise passed it.
   , useContext :: Bool
   -- ^ Whether this t'Miso.Types.Component' should be re-rendered when the
   --   app-global @context@ changes (see 'Miso.Effect.modifyContext').
@@ -892,8 +905,10 @@ withProps = vprops
 -- Embeds a subtree that is resolved against the enclosing t'Component'\'s
 -- @model@ at the point the enclosing 'View' is built or rendered, so a helper
 -- deep in a view tree can read @model@ without needing it threaded through as
--- an explicit argument — unlike 'view' itself, which receives the @model@ as
--- its only parameter.
+-- an explicit argument. Unlike @context@ and @props@, the @model@ is /also/
+-- handed to 'view' as its only parameter — that is a convenience, not a
+-- restriction: @view _ = vmodel $ \\m -> …@ is equivalent, and 'vmodel' is
+-- the better choice for a helper the @model@ is not otherwise passed to.
 --
 -- @
 -- vmodel $ \\Model { count } -> span_ [] [ text (ms count) ]

--- a/tests/app/Main.hs
+++ b/tests/app/Main.hs
@@ -147,7 +147,7 @@ readText elemId = fromJSValUnchecked =<< eval
   ("document.getElementById('" <> elemId <> "').textContent")
 -----------------------------------------------------------------------------
 testComponent :: Component () () Int Action
-testComponent = component (0 :: Int) update_ $ \_ _ _ -> button_ [ id_ "foo", onClick AddOne ] [ "click me " ]
+testComponent = component (0 :: Int) update_ $ \_ -> button_ [ id_ "foo", onClick AddOne ] [ "click me " ]
   where
     update_ = \case
       AddOne -> this += 1
@@ -160,11 +160,11 @@ data Action = AddOne
 -- 'staticSwapRoot'; the differ must replace one with the other, not keep the
 -- first and run the second's @diffProps@ against it.
 staticProbeA, staticProbeB :: Component () () () Action
-staticProbeA = component () noop $ \_ _ _ -> div_ [ id_ "static-a" ] [ "A" ]
-staticProbeB = component () noop $ \_ _ _ -> div_ [ id_ "static-b" ] [ "B" ]
+staticProbeA = component () noop $ \_ -> div_ [ id_ "static-a" ] [ "A" ]
+staticProbeB = component () noop $ \_ -> div_ [ id_ "static-b" ] [ "B" ]
 -----------------------------------------------------------------------------
 staticSwapRoot :: Component () () Bool Action
-staticSwapRoot = component False (\AddOne -> this %= not) $ \_ _ swapped ->
+staticSwapRoot = component False (\AddOne -> this %= not) $ \swapped ->
   div_ []
     [ if swapped
         then vcomp_ (static (mountStatic staticProbeB))
@@ -1758,7 +1758,7 @@ main = withJS $ do
 
       it "Should mount 1000 components" $ do
         liftIO $ startApp mempty $
-          ((component (0 :: Int) noop $ \_ _ _ ->
+          ((component (0 :: Int) noop $ \_ ->
             div_ [] (replicate 999 (mount_ testComponent))) :: Component () () Int ())
         mountedComponents >>= (`shouldBe` 1000)
 
@@ -1771,7 +1771,7 @@ main = withJS $ do
         -- undefined), so freeFunction was never called and every non-root
         -- Component unmount leaked the mount/unmount closures.
         liftIO $ startApp mempty $
-          ((component (0 :: Int) noop $ \_ _ _ ->
+          ((component (0 :: Int) noop $ \_ ->
             div_ [] [ mount_ testComponent ]) :: Component () () Int ())
         mountedComponents >>= (`shouldBe` 2)
         childState@ComponentState {..} <-
@@ -1807,7 +1807,7 @@ main = withJS $ do
         -- used to inherit those leftovers instead of getting its own fresh
         -- (unset) values.
         liftIO $ startApp mempty $
-          component (0 :: Int) noop $ \_ _ _ ->
+          component (0 :: Int) noop $ \_ ->
             div_
               [ event (static (onMain "click" emptyDecoder (\() _ _ -> AddOne)))
               , on "mouseover" emptyDecoder (\() _ _ -> AddOne)
@@ -1850,11 +1850,11 @@ main = withJS $ do
 
     describe "VContext tests" $ do
       let contextProbe :: Component Int () () Action
-          contextProbe = component () noop $ \_ _ _ ->
+          contextProbe = component () noop $ \_ ->
             div_ [ id_ "ctx-probe" ] [ vcontext (text . ms) ]
 
           contextRoot :: Bool -> Component Int () () ContextAction
-          contextRoot useContext = component () (\BumpContext -> modifyContext (+1)) $ \_ _ _ ->
+          contextRoot useContext = component () (\BumpContext -> modifyContext (+1)) $ \_ ->
             div_ [] [ mount_ contextProbe { useContext } ]
 
           readProbe = readText "ctx-probe"
@@ -1916,17 +1916,17 @@ main = withJS $ do
     describe "VProps tests" $ do
       let -- A child whose @props@ is an 'Int', displayed via 'vprops'.
           propsProbe :: Component () Int () Action
-          propsProbe = component () noop $ \_ _ _ ->
+          propsProbe = component () noop $ \_ ->
             div_ [ id_ "props-probe" ] [ vprops (text . ms) ]
 
           -- A root that forwards its own 'Int' model to 'propsProbe' as @props@.
           propsRoot :: Component () () Int Action
-          propsRoot = component (1 :: Int) (\AddOne -> this += 1) $ \_ _ m ->
+          propsRoot = component (1 :: Int) (\AddOne -> this += 1) $ \m ->
             div_ [] [ mountWithProps m propsProbe ]
 
       it "vprops resolves the mounting component's props at initial mount" $ do
         let root :: App () Action
-            root = component () noop $ \_ _ _ ->
+            root = component () noop $ \_ ->
               div_ [] [ mountWithProps (100 :: Int) propsProbe ]
         liftIO $ startApp mempty root
         txt <- liftIO (readText "props-probe")
@@ -1945,16 +1945,16 @@ main = withJS $ do
         -- parent can host a 'MisoString'-props child and each 'vprops' /
         -- 'withProps' resolves against its own component.
         let inner :: Component () MisoString () Action
-            inner = component () noop $ \_ _ _ ->
+            inner = component () noop $ \_ ->
               span_ [ id_ "props-inner" ] [ withProps text ]
             outer :: Component () Int () Action
-            outer = component () noop $ \_ _ _ ->
+            outer = component () noop $ \_ ->
               div_ [ id_ "props-outer" ]
                 [ span_ [] [ vprops (text . ms) ]
                 , mountWithProps ("inner" :: MisoString) inner
                 ]
             root :: App () Action
-            root = component () noop $ \_ _ _ ->
+            root = component () noop $ \_ ->
               div_ [] [ mountWithProps (7 :: Int) outer ]
         liftIO $ startApp mempty root
         outerTxt <- liftIO (readText "props-outer")
@@ -1974,7 +1974,7 @@ main = withJS $ do
 
       it "a vprops resolving to an empty fragment contributes no child" $ do
         let root :: App () Action
-            root = component () noop $ \_ _ _ ->
+            root = component () noop $ \_ ->
               div_ [ id_ "props-wrap" ] [ "a", vprops (\() -> vfrag []), "b" ]
         liftIO $ startApp mempty root
         count <- liftIO $ fromJSValUnchecked =<< eval
@@ -1989,7 +1989,7 @@ main = withJS $ do
       let -- A root whose 'Int' model is displayed via 'vmodel' rather than
           -- through the 'view' argument.
           modelRoot :: App Int Action
-          modelRoot = component (1 :: Int) (\AddOne -> this += 1) $ \_ _ _ ->
+          modelRoot = component (1 :: Int) (\AddOne -> this += 1) $ \_ ->
             div_ [ id_ "model-probe" ] [ vmodel (text . ms) ]
 
       it "vmodel resolves the component's model at initial mount" $ do
@@ -2010,10 +2010,10 @@ main = withJS $ do
         -- parent can host a 'MisoString'-model child and each 'vmodel' /
         -- 'withModel' resolves against its own component.
         let inner :: Component () () MisoString Action
-            inner = component ("inner" :: MisoString) noop $ \_ _ _ ->
+            inner = component ("inner" :: MisoString) noop $ \_ ->
               span_ [ id_ "model-inner" ] [ withModel text ]
             outer :: Component () () Int Action
-            outer = component (7 :: Int) noop $ \_ _ _ ->
+            outer = component (7 :: Int) noop $ \_ ->
               div_ [ id_ "model-outer" ]
                 [ span_ [] [ vmodel (text . ms) ]
                 , mount_ inner
@@ -2030,7 +2030,7 @@ main = withJS $ do
 
       it "a vmodel resolving to an empty fragment contributes no child" $ do
         let root :: App () Action
-            root = component () noop $ \_ _ _ ->
+            root = component () noop $ \_ ->
               div_ [ id_ "model-wrap" ] [ "a", vmodel (\() -> vfrag []), "b" ]
         liftIO $ startApp mempty root
         count <- liftIO $ fromJSValUnchecked =<< eval


### PR DESCRIPTION
The `view` field of a Component was

```haskell
context -> props -> model -> View context props model action
```

and is now

```haskell
model -> View context props model action
```

The context and props are read where they are needed with the ambient accessors withContext / vcontext and withProps / vprops, which resolve at the point the enclosing View is built or rendered. A view that ignored them no longer has to name them, and one that used them reads them at the point of use instead of threading them down through every helper.

toHtmlWith still takes the context, props and model — they are what the accessors in the rendered tree resolve against — but the view it is applied to now takes only the model:

```haskell
toHtmlWith ctx props model (view comp model)
```

The native gallery shows both accessors: `badgeView` reads its theme and its props ambiently, and mountedComponentSection no longer has the theme threaded into it from the top-level view.

Also corrects the ~40 haddock examples that still showed the pre-1.13 `view :: context -> props -> Model -> View context Action` shape, whose View arity was stale too.