### PR TITLE
`docs`: fix stale `view`/`View` Haddocks and `context`/`props` ambient-read examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,9 +197,9 @@ main = startApp defaultEvents app
 foreign export javascript "hs_start" main :: IO ()
 #endif
 ----------------------------------------------------------------------------
--- | `vcomp` takes as arguments the initial model, update function, view function
+-- | `component` takes as arguments the initial model, update function, view function
 app :: App Int Action
-app = vcomp 0 updateModel viewModel
+app = component 0 updateModel viewModel
 ----------------------------------------------------------------------------
 -- | Updates model, optionally introduces side effects
 updateModel :: Action -> Effect context props Int Action

--- a/src/Miso.hs
+++ b/src/Miso.hs
@@ -138,14 +138,13 @@
 --       Add -> 'Miso.Lens.this' 'Miso.Lens.+=' 1
 --       Subtract -> 'Miso.Lens.this' 'Miso.Lens.-=' 1
 --
---          * - The type of the global @context@
---          |     * - The type of the @props@ inherited from the parent t'Miso.Types.Component'
---          |     |      * - The type of the current t'Miso.Types.Component' @model@
---          |     |      |           * - The global @context@ threaded into the 'View' (@'View' context props model action@)
---          |     |      |           |  * - The type of the action that updates t'Miso.Types.Component' @model@
---          |     |      |           |  |
---     v :: () -> () -> 'Int' -> 'View' () () 'Int' Action
---     v _context _props x = 'Miso.Types.vfrag'
+--                          * - The type of the global @context@
+--                          |  * - The type of the @props@ inherited from the parent t'Miso.Types.Component'
+--                          |  |  * - The type of the current t'Miso.Types.Component' @model@ (also 'Miso.Types.view'\'s sole argument)
+--                          |  |  |     * - The type of the action that updates t'Miso.Types.Component' @model@
+--                          |  |  |     |
+--     v :: 'Int' -> 'View' () () 'Int' Action
+--     v x = 'Miso.Types.vfrag'
 --       [ H.'Miso.Html.Element.button_' [ HE.'Miso.Html.Event.onClick' Add, HP.'Miso.Html.Property.id_' "add" ] [ "+" ]
 --       , 'Miso.Types.text' ('ms' x)
 --       , H.'Miso.Html.Elemment.button_' [ HE.'Miso.Html.Event.onClick' Subtract, HP.'Miso.Html.Property.id_' "subtract" ] [ "-" ]
@@ -216,7 +215,7 @@
 -- data 'View' context props model action
 --   = 'VNode' 'Namespace' 'Tag' ['Attribute' model action] ['View' context props model action] 'DirectEvents'
 --   | 'VText' (Maybe t'Key') 'MisoString'
---   | 'VComp' ('SomeComponent' context)
+--   | 'VComp' (t'SomeComponent' context)
 --   | forall childProps . 'VCompStatic' (StaticPtr (t'SomeStaticComponent' childProps context)) childProps
 --   | 'VFrag' (Maybe t'Key') ['View' context props model action]
 --   | 'VContext' (context -> 'View' context props model action)
@@ -248,9 +247,9 @@
 -- * @fragment@, 'Miso.Types.vfrag', 'fragment_', 'vfrag_' — build a 'VFrag'
 -- * ('+>') — key and mount a child t'Miso.Types.Component'
 -- * 'vcomp', 'vcomp_' — build a 'VCompStatic' (see below)
--- * 'vcontext' \/ 'withContext' — build a 'VContext'
--- * 'vprops' \/ 'withProps' — build a 'VProps'
--- * 'vmodel' \/ 'withModel' — build a 'VModel'
+-- * 'vcontext' \/ 'withContext' — access the context
+-- * 'vprops' \/ 'withProps' — access the props
+-- * 'vmodel' \/ 'withModel' — access the model
 --
 -- A full list of element smart constructors built on 'node' (e.g. 'Miso.Html.Element.Miso.Html.Element.div_') can be found in "Miso.Html.Element".
 --
@@ -267,7 +266,7 @@
 -- * __@context@__ — global; the same value is visible to the whole tree.
 --
 -- This is why @context@ is a type parameter on both t'Miso.Types.Component' and 'View'
--- (@'Miso.Types.Component' context props model action@, @'View' context props model action@): the
+-- (@t'Miso.Types.Component' context props model action@, @'View' context props model action@): the
 -- parameter is threaded through the entire view tree so that every nested
 -- t'Miso.Types.Component' — reachable via t'SomeComponent' — is statically guaranteed to
 -- agree on __one__ @context@ type. There is exactly one live @context@ value per
@@ -293,7 +292,7 @@
 --
 -- @
 -- view :: model -> 'View' context props model action
--- view _model = 'withContext' $ \\ctx -> ...
+-- view _model = 'vcontext' $ \\ctx -> ...
 -- @
 --
 -- The @model@ is the one of the three that /is/ an argument, purely for
@@ -341,107 +340,6 @@
 -- (usually nested) components whose 'Miso.Types.view' depends on the @context@
 -- and must refresh when it changes.
 --
--- = 'VContext' (ambient context)
---
--- 'VContext' is an /ambient accessor/ for the app-global @context@, not a
--- node: it wraps a @context -> 'View' context props model action@ function
--- that is applied, and the wrapper discarded, whenever the enclosing 'View'
--- is built or rendered. It lets any part of a view tree read @context@
--- without needing it threaded through as an explicit argument. Since
--- 'Miso.Types.view' takes only the @model@, this is /the/ way to read the
--- @context@ during render.
---
--- @
--- 'vcontext' $ \\theme -> 'Miso.Html.Element.span_' [] [ 'Miso.Types.text' (themeLabel theme) ]
--- @
---
--- The function is applied to the current @context@ whenever the enclosing
--- 'View' is built or rendered — it does not itself trigger a redraw. Whether
--- a t'Miso.Types.Component' redraws at all on a context change is still
--- decided solely by 'Miso.Types.useContext', same as everywhere else.
---
--- The smart constructors for 'VContext' are 'vcontext' and 'withContext'
--- (a synonym).
---
--- = 'VProps' (ambient props)
---
--- 'VProps' is the @props@ counterpart of 'VContext': an ambient accessor
--- for the enclosing t'Miso.Types.Component'\'s @props@. It wraps a
--- @props -> 'View' context props model action@ function that is applied, and
--- the wrapper discarded, whenever the enclosing 'View' is built or rendered,
--- so any part of a view tree can read @props@ without needing it threaded
--- through as an explicit argument. Since 'Miso.Types.view' takes only the
--- @model@, this is /the/ way to read the @props@ during render.
---
--- @
--- 'vprops' $ \\Props { title } -> 'Miso.Html.Element.h1_' [] [ 'Miso.Types.text' title ]
--- @
---
--- Unlike @context@, which is one global value, @props@ are per-component.
--- That is why @props@ is a type parameter of 'View' (just like @model@): the
--- @props@ a 'VProps' sees is statically the @props@ of the
--- t'Miso.Types.Component' whose 'Miso.Types.view' contains it, and a mismatch
--- is a compile-time error. A child mounted with 'mountWithProps' \/ 'vcomp'
--- sees /its own/ @props@, never its parent's — the mount boundary forgets
--- the child's @props@ type just as it forgets its @model@ and @action@.
---
--- The function is applied to the current @props@ whenever the enclosing
--- 'View' is built or rendered. It adds no redraw logic of its own: a
--- component is redrawn when its parent passes it different @props@ (the
--- props phase), and the node is re-resolved as part of that redraw.
---
--- The smart constructors for 'VProps' are 'vprops' and 'withProps'
--- (a synonym).
---
--- == Why not @ImplicitParams@ or a @Reader@?
---
--- Both are alternatives for ambient values. @ImplicitParams@ (@?props@,
--- @?context@, @?model@) gives the same "read it where you need it"
--- ergonomics, but is a GHC-specific extension whose constraints leak into
--- every helper's signature. A @Reader@ (or @ReaderT@) over the 'View' would
--- work on any compiler, but forces a monadic style onto view code that is
--- otherwise plain applicative expressions and lists. 'VContext', 'VProps'
--- and 'VModel' keep the 'View' DSL as ordinary Haskell values: the accessor
--- is just another constructor, resolved by the runtime, with nothing to lift
--- or thread.
---
--- = 'VModel' (ambient model)
---
--- 'VModel' completes the trio: an ambient accessor for the enclosing
--- t'Miso.Types.Component'\'s @model@. It wraps a
--- @model -> 'View' context props model action@ function that is applied, and
--- the wrapper discarded, whenever the enclosing 'View' is built or rendered,
--- so a helper deep in a view tree can read @model@ without needing it
--- threaded through as an explicit argument. Unlike @context@ and @props@,
--- the @model@ is /also/ handed to 'Miso.Types.view' as its only parameter —
--- a convenience, not a restriction: @view _ = 'vmodel' $ \\m -> …@ is
--- equivalent to taking it as an argument.
---
--- @
--- 'vmodel' $ \\Model { count } -> 'Miso.Html.Element.span_' [] [ 'Miso.Types.text' ('Miso.String.ms' count) ]
--- @
---
--- As with @props@, @model@ is a type parameter of 'View', so the @model@ a
--- 'VModel' sees is statically the @model@ of the t'Miso.Types.Component'
--- whose 'Miso.Types.view' contains it, and a mismatch is a compile-time
--- error. A child mounted with 'mount_' \/ 'vcomp' sees /its own/ @model@,
--- never its parent's.
---
--- The function is applied to the current @model@ whenever the enclosing
--- 'View' is built or rendered. It adds no redraw logic of its own: a
--- component is redrawn when its @model@ changes after an 'Miso.Types.update',
--- and the accessor is re-resolved as part of that redraw.
---
--- When serialising, a bare 'View' under 'Miso.Html.Render.toHtml' is static
--- markup with @model ~ ()@; a view that reads a real @model@ is rendered with
--- 'Miso.Html.Render.toHtmlWith', which takes the value. A 'VModel' inside a
--- mounted component sees that component's initial (or hydrated) @model@.
---
--- The smart constructors for 'VModel' are 'vmodel' and 'withModel'
--- (a synonym). Like 'withContext' and 'withProps', 'withModel' provides
--- /ambient/ access to the component's @model@: any helper in the view tree
--- can reach it without the value being passed down explicitly.
---
 -- = 'VComp' (Component nodes)
 --
 -- == Composition
@@ -463,8 +361,8 @@
 -- Practically, using this combinator looks like:
 --
 -- @
--- viewModel :: context -> props -> Int -> 'View' context props model action
--- viewModel _ _ _ = 'Miso.Html.Element.div_' [ 'Miso.Html.Property.id_' "container" ] [ "counter" '+>' counter ]
+-- viewModel :: Int -> 'View' context props model action
+-- viewModel _ = 'Miso.Html.Element.div_' [ 'Miso.Html.Property.id_' "container" ] [ "counter" '+>' counter ]
 -- @
 --
 -- The @\"counter\"@ string is a unique t'Key' that identifies the t'Miso.Types.Component' at runtime. These keys are very important when
@@ -583,7 +481,7 @@
 -- Unlike 'VComp' and 'VFrag', 'VText' has a one-to-one correspondence with a physical DOM node:
 -- each 'VText' in the virtual DOM maps to exactly one @Text@ node in the browser.
 --
--- The simplest way to produce a 'VText' is via the @IsString@ instance on @'View' action@.
+-- The simplest way to produce a 'VText' is via the @IsString@ instance on @'View' context props model action@.
 -- String literals inside a child list are automatically promoted to 'VText' nodes without
 -- any extra imports:
 --
@@ -682,6 +580,107 @@
 -- * 'Miso.Types.vfrag'      — unkeyed fragment (alias)
 -- * 'fragment_'  — keyed fragment
 -- * 'vfrag_'     — keyed fragment (alias, infix-friendly: @\"key\" \`vfrag_\` [...]@)
+--
+-- = 'VContext' (ambient context)
+--
+-- 'VContext' is an /ambient accessor/ for the app-global @context@, not a
+-- node: it wraps a @context -> 'View' context props model action@ function
+-- that is applied, and the wrapper discarded, whenever the enclosing 'View'
+-- is built or rendered. It lets any part of a view tree read @context@
+-- without needing it threaded through as an explicit argument. Since
+-- 'Miso.Types.view' takes only the @model@, this is /the/ way to read the
+-- @context@ during render.
+--
+-- @
+-- 'vcontext' $ \\theme -> 'Miso.Html.Element.span_' [] [ 'Miso.Types.text' (themeLabel theme) ]
+-- @
+--
+-- The function is applied to the current @context@ whenever the enclosing
+-- 'View' is built or rendered — it does not itself trigger a redraw. Whether
+-- a t'Miso.Types.Component' redraws at all on a context change is still
+-- decided solely by 'Miso.Types.useContext', same as everywhere else.
+--
+-- The smart constructors for 'VContext' are 'vcontext' and 'withContext'
+-- (a synonym).
+--
+-- = 'VProps' (ambient props)
+--
+-- 'VProps' is the @props@ counterpart of 'VContext': an ambient accessor
+-- for the enclosing t'Miso.Types.Component'\'s @props@. It wraps a
+-- @props -> 'View' context props model action@ function that is applied, and
+-- the wrapper discarded, whenever the enclosing 'View' is built or rendered,
+-- so any part of a view tree can read @props@ without needing it threaded
+-- through as an explicit argument. Since 'Miso.Types.view' takes only the
+-- @model@, this is /the/ way to read the @props@ during render.
+--
+-- @
+-- 'vprops' $ \\Props { title } -> 'Miso.Html.Element.h1_' [] [ 'Miso.Types.text' title ]
+-- @
+--
+-- Unlike @context@, which is one global value, @props@ are per-component.
+-- That is why @props@ is a type parameter of 'View' (just like @model@): the
+-- @props@ a 'VProps' sees is statically the @props@ of the
+-- t'Miso.Types.Component' whose 'Miso.Types.view' contains it, and a mismatch
+-- is a compile-time error. A child mounted with 'mountWithProps' \/ 'vcomp'
+-- sees /its own/ @props@, never its parent's — the mount boundary forgets
+-- the child's @props@ type just as it forgets its @model@ and @action@.
+--
+-- The function is applied to the current @props@ whenever the enclosing
+-- 'View' is built or rendered. It adds no redraw logic of its own: a
+-- component is redrawn when its parent passes it different @props@ (the
+-- props phase), and the node is re-resolved as part of that redraw.
+--
+-- The smart constructors for 'VProps' are 'vprops' and 'withProps'
+-- (a synonym).
+--
+-- == Why not @ImplicitParams@ or a @Reader@?
+--
+-- Both are alternatives for ambient values. @ImplicitParams@ (@?props@,
+-- @?context@, @?model@) gives the same "read it where you need it"
+-- ergonomics, but is a GHC-specific extension whose constraints leak into
+-- every helper's signature. A @Reader@ (or @ReaderT@) over the 'View' would
+-- work on any compiler, but forces a monadic style onto view code that is
+-- otherwise plain applicative expressions and lists. 'VContext', 'VProps'
+-- and 'VModel' keep the 'View' DSL as ordinary Haskell values: the accessor
+-- is just another constructor, resolved by the runtime, with nothing to lift
+-- or thread.
+--
+-- = 'VModel' (ambient model)
+--
+-- 'VModel' completes the trio: an ambient accessor for the enclosing
+-- t'Miso.Types.Component'\'s @model@. It wraps a
+-- @model -> 'View' context props model action@ function that is applied, and
+-- the wrapper discarded, whenever the enclosing 'View' is built or rendered,
+-- so a helper deep in a view tree can read @model@ without needing it
+-- threaded through as an explicit argument. Unlike @context@ and @props@,
+-- the @model@ is /also/ handed to 'Miso.Types.view' as its only parameter —
+-- a convenience, not a restriction: @view _ = 'vmodel' $ \\m -> …@ is
+-- equivalent to taking it as an argument.
+--
+-- @
+-- 'vmodel' $ \\Model { count } -> 'Miso.Html.Element.span_' [] [ 'Miso.Types.text' ('Miso.String.ms' count) ]
+-- @
+--
+-- As with @props@, @model@ is a type parameter of 'View', so the @model@ a
+-- 'VModel' sees is statically the @model@ of the t'Miso.Types.Component'
+-- whose 'Miso.Types.view' contains it, and a mismatch is a compile-time
+-- error. A child mounted with 'mount_' \/ 'vcomp' sees /its own/ @model@,
+-- never its parent's.
+--
+-- The function is applied to the current @model@ whenever the enclosing
+-- 'View' is built or rendered. It adds no redraw logic of its own: a
+-- component is redrawn when its @model@ changes after an 'Miso.Types.update',
+-- and the accessor is re-resolved as part of that redraw.
+--
+-- When serialising, a bare 'View' under 'Miso.Html.Render.toHtml' is static
+-- markup with @model ~ ()@; a view that reads a real @model@ is rendered with
+-- 'Miso.Html.Render.toHtmlWith', which takes the value. A 'VModel' inside a
+-- mounted component sees that component's initial (or hydrated) @model@.
+--
+-- The smart constructors for 'VModel' are 'vmodel' and 'withModel'
+-- (a synonym). Like 'withContext' and 'withProps', 'withModel' provides
+-- /ambient/ access to the component's @model@: any helper in the view tree
+-- can reach it without the value being passed down explicitly.
 --
 -- = t'Key'
 --
@@ -925,7 +924,7 @@
 --
 -- @
 -- view :: model -> 'View' context props model action
--- view model = 'withProps' $ \\props -> …
+-- view model = 'vprops' $ \\props -> …
 -- @
 --
 -- Top-level applications have no parent, so @props@ is always @()@ and there
@@ -967,9 +966,10 @@
 -- @
 --
 -- Because there is no parent to inherit from, @props@ will always be @()@ for a
--- root-level t'Miso.Types.Component'. You can ignore the @context@ and @props@ arguments in
--- 'Miso.Lens.view' and skip 'getProps' in 'Miso.Types.update'. Use 'startAppWithContext'
--- to seed a non-trivial @context@.
+-- root-level t'Miso.Types.Component'. There is nothing meaningful for 'vcontext' \/ 'vprops'
+-- to read in 'Miso.Lens.view' (both resolve to @()@ unless seeded), and 'getProps' is
+-- likewise not useful in 'Miso.Types.update'. Use 'startAppWithContext' to seed a
+-- non-trivial @context@.
 --
 -- === Passing props to a child t'Miso.Types.Component'
 --
@@ -1006,9 +1006,10 @@
 -- child :: t'Miso.Types.Component' ()      Greeting ()     ChildAction
 -- child = 'Miso.Types.component' () updateChild viewChild
 --   where
---     viewChild :: () -> Greeting -> () -> 'View' () Greeting () ChildAction
---     viewChild _ (Greeting g) _ =
---       'Miso.Html.Element.div_' [] [ 'Miso.Types.text' ("Hello, " <> g <> "!") ]
+--     viewChild :: () -> 'View' () Greeting () ChildAction
+--     viewChild _ =
+--       'vprops' $ \\(Greeting g) ->
+--         'Miso.Html.Element.div_' [] [ 'Miso.Types.text' ("Hello, " <> g <> "!") ]
 --
 --     updateChild :: ChildAction -> 'Effect' () Greeting () ChildAction
 --     updateChild = \\case
@@ -1020,8 +1021,8 @@
 -- parentComp :: 'App' ParentModel ParentAction
 -- parentComp = 'Miso.Types.component' (ParentModel \"World\") 'noop' viewParent
 --   where
---     viewParent :: () -> () -> ParentModel -> 'View' () () ParentModel ParentAction
---     viewParent _ _ (ParentModel g) = 'mountWithProps_' "child" (Greeting g) child
+--     viewParent :: ParentModel -> 'View' () () ParentModel ParentAction
+--     viewParent (ParentModel g) = 'mountWithProps_' "child" (Greeting g) child
 -- -----------------------------------------------------------------------------
 -- newtype ParentModel = ParentModel 'MisoString' deriving ('Eq')
 --
@@ -1154,7 +1155,7 @@
 -- 'Miso.Lens.set'  l v            -- write a field
 -- 'Miso.Lens.over' l f            -- modify a field
 -- r 'Miso.Lens.^.' l              -- infix read
--- r 'Data.Function.&' l 'Miso.Lens..~' v         -- infix write
+-- r 'Data.Function.&' l 'Miso.Lens..~' v          -- infix write
 -- @
 --
 -- == @MonadState@ operators (for use inside 'Effect')
@@ -1334,7 +1335,7 @@
 -- @
 -- import Servant.Miso.Html (HTML)
 --
--- type Home    = \"home\"    :\> Get '[HTML] ('Miso.Types.Component' context props model action)
+-- type Home    = \"home\"    :\> Get '[HTML] (t'Miso.Types.Component' context props model action)
 -- type About   = \"about\"   :\> Get '[HTML] ('View' context props model action)
 -- type Contact = \"contact\" :\> Get '[HTML] ['View' context props model action]
 -- type API = Home :\<|\> About :\<|\> Contact
@@ -1801,8 +1802,8 @@
 -- in a @\<script\>@ tag alongside the rendered HTML:
 --
 -- @
--- serverView :: context -> props -> Model -> 'View' context props Model Action
--- serverView _ _ m =
+-- serverView :: Model -> 'View' context props Model Action
+-- serverView m =
 --   'Miso.Html.Element.div_' []
 --     [ 'Miso.Html.Element.script_' [] [ 'textRaw' ("window.__initialModel__ = " \<\> 'Miso.JSON.encode' m) ]
 --     , appView m

--- a/src/Miso/CSS.hs
+++ b/src/Miso/CSS.hs
@@ -29,8 +29,8 @@
 -- import qualified "Miso.CSS"       as CSS
 -- import           "Miso.CSS.Color" ('Miso.CSS.Color.red', 'Miso.CSS.Color.rgba')
 --
--- myView :: 'Miso.Types.View' Model Action
--- myView =
+-- myView :: model -> 'Miso.Types.View' context props model Action
+-- myView _ =
 --   'Miso.Html.Element.div_'
 --     [ CSS.'Miso.CSS.style_'
 --         [ CSS.'Miso.CSS.display'        "flex"

--- a/src/Miso/CSS/Color.hs
+++ b/src/Miso/CSS/Color.hs
@@ -43,8 +43,8 @@
 -- import qualified "Miso.CSS"       as CSS
 -- import           "Miso.CSS.Color"
 --
--- myView :: 'Miso.Types.View' Model Action
--- myView =
+-- myView :: Model -> 'Miso.Types.View' context props Model Action
+-- myView _ =
 --   'Miso.Html.Element.div_'
 --     [ CSS.'Miso.CSS.style_'
 --         [ CSS.'Miso.CSS.backgroundColor' 'cornflowerblue'

--- a/src/Miso/Canvas.hs
+++ b/src/Miso/Canvas.hs
@@ -47,7 +47,7 @@
 -- import qualified "Miso.CSS.Color" as Color
 -- import qualified "Miso.Html.Property" as HP
 --
--- view :: Model -> 'Miso.Types.View' Model Action
+-- view :: Model -> 'Miso.Types.View' context props Model Action
 -- view m =
 --   'canvas'
 --     [ HP.'Miso.Html.Property.width_' \"800\", HP.'Miso.Html.Property.height_' \"480\" ]

--- a/src/Miso/Html.hs
+++ b/src/Miso/Html.hs
@@ -32,7 +32,7 @@
 --
 -- data Action = Increment | Decrement | Reset
 --
--- view :: Int -> 'Miso.Types.View' Int Action
+-- view :: Int -> 'Miso.Types.View' context props Int Action
 -- view n =
 --   'Miso.Html.Element.div_' [ 'Miso.Html.Property.class_' \"counter\" ]
 --     [ 'h1_' [] [ 'Miso.text' \"Counter\" ]

--- a/src/Miso/Html/Element.hs
+++ b/src/Miso/Html/Element.hs
@@ -30,7 +30,7 @@
 -- @
 -- import "Miso"
 --
--- view :: Model -> 'Miso.Types.View' Model Action
+-- view :: Model -> 'Miso.Types.View' context props Model Action
 -- view m =
 --   'div_' []
 --     [ 'h1_' [] [ 'Miso.text' \"Hello, miso!\" ]

--- a/src/Miso/Html/Event.hs
+++ b/src/Miso/Html/Event.hs
@@ -32,7 +32,7 @@
 -- @
 -- import "Miso"
 --
--- view :: Model -> 'Miso.Types.View' Model Action
+-- view :: Model -> 'Miso.Types.View' context props Model Action
 -- view m =
 --   'Miso.Html.Element.div_' []
 --     [ 'Miso.Html.Element.button_' [ 'onClick' Increment ]        [ 'Miso.text' \"+\" ]

--- a/src/Miso/Html/Property.hs
+++ b/src/Miso/Html/Property.hs
@@ -27,7 +27,7 @@
 -- @
 -- import "Miso"
 --
--- view :: Model -> 'Miso.Types.View' Model Action
+-- view :: Model -> 'Miso.Types.View' context props Model Action
 -- view m =
 --   'Miso.Html.Element.div_' [ 'id_' \"app\", 'class_' \"container\" ]
 --     [ 'Miso.Html.Element.input_'

--- a/src/Miso/Runtime.hs
+++ b/src/Miso/Runtime.hs
@@ -335,7 +335,7 @@ initialize events _componentParentId hydrate isRoot live _componentContext initi
   forM_ mount _componentSink
 #ifdef NATIVE
   -- Ship the child's initial @props@ so the MTS can rebuild the mirror
-  -- component by pairing them with the 'SomeStaticComponent' recovered from the
+  -- component by pairing them with the t'SomeStaticComponent' recovered from the
   -- 'StaticKey'. The no-props case serializes @()@ (JSON @null@).
   when (bts && not isRoot) $ do
     -- 'mount()' runs synchronously mid-diff (see @ts/miso/dom.ts@
@@ -2390,7 +2390,7 @@ effectListener Proxy jsval = void $ do
             Nothing ->
               FFI.consoleError "[effectListener]: staticPtr NOT found for effectStaticKey"
             Just ptr ->
-              -- The 'SomeStaticComponent' carries the child's dictionaries, so the
+              -- The t'SomeStaticComponent' carries the child's dictionaries, so the
               -- @action@ type (and its 'FromJSON') is in scope from the key alone.
               case deRefStaticPtr ptr of
                 SomeStaticComponent (_ :: Component context props model action) ->

--- a/src/Miso/Subscription/Canvas.hs
+++ b/src/Miso/Subscription/Canvas.hs
@@ -34,7 +34,7 @@ import Miso.Subscription.Util
 --
 -- data Action = InitCanvas DOMRef | StopCanvas
 --
--- canvasComponent :: 'Component' context props model action
+-- canvasComponent :: t'Component' context props model action
 -- canvasComponent = 'component' m u v
 --   where
 --     m = ()
@@ -44,7 +44,7 @@ import Miso.Subscription.Util
 --           drawScene currentModel
 --       StopCanvas ->
 --         stopSub "galaxy"
---     v _context _props () =
+--     v () =
 --       'canvas_' [ onCreatedWith InitCanvas, onDestroyed StopCanvas ] []
 --
 -- drawScene :: Model -> 'Canvas' ()

--- a/src/Miso/Svg/Event.hs
+++ b/src/Miso/Svg/Event.hs
@@ -31,7 +31,7 @@
 --
 -- data Action = AnimDone | Zoomed
 --
--- view :: Model -> 'Miso.Types.View' Model Action
+-- view :: Model -> 'Miso.Types.View' context props Model Action
 -- view _ =
 --   @svg_@ []
 --     [ 'Miso.Svg.Element.animate_'

--- a/src/Miso/Types.hs
+++ b/src/Miso/Types.hs
@@ -34,7 +34,7 @@
 --
 -- = The Component record
 --
--- @'Component' context props model action@ is the central record type. It
+-- @t'Component' context props model action@ is the central record type. It
 -- wires together the MVU loop and all supporting runtime configuration:
 --
 -- @
@@ -42,7 +42,7 @@
 --   { model           :: model
 --   , hydrateModel    :: Maybe (IO model)
 --   , update          :: action -> 'Miso.Effect.Effect' context props model action
---   , view            :: context -> props -> model -> 'View' context props model action
+--   , view            :: model -> 'View' context props model action
 --   , useContext      :: Bool
 --   , subs            :: ['Miso.Effect.Sub' action]
 --   , styles          :: ['CSS']
@@ -99,16 +99,16 @@
 --
 -- = Key types at a glance
 --
--- ['Component'] full MVU application\/component record
--- ['App'] alias for @'Component' () () model action@
+-- [t'Component'] full MVU application\/component record
+-- ['App'] alias for @t'Component' () () model action@
 -- ['View'] virtual DOM node
 -- ['Attribute'] DOM property, class list, event handler, or style
 -- ['Namespace'] @HTML@ \| @SVG@ \| @MATHML@
--- ['Key'] reconciliation hint for list diffing
+-- [t'Key'] reconciliation hint for list diffing
 -- ['CSS'] stylesheet reference (@Href@, @Style@, @Sheet@)
 -- ['JS'] script reference (@Src@, @Script@, @Module@, …)
 -- ['LogLevel'] debug verbosity (@Off@, @DebugHydrate@, …)
--- ['URI'] parsed URL (path + query string + fragment)
+-- [t'URI'] parsed URL (path + query string + fragment)
 --
 -- = Text combinators
 --
@@ -288,7 +288,7 @@ data Component context props model action
   --   them at the point of use rather than threading them down by hand.
   --
   --   @
-  --   view m = div_ [] [ withContext $ \\theme -> ... , text (ms m) ]
+  --   view m = div_ [] [ vcontext $ \\theme -> ... , text (ms m) ]
   --   @
   --
   --   __Note:__ the @model@ is an argument purely for convenience — it is the
@@ -297,7 +297,7 @@ data Component context props model action
   --   ambiently through 'withModel' \/ 'vmodel', so
   --
   --   @
-  --   view _ = withModel $ \\m -> ...
+  --   view _ = vmodel $ \\m -> ...
   --   @
   --
   --   is equivalent to taking it as an argument; use whichever reads better.
@@ -549,7 +549,7 @@ data SomeComponent context
 --
 -- Built with 'mountStatic'; consumed by 'vcomp' \/ 'vcomp_'.
 --
--- Up to 1.13 this held a @props -> 'SomeComponent' context@ function instead
+-- Up to 1.13 this held a @props -> t'SomeComponent' context@ function instead
 -- of the component itself, which forced the main thread to apply it to a
 -- placeholder just to reach the dictionaries; see 'mountStatic'.
 --
@@ -789,7 +789,7 @@ vcomp = flip VCompStatic
 -- | Like 'vcomp', but for a t'Miso.Types.Component' that takes no @props@.
 --
 -- @'vcomp_' = 'vcomp' ()@ — pair it with 'mountStatic' on a component whose
--- @props@ are @()@, which produces a @'SomeStaticComponent' () context@.
+-- @props@ are @()@, which produces a @t'SomeStaticComponent' () context@.
 --
 -- @
 -- div_ [] [ vcomp_ (static (mountStatic myComp)) ]


### PR DESCRIPTION
## Summary

Documentation-only pass across `src/`. No code changes.

The `view :: context -> props -> model -> View ...` API was refactored down to `view :: model -> View context props model action` across a few recent PRs (#1638, #1639, #1643, #1645), and a number of Haddock examples never caught up.

- **Stale `View` arity** — several quick-start examples still used the pre-`context`/`props` two-parameter form `View Model Action` instead of the current `View context props model action`:
  - `src/Miso/Html.hs`, `src/Miso/Html/Element.hs`, `src/Miso/Html/Event.hs`, `src/Miso/Html/Property.hs`, `src/Miso/Svg/Event.hs`, `src/Miso/Canvas.hs`, `src/Miso/CSS.hs`, `src/Miso/CSS/Color.hs`

- **Stale `view` arguments** — examples still showed `view` taking `context`/`props`/`model` as explicit arguments instead of the current single `model` argument, reading `context`/`props` ambiently:
  - `src/Miso.hs`: the tutorial `v` function, the `VComp` section's `viewModel`, the props section's `viewChild`/`viewParent`, and the prerendering section's `serverView`
  - `src/Miso/Types.hs`: the `Component` record's `view` field doc
  - `src/Miso/Subscription/Canvas.hs`: the `canvasSub` example

- **`context`/`props` named as arguments → `vcontext`/`vprops` at call sites** — wherever an example named the *accessor function* (not the `context`/`props` type variables) it now uses the canonical `vcontext`/`vprops` names instead of the `withContext`/`withProps` synonyms:
  - `src/Miso.hs`, `src/Miso/Types.hs`, `src/Miso/I18n.hs`
  - `src/Miso.hs`: dropped a stale claim that you can "ignore the `context` and `props` arguments in `view`" (they haven't been arguments since the refactor)

- **Section ordering** — `src/Miso.hs`: moved the `VContext`/`VProps`/`VModel` (ambient accessor) prose sections to after `VComp`, `VCompStatic`, `VNode`, `VText`, `VFrag`, matching the order used elsewhere in the module

- **Haddock link consistency** — `t'Foo'` vs `'Foo'`: `Component`, `Key`, `URI`, `SomeComponent`, and `SomeStaticComponent` all have a single data constructor sharing the type's name, so a bare `'Foo'` link is ambiguous and can resolve to the constructor instead of the type. Standardized on `t'Foo'` at every such reference across `src/Miso.hs`, `src/Miso/Types.hs`, `src/Miso/Runtime.hs`, and `src/Miso/Subscription/Canvas.hs`

- **Rendered alignment** — `src/Miso.hs`: fixed the "Basic lens operations" example table, where inline comments no longer lined up once Haddock stripped `Module.Path.` qualifiers down to short display names during rendering

- **README.md**: `app = vcomp 0 updateModel viewModel` used `vcomp` (which builds a `VCompStatic` native Lynx mount) where the top-level smart constructor `component` was meant

## Test plan

- [x] `cabal haddock` (or equivalent) to visually spot-check rendered output for the touched modules
- [x] Confirm no other modules were missed by re-running the arity/argument sweeps described above