### PR TITLE
`flake`: expose `overlays.default`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -39,6 +39,11 @@
 
   outputs = { self, nixpkgs, flake-utils, ... } @ inputs:
 
+    {
+      # Reusable for downstream flakes: `overlays.default = miso.overlays.default;`
+      overlays.default = final: prev: import ./nix/overlay.nix final prev;
+    } //
+
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = import nixpkgs {


### PR DESCRIPTION
Downstream flakes previously had no official way to reuse miso's Haskell package overlay (`nix/overlay.nix`) and had to reach for the file path directly. Expose it as the standard `overlays.default` output.