### PR TITLE
ci: bump stale GitHub Actions versions, drop dead security opt-in

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,22 +5,19 @@ on:
       - master
   pull_request:
 
-env:
-  ACTIONS_ALLOW_UNSECURE_COMMANDS: true
-
 jobs:
   build-linux:
     runs-on: ubuntu-latest
     steps:
-     - uses: ners/simply-nix@main
+     - uses: ners/simply-nix@2e89c5f0aaa5e4a7265dae7880e69d2c06efd6b5 # main, no tagged releases; pinned 2026-09
        with:
          reclaim_space: true
-     - uses: actions/checkout@v3.5.3
+     - uses: actions/checkout@v7.0.1
      - name: Cancel Previous Runs
-       uses: styfle/cancel-workflow-action@0.9.1
+       uses: styfle/cancel-workflow-action@0.13.1
        with:
          access_token: ${{ github.token }}
-     - uses: cachix/cachix-action@v16
+     - uses: cachix/cachix-action@v17
        with:
          name: haskell-miso-cachix
          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
@@ -115,16 +112,16 @@ jobs:
   build-bundle:
     runs-on: ubuntu-latest
     steps:
-     - uses: actions/checkout@v3.5.3
+     - uses: actions/checkout@v7.0.1
      - name: Cancel Previous Runs
-       uses: styfle/cancel-workflow-action@0.9.1
+       uses: styfle/cancel-workflow-action@0.13.1
        with:
          access_token: ${{ github.token }}
-     - uses: cachix/install-nix-action@v31
+     - uses: cachix/install-nix-action@v31.11.1
        with:
          extra_nix_config: |
            experimental-features = nix-command flakes
-     - uses: cachix/cachix-action@v16
+     - uses: cachix/cachix-action@v17
        with:
          name: haskell-miso-cachix
          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
@@ -146,7 +143,7 @@ jobs:
          cp result/main.lynx.bundle.sha256 bundle-artifact/main.lynx.bundle.sha256
 
      - name: Upload Lynx bundle
-       uses: actions/upload-artifact@v4
+       uses: actions/upload-artifact@v7.0.1
        with:
          name: lynx-bundle
          path: |
@@ -158,16 +155,16 @@ jobs:
     runs-on: macos-latest
     needs: build-bundle
     steps:
-     - uses: actions/checkout@v3.5.3
+     - uses: actions/checkout@v7.0.1
      - name: Cancel Previous Runs
-       uses: styfle/cancel-workflow-action@0.9.1
+       uses: styfle/cancel-workflow-action@0.13.1
        with:
          access_token: ${{ github.token }}
-     - uses: cachix/install-nix-action@v31
+     - uses: cachix/install-nix-action@v31.11.1
        with:
          extra_nix_config: |
            experimental-features = nix-command flakes
-     - uses: cachix/cachix-action@v16
+     - uses: cachix/cachix-action@v17
        with:
          name: haskell-miso-cachix
          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
@@ -209,14 +206,14 @@ jobs:
     runs-on: macos-latest
     needs: build-bundle
     steps:
-     - uses: actions/checkout@v3.5.3
+     - uses: actions/checkout@v7.0.1
      - name: Cancel Previous Runs
-       uses: styfle/cancel-workflow-action@0.9.1
+       uses: styfle/cancel-workflow-action@0.13.1
        with:
          access_token: ${{ github.token }}
 
      - name: Download Lynx bundle
-       uses: actions/download-artifact@v4
+       uses: actions/download-artifact@v8.0.1
        with:
          name: lynx-bundle
          path: bundle-artifact
@@ -249,20 +246,20 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-bundle
     steps:
-     - uses: actions/checkout@v3.5.3
+     - uses: actions/checkout@v7.0.1
      - name: Cancel Previous Runs
-       uses: styfle/cancel-workflow-action@0.9.1
+       uses: styfle/cancel-workflow-action@0.13.1
        with:
          access_token: ${{ github.token }}
-     - uses: actions/setup-java@v4
+     - uses: actions/setup-java@v6.0.1
        with:
          distribution: temurin
          java-version: '17'
-     - uses: cachix/install-nix-action@v31
+     - uses: cachix/install-nix-action@v31.11.1
        with:
          extra_nix_config: |
            experimental-features = nix-command flakes
-     - uses: cachix/cachix-action@v16
+     - uses: cachix/cachix-action@v17
        with:
          name: haskell-miso-cachix
          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
@@ -280,7 +277,7 @@ jobs:
        run: nix-build -A sample-app-native-android
 
      - name: Download Lynx bundle
-       uses: actions/download-artifact@v4
+       uses: actions/download-artifact@v8.0.1
        with:
          name: lynx-bundle
          path: bundle-artifact

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,10 @@ on:
       - master
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+
 jobs:
   build-linux:
     runs-on: ubuntu-latest
@@ -13,10 +17,6 @@ jobs:
        with:
          reclaim_space: true
      - uses: actions/checkout@v7.0.1
-     - name: Cancel Previous Runs
-       uses: styfle/cancel-workflow-action@0.13.1
-       with:
-         access_token: ${{ github.token }}
      - uses: cachix/cachix-action@v17
        with:
          name: haskell-miso-cachix
@@ -113,10 +113,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
      - uses: actions/checkout@v7.0.1
-     - name: Cancel Previous Runs
-       uses: styfle/cancel-workflow-action@0.13.1
-       with:
-         access_token: ${{ github.token }}
      - uses: cachix/install-nix-action@v31.11.1
        with:
          extra_nix_config: |
@@ -156,10 +152,6 @@ jobs:
     needs: build-bundle
     steps:
      - uses: actions/checkout@v7.0.1
-     - name: Cancel Previous Runs
-       uses: styfle/cancel-workflow-action@0.13.1
-       with:
-         access_token: ${{ github.token }}
      - uses: cachix/install-nix-action@v31.11.1
        with:
          extra_nix_config: |
@@ -207,10 +199,6 @@ jobs:
     needs: build-bundle
     steps:
      - uses: actions/checkout@v7.0.1
-     - name: Cancel Previous Runs
-       uses: styfle/cancel-workflow-action@0.13.1
-       with:
-         access_token: ${{ github.token }}
 
      - name: Download Lynx bundle
        uses: actions/download-artifact@v8.0.1
@@ -247,10 +235,6 @@ jobs:
     needs: build-bundle
     steps:
      - uses: actions/checkout@v7.0.1
-     - name: Cancel Previous Runs
-       uses: styfle/cancel-workflow-action@0.13.1
-       with:
-         access_token: ${{ github.token }}
      - uses: actions/setup-java@v6.0.1
        with:
          distribution: temurin


### PR DESCRIPTION
## Summary
- Bumps every GitHub Action in the workflow that was stale: `actions/checkout` (v3.5.3 → v7.0.1, 4 majors behind), `actions/upload-artifact` (v4 → v7.0.1), `actions/download-artifact` (v4 → v8.0.1), `actions/setup-java` (v4 → v6.0.1), `cachix/cachix-action` (v16 → v17), `cachix/install-nix-action` (v31 → v31.11.1).
- Pins `ners/simply-nix` to a commit SHA — it had no tagged releases at all, so `@main` was a floating branch ref.
- Removes `ACTIONS_ALLOW_UNSECURE_COMMANDS: true`, a dead opt-in that re-enables a class of workflow commands GitHub disabled by default for security reasons; nothing in this workflow uses them.
- Replaces the `styfle/cancel-workflow-action` step (duplicated in all 5 jobs) with a single top-level `concurrency` block — same same-branch/superseded-run cancellation semantics, per that action's own README, which now recommends this native alternative. Runs on `master` are exempted from cancellation.

Verified with `actionlint` (clean) after each change; confirmed no stale action refs remain.

## Test plan
- [x] CI passes on this PR