### PR TITLE
nix: fix deprecated `pkgs.system` in `wasm32-wasi` package set

### DIFF
--- a/nix/wasm/default.nix
+++ b/nix/wasm/default.nix
@@ -7,7 +7,7 @@ self: super:
     let
       src = self.wasm-flake;
     in
-      (builtins.getFlake src).outputs.packages."${super.system}";
+      (builtins.getFlake src).outputs.packages."${super.stdenv.hostPlatform.system}";
 
   wasm-cabal =
     self.ghc-wasm-meta.wasm32-wasi-cabal-9_12;

--- a/nix/wasm/mk-wasm-bundle.nix
+++ b/nix/wasm/mk-wasm-bundle.nix
@@ -7,7 +7,7 @@
 pkgs:
 let
   shim = import ./browser-shim.nix pkgs;
-  ghcWasmMeta = (builtins.getFlake "gitlab:haskell-wasm/ghc-wasm-meta?host=gitlab.haskell.org").outputs.packages.${pkgs.system};
+  ghcWasmMeta = (builtins.getFlake "gitlab:haskell-wasm/ghc-wasm-meta?host=gitlab.haskell.org").outputs.packages.${pkgs.stdenv.hostPlatform.system};
 in
 { name, drv, exeName, title ? exeName, scripts ? "" }:
 pkgs.stdenvNoCC.mkDerivation {

--- a/nix/wasm/package-set.nix
+++ b/nix/wasm/package-set.nix
@@ -13,7 +13,7 @@
 #
 # Ported from https://github.com/ners/nix-wasm (default.nix and the two
 # nixpkgs-patches/*.patch files).
-{ pkgs, ghcWasmMeta, nixpkgsPath ? pkgs.path, system ? pkgs.system }:
+{ pkgs, ghcWasmMeta, nixpkgsPath ? pkgs.path, system ? pkgs.stdenv.hostPlatform.system }:
 let
   inherit (pkgs) lib;
 


### PR DESCRIPTION
Recent nixpkgs deprecated the top-level `system` attribute in favor of `stdenv.hostPlatform.system`, which triggers an evaluation warning whenever the wasmPkgs overlay (and downstream consumers like miso-cli) evaluate the wasm32-wasi GHC package set.