### PR TITLE
fix: pre-release regressions found reviewing 1.13.0 -> 1.14.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,10 @@ All notable changes to `miso` are documented here.
   Resolved against the current `context` whenever the enclosing `View` is
   built or rendered; it does not itself trigger a redraw — that is still
   governed solely by `useContext`. `withContext` is a synonym for `vcontext`.
+- **`onDestroyedWith`** (`Miso.Event`). Like `onDestroyed` but also receives
+  the element's (already-detached) `DOMRef`, completing the lifecycle hook
+  family alongside `onCreated` / `onCreatedWith` and `onBeforeDestroyed` /
+  `onBeforeDestroyedWith`.
 
 ### Removed
 
@@ -139,6 +143,11 @@ All notable changes to `miso` are documented here.
 
 ### Fixed
 
+- **`onDestroyedWith` / `onBeforeDestroyedWith` now receive the element's
+  `DOMRef` instead of `undefined`.** `callDestroyed` and
+  `callBeforeDestroyed` invoked the hooks with no argument, so the `DOMRef`
+  callback was always `undefined` on the Haskell side. Zero-argument
+  `onDestroyed` / `onBeforeDestroyed` users are unaffected.
 - **Static mounts now carry their `StaticKey` as the diff key.** A
   `VCompStatic` node had no `key`, so two different `static` sites at the
   same position compared equal in the differ: the first component stayed

--- a/src/Miso/Event.hs
+++ b/src/Miso/Event.hs
@@ -296,7 +296,7 @@ onDestroyed action =
 -- library, drop it from a lookup table) — for teardown that needs the
 -- element still live in the document, use 'onBeforeDestroyedWith'.
 --
--- @since 1.13.0.0
+-- @since 1.14.0.0
 --
 onDestroyedWith
   :: (DOMRef -> action)

--- a/src/Miso/Html/Render.hs
+++ b/src/Miso/Html/Render.hs
@@ -318,17 +318,25 @@ collapseSiblingTextNodes
   -> [View context props model action]
 collapseSiblingTextNodes ctx_ props_ model_ = go
   where
-    -- Look through the wrapper constructors first, so a 'VProps' \/ 'VModel'
-    -- \/ 'VContext' that resolves to text is collapsed with its neighbours
+    -- Look through the wrapper constructors, so a 'VProps' \/ 'VModel' \/
+    -- 'VContext' that resolves to text is collapsed with its neighbours
     -- exactly as the client does after 'buildVTree' has resolved it.
-    -- Otherwise an empty 'VText' behind a wrapper renders as a lone space
-    -- that hydration cannot reconcile.
-    go (VProps f : xs) = go (f props_ : xs)
-    go (VContext f : xs) = go (f ctx_ : xs)
-    go (VModel f : xs) = go (f model_ : xs)
-    go (VText _ x : VText k y : xs) = go (VText k (x <> y) : xs)
-    go (x : xs) = x : go xs
-    go [] = []
+    resolve (VProps f) = resolve (f props_)
+    resolve (VContext f) = resolve (f ctx_)
+    resolve (VModel f) = resolve (f model_)
+    resolve v = v
+
+    -- Resolve *both* sides of a pair before deciding whether they merge —
+    -- not just the head, as the single-pass version once did. Otherwise a
+    -- literal 'VText' immediately followed by a wrapper resolving to text
+    -- (or to empty text, which 'renderBuilder' renders as a lone space) is
+    -- never recognised as adjacent, since the second element is only
+    -- resolved on a later call, by which point the first has already been
+    -- emitted.
+    go (x : y : xs)
+      | VText _ a <- resolve x, VText k b <- resolve y = go (VText k (a <> b) : xs)
+      | otherwise = x : go (y : xs)
+    go xs = xs
 ----------------------------------------------------------------------------
 -- | Helper for turning JSON into Text
 -- Object, Array and Null are kind of non-sensical here

--- a/src/Miso/Native.hs
+++ b/src/Miso/Native.hs
@@ -396,6 +396,7 @@ module Miso.Native
    , nativeWithContext
      -- * t'Miso.Types.Component' mounting
    , mountStatic
+   , mountStaticWithProps
      -- * Element
    , module Miso.Native.Element
      -- * FFI
@@ -406,7 +407,7 @@ module Miso.Native
 -----------------------------------------------------------------------------
 import Miso.Runtime (initComponent)
 import Miso.Types (Events, SomeStaticComponent(..), Hydrate(..))
-import Miso.Types (mountStatic)
+import Miso.Types (mountStatic, mountStaticWithProps)
 -----------------------------------------------------------------------------
 import Miso.Native.Element
 import Miso.Native.FFI

--- a/src/Miso/Runtime.hs
+++ b/src/Miso/Runtime.hs
@@ -786,9 +786,12 @@ globalQueue = unsafePerformIO (newIORef emptyQueue)
 -- them keeps this exact instead of relying on all live components pointing at
 -- the same cell.
 --
--- 'atomicModifyIORef'' forces the new @context@, so a component that never
--- redraws cannot accumulate a thunk chain, and an @f@ that throws damages only
--- this cell rather than the 'components' registry.
+-- 'atomicModifyIORef'' forces the new @context@ to weak head normal form on
+-- every update, so a component that never redraws cannot leave this cell
+-- holding an unevaluated chain of 'modifyContextAll' applications (the classic
+-- lazy-@'atomicModifyIORef'@ space leak) — it does not deeply force a lazy
+-- field nested inside @context@ itself. An @f@ that throws damages only this
+-- cell rather than the 'components' registry.
 --
 -- @since 1.14.0.0
 modifyContextAll :: IORef context -> (context -> context) -> IO ()

--- a/src/Miso/Types.hs
+++ b/src/Miso/Types.hs
@@ -608,7 +608,7 @@ fragment_ key = VFrag (Just (Key key))
 -- t'Miso.Types.ComponentState' for it, and any main-thread (@OnStatic@)
 -- event handler inside that subtree silently fails to dispatch for the
 -- component's whole lifetime, with only a console error as a clue. Use
--- 'vcomp' with 'mountStaticWithProps' instead for anything that may mount
+-- 'vcomp' with 'mountStatic' instead for anything that may mount
 -- after the initial frame under @NATIVE@ — the compile-time
 -- 'GHC.StaticPtr.StaticKey' already supplies the identity a manual key would,
 -- no explicit key needed.
@@ -628,7 +628,7 @@ fragment_ key = VFrag (Just (Key key))
   -> View context props model action
 infixr 0 +>
 #ifdef NATIVE
-{-# WARNING (+>) "[NATIVE] '+>' has no StaticKey; a component mounted with it after the initial frame silently drops OnStatic handlers inside it. Use 'vcomp' with 'mountStaticWithProps' instead." #-}
+{-# WARNING (+>) "[NATIVE] '+>' has no StaticKey; a component mounted with it after the initial frame silently drops OnStatic handlers inside it. Use 'vcomp' with 'mountStatic' instead." #-}
 #endif
 key +> child = VComp (SomeComponent (Just (toKey key)) () child)
 -----------------------------------------------------------------------------
@@ -651,7 +651,7 @@ mountStaticWithProps = SomeStaticComponent
 -- also builds an unkeyed @VComp@ with no 'GHC.StaticPtr.StaticKey', so the
 -- same caveat applies: components mounted with this /after/ the initial
 -- frame never get a main-thread mirror registered, silently breaking
--- @OnStatic@ handlers inside them. Use 'vcomp' with 'mountStaticWithProps'
+-- @OnStatic@ handlers inside them. Use 'vcomp' with 'mountStatic'
 -- instead for anything that may mount dynamically under @NATIVE@.
 mountWithProps
   :: forall context childProps childModel childAction model action props .
@@ -665,7 +665,7 @@ mountWithProps
   -- ^ t'Component' to mount
   -> View context props model action
 #ifdef NATIVE
-{-# WARNING mountWithProps "[NATIVE] 'mountWithProps' has no StaticKey; a component mounted with it after the initial frame silently drops OnStatic handlers inside it. Use 'vcomp' with 'mountStaticWithProps' instead." #-}
+{-# WARNING mountWithProps "[NATIVE] 'mountWithProps' has no StaticKey; a component mounted with it after the initial frame silently drops OnStatic handlers inside it. Use 'vcomp' with 'mountStatic' instead." #-}
 #endif
 mountWithProps props comp = VComp (SomeComponent Nothing props comp)
 -----------------------------------------------------------------------------
@@ -676,7 +676,7 @@ mountWithProps props comp = VComp (SomeComponent Nothing props comp)
 -- just the diffing t'Key', unrelated), so the same caveat applies: mounted
 -- /after/ the initial frame, it never gets a main-thread mirror registered,
 -- silently breaking @OnStatic@ handlers inside it. Use 'vcomp' with
--- 'mountStaticWithProps' instead for anything that may mount dynamically
+-- 'mountStatic' instead for anything that may mount dynamically
 -- under @NATIVE@ — the compile-time 'GHC.StaticPtr.StaticKey' already
 -- supplies the identity a manual key would, no explicit key needed.
 mountWithProps_
@@ -692,7 +692,7 @@ mountWithProps_
   -- ^ t'Component' to mount
   -> View context props model action
 #ifdef NATIVE
-{-# WARNING mountWithProps_ "[NATIVE] 'mountWithProps_' has no StaticKey; a component mounted with it after the initial frame silently drops OnStatic handlers inside it. Use 'vcomp' with 'mountStaticWithProps' instead." #-}
+{-# WARNING mountWithProps_ "[NATIVE] 'mountWithProps_' has no StaticKey; a component mounted with it after the initial frame silently drops OnStatic handlers inside it. Use 'vcomp' with 'mountStatic' instead." #-}
 #endif
 mountWithProps_ key props child = VComp (SomeComponent (Just (Key key)) props child)
 -----------------------------------------------------------------------------

--- a/tests/app/Main.hs
+++ b/tests/app/Main.hs
@@ -2055,6 +2055,21 @@ main = withJS $ do
         toHtml ([ "a", "", "c" ] :: [View () () () Action])
           `shouldBe` "ac"
 
+      it "toHtmlWith collapses a literal text node with a wrapper that resolves to empty text right after it" $ do
+        -- Regression: a literal 'VText' followed by a 'VModel' \/ 'VProps' \/
+        -- 'VContext' resolving to "" must not leave the empty text stranded —
+        -- it renders as a lone space (see the comment on 'renderBuilder'\'s
+        -- @VText _ ""@ case), producing a stray trailing space.
+        toHtmlWith () () ("" :: MisoString) (div_ [] [ "a", withModel text ])
+          `shouldBe` "<div>a</div>"
+
+      it "toHtmlWith fully collapses a run of text interleaved with empty-resolving wrappers" $ do
+        -- Regression: with two wrappers resolving to "" between two literal
+        -- texts, a partial collapse left an un-merged empty node in the
+        -- middle, rendering as an internal stray space ("x y" instead of "xy").
+        toHtmlWith () () ("" :: MisoString) (div_ [] [ "x", withModel text, withModel text, "y" ])
+          `shouldBe` "<div>xy</div>"
+
     describe "Miso.DSL `await` tests" $ do
       it "Successful Promise resolution should result in a value" $ do
         -- Create a Promise and immediately resolve it with `42`


### PR DESCRIPTION
Five small fixes turned up while reviewing everything that changed between the `1.13.0` tag and the `1.14.0.0` release commit, ahead of tagging.

## Fixes

1. **`collapseSiblingTextNodes` misses adjacent literal-then-wrapper text** (`src/Miso/Html/Render.hs`). The SSR text-merging pass for `VContext`/`VProps`/`VModel` only resolved a wrapper node when it was the *first* half of a compared pair, so a literal `VText` immediately followed by a wrapper resolving to text (or empty text) never got merged with it. Concretely, `toHtmlWith () () "" (div_ [] ["x", withModel text, withModel text, "y"])` rendered `"<div>x y</div>"` instead of `"<div>xy</div>"` — a stray internal space that breaks the client's hydration walk (it isn't something `.trim()` can hide) and causes a silent fallback to a full re-render. Fixed to resolve both sides of a pair at the point they're compared. Adds regression tests for the orderings that were broken.

2. **Dropped `mountStaticWithProps` export** (`src/Miso/Native.hs`). It was exported in 1.13.0 and is still a valid (deprecated) function, but got dropped from `Miso.Native`'s export list during the `SomeStaticComponent` refactor — breaking anyone using the canonical `import Miso.Native` pattern.

3. **Circular deprecation warnings** (`src/Miso/Types.hs`). The `WARNING` pragmas on `(+>)`, `mountWithProps` and `mountWithProps_` told users to switch to `mountStaticWithProps` — but this same diff marks `mountStaticWithProps` itself `DEPRECATED` in favor of `mountStatic`. Repointed the warnings at `mountStatic` directly.

4. **`onDestroyedWith`'s stale `@since` tag and missing CHANGELOG entries** (`src/Miso/Event.hs`, `CHANGELOG.md`). It's new in this release but was tagged `@since 1.13.0.0`. Also documents the accompanying fix that made `onDestroyed`/`onBeforeDestroyed` pass the element's real `DOMRef` instead of `undefined`, which had no CHANGELOG entry.

5. **`modifyContextAll`'s doc comment overstated `atomicModifyIORef'`'s guarantee** (`src/Miso/Runtime.hs`). It claimed the new context "cannot accumulate a thunk chain" — true only for the classic lazy-`atomicModifyIORef` leak pattern (WHNF forcing on the cell itself), not for lazy fields nested inside `context`. Reworded to be precise.

## Test plan

- [x] `cabal build -f native miso` (plain GHC, no WASM toolchain) typechecks clean after each fix
- [x] Empirically verified the `collapseSiblingTextNodes` fix in GHCi against both the previously-broken cases and the pre-existing passing tests
- [x] Added two regression tests to `tests/app/Main.hs` covering the orderings that were broken