### PR TITLE
ci: pin ghc-wasm-meta to flake.lock everywhere

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -41,7 +41,7 @@
 
     {
       # Reusable for downstream flakes: `overlays.default = miso.overlays.default;`
-      overlays.default = final: prev: import ./nix/overlay.nix final prev;
+      overlays.default = import ./nix/overlay.nix { ghcWasmMeta = inputs.ghc-wasm-meta; };
     } //
 
     flake-utils.lib.eachDefaultSystem (system:
@@ -49,7 +49,7 @@
         pkgs = import nixpkgs {
           inherit system;
           # Miso's overlays (provides rspeedy, ghcNative, mkLynxBundle, ...)
-          overlays = [ (import ./nix/overlay.nix) ];
+          overlays = [ (import ./nix/overlay.nix { ghcWasmMeta = inputs.ghc-wasm-meta; }) ];
         };
       in
       {

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -9,7 +9,7 @@ let
   config.allowBroken = false;
   config.android_sdk.accept_license = true;
   overlays = [ (import ./wasm)
-               (import ./overlay.nix)
+               (import ./overlay.nix {})
              ] ++ options.overlays;
   legacyPkgs = import ./legacy options;
   pkgs = import nixpkgs { inherit overlays config; };

--- a/nix/ghc-wasm-meta.nix
+++ b/nix/ghc-wasm-meta.nix
@@ -1,0 +1,18 @@
+# The ghc-wasm-meta flake, pinned to the revision recorded in flake.lock.
+#
+# flake.nix receives it as a locked input; this is for everything evaluated
+# outside the flake -- default.nix / nix-build, and the overlay's default --
+# so both resolve the same toolchain and `nix flake update ghc-wasm-meta`
+# bumps all of it at once. The rev + narHash make the reference locked, which
+# is what lets `builtins.getFlake` run under pure evaluation: an unlocked
+# reference errors there ("cannot call 'getFlake' on unlocked flake
+# reference"), which broke `overlays.default` for downstream flakes.
+let
+  lock = builtins.fromJSON (builtins.readFile ../flake.lock);
+  node = lock.nodes.${lock.nodes.root.inputs.ghc-wasm-meta}.locked;
+  # A base64 narHash can contain '+', '/' and '='; percent-encode for the URL.
+  encode = builtins.replaceStrings [ "+" "/" "=" ] [ "%2B" "%2F" "%3D" ];
+in
+(builtins.getFlake
+  "${node.type}:${node.owner}/${node.repo}/${node.rev}?host=${node.host}&narHash=${encode node.narHash}"
+).outputs

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -1,8 +1,16 @@
+# `ghcWasmMeta` is the ghc-wasm-meta flake's outputs. flake.nix passes its
+# locked input; everything else gets the same revision via nix/ghc-wasm-meta.nix,
+# which reads it out of flake.lock.
+{ ghcWasmMeta ? import ./ghc-wasm-meta.nix }:
 self: super:
 let
   js = import ./js super;
 in
 {
+  # The wasm32-wasi toolchain everything below reads from. Exposed so the
+  # legacy nix/wasm overlay and mk-wasm-bundle.nix share this one pin.
+  inherit ghcWasmMeta;
+
   # JS tooling
   inherit (js) rspeedy;
 
@@ -30,7 +38,7 @@ in
   # e.g. wasmPkgs.haskell.packages.ghc9141.callCabal2nix
   wasmPkgs = import ./wasm/package-set.nix {
     pkgs = super;
-    ghcWasmMeta = (builtins.getFlake "gitlab:haskell-wasm/ghc-wasm-meta?host=gitlab.haskell.org").outputs;
+    inherit ghcWasmMeta;
   };
 
   # Packages a wasmPkgs-built executable into a browser-loadable bundle

--- a/nix/wasm/default.nix
+++ b/nix/wasm/default.nix
@@ -1,13 +1,9 @@
 self: super:
 {
 
-  wasm-flake = "gitlab:haskell-wasm/ghc-wasm-meta?host=gitlab.haskell.org";
-
+  # Pinned by flake.lock -- see nix/ghc-wasm-meta.nix (via nix/overlay.nix).
   ghc-wasm-meta =
-    let
-      src = self.wasm-flake;
-    in
-      (builtins.getFlake src).outputs.packages."${super.stdenv.hostPlatform.system}";
+    self.ghcWasmMeta.packages."${super.stdenv.hostPlatform.system}";
 
   wasm-cabal =
     self.ghc-wasm-meta.wasm32-wasi-cabal-9_12;

--- a/nix/wasm/mk-wasm-bundle.nix
+++ b/nix/wasm/mk-wasm-bundle.nix
@@ -7,7 +7,8 @@
 pkgs:
 let
   shim = import ./browser-shim.nix pkgs;
-  ghcWasmMeta = (builtins.getFlake "gitlab:haskell-wasm/ghc-wasm-meta?host=gitlab.haskell.org").outputs.packages.${pkgs.stdenv.hostPlatform.system};
+  # Pinned by flake.lock -- see nix/ghc-wasm-meta.nix (via nix/overlay.nix).
+  ghcWasmMeta = pkgs.ghcWasmMeta.packages.${pkgs.stdenv.hostPlatform.system};
 in
 { name, drv, exeName, title ? exeName, scripts ? "" }:
 pkgs.stdenvNoCC.mkDerivation {


### PR DESCRIPTION
Follow-up from the 1.13.0 → 1.14.0.0 review.

## Problem

`nix/overlay.nix` (the `wasmPkgs` package set), `nix/wasm/mk-wasm-bundle.nix` and the legacy `nix/wasm` overlay all fetched `ghc-wasm-meta` with an **unlocked** `builtins.getFlake "gitlab:haskell-wasm/ghc-wasm-meta?host=…"`, while `flake.nix` already carries `ghc-wasm-meta` as a locked input (used by the `wasm` devShell). Two consequences:

- **Reproducibility regression.** Every wasm artifact built by `nix-build` — `miso-wasm-ghc9141`, `sample-app-wasm-ghc9141` and the three `playwright-wasm*` integration tests — tracked upstream's *current tip* at evaluation time. Before #1650 the playwright tests went through `nix develop .#wasm`, i.e. the locked input, so this is new: an upstream rename of `all_9_14` / `wasm32-wasi-ghc-9_14` would break master CI with no change in this repo. (It only worked at all because CI uses legacy, impure `nix-build`.)
- **`overlays.default` was unusable from a downstream pure flake.** Any consumer touching `wasmPkgs` / `wasmWebBundle` hit `error: cannot call 'getFlake' on unlocked flake reference … (use --impure to override)`.

## Fix

One source of truth: `flake.lock`'s `ghc-wasm-meta` node.

- `nix/overlay.nix` now takes `{ ghcWasmMeta }` (the flake's outputs) and exposes it as `pkgs.ghcWasmMeta`; `wasmPkgs`, `mk-wasm-bundle.nix` and the legacy `nix/wasm` overlay all read the toolchain from there.
- `flake.nix` passes its locked `inputs.ghc-wasm-meta`.
- Everything evaluated outside the flake (`default.nix` / `nix-build`) goes through the new `nix/ghc-wasm-meta.nix`, which reads the lock node and builds a **locked** `rev+narHash` reference — accepted by pure evaluation, and the `narHash` is enforced (verified: a wrong hash fails with `NAR hash mismatch`).
- `nix flake update ghc-wasm-meta` now bumps all of it at once.

## Note on the pin itself

The lock (`60098a5`, Apr 2026) is ~5 months behind upstream's tip that CI has been silently building with since #1650, so the pinned wasm derivations differ from the last few CI runs. That toolchain is the one `nix develop .#wasm` / `make build` and the pre-#1650 playwright CI runs have been using throughout 1.14 development, so it's well exercised; bumping it is now a deliberate `nix flake update ghc-wasm-meta` rather than a side effect of the calendar.

## Verified

- [x] `nix-instantiate -A miso-wasm-ghc9141 -A sample-app-wasm-bundle-ghc9141` (legacy path) instantiates with the pin
- [x] `nix flake show` / `nix eval .#devShells.x86_64-linux.wasm.drvPath` — flake still evaluates in pure mode, devShell unchanged
- [x] Downstream pure-flake consumer (`overlays.default` → `wasmPkgs…miso.drvPath`): fails on `master` with the unlocked-reference error, evaluates on this branch
- [x] `grep getFlake` — the only remaining call is the locked one in `nix/ghc-wasm-meta.nix`
- [ ] CI: the `(WASM)` `nix-build` steps and `playwright-wasm*` runs now build against the locked rev