### PR TITLE
docs: title the CHANGELOG section for 1.14.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to `miso` are documented here.
 
-## Unreleased
+## 1.14.0.0
 
 ### Added
 


### PR DESCRIPTION
Follow-up from the 1.13.0 → 1.14.0.0 review.

`miso.cabal` has been at `1.14.0.0` since #1647, but `CHANGELOG.md` still heads this release's entries as `## Unreleased`. Renames it to `## 1.14.0.0` ahead of tagging. No other changes.