### PR TITLE
chore: add upper bounds for ghcjs-base, ghcjs-prim and ghc-experimental

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -5,7 +5,7 @@ packages:
   tests/
 
 allow-newer:
-  all:base
+  all:base,
   all:ghc-experimental
 
 if arch(wasm32)

--- a/cabal.project
+++ b/cabal.project
@@ -6,6 +6,7 @@ packages:
 
 allow-newer:
   all:base
+  all:ghc-experimental
 
 if arch(wasm32)
   shared: True

--- a/miso.cabal
+++ b/miso.cabal
@@ -298,17 +298,17 @@ library
     hs-source-dirs:
       ffi/js
     build-depends:
-      ghcjs-base -any
+      ghcjs-base < 0.9
 
     if impl(ghcjs)
       build-depends:
-        ghcjs-prim
+        ghcjs-prim < 0.2
 
   elif arch(wasm32)
     hs-source-dirs:
       ffi/wasm
     build-depends:
-      ghc-experimental,
+      ghc-experimental < 9.15,
       template-haskell >= 2.21 && < 2.25
     exposed-modules:
       Miso.DSL.TH

--- a/miso.cabal
+++ b/miso.cabal
@@ -308,7 +308,7 @@ library
     hs-source-dirs:
       ffi/wasm
     build-depends:
-      ghc-experimental < 9.15,
+      ghc-experimental < 9.1500,
       template-haskell >= 2.21 && < 2.25
     exposed-modules:
       Miso.DSL.TH


### PR DESCRIPTION
Follow-up from the 1.13.0 → 1.14.0.0 review.

`cabal check` flags these three as missing upper bounds (Hackage warns about it at upload time). This bounds them to what the package sets actually use:

| dependency | condition | bound | what's actually used |
|---|---|---|---|
| `ghcjs-base` | `arch(javascript) \|\| impl(ghcjs)` | `< 0.9` | the GHC-JS set pins `0.8.0.4` (the GHC-JS-backend fork; Hackage's `0.2.x` predates it) |
| `ghcjs-prim` | `impl(ghcjs)` | `< 0.2` | legacy GHCJS 8.6 ships `0.1.x` |
| `ghc-experimental` | `arch(wasm32)` | `< 9.1500` | GHC 9.14.x ships `9.1401.0`; the package encodes the GHC version as a single component (`9.14.1` → `9.1401`), so this is "through GHC 9.14.x" — the counterpart of the existing `template-haskell < 2.25` |

The GHC-HEAD `wasm-latest` dev shell ships `ghc-experimental-9.1500.0`, which that bound rejects, so `cabal.project` relaxes it with `allow-newer: all:ghc-experimental` — the same treatment `base` already gets there. This keeps the bound meaningful for the Hackage package while not breaking the bleeding-edge shell.

Note: the first revision of this PR had `< 9.15`, which reads right but is wrong — component-wise, `1401 > 15`, so it rejected the installed `9.1401.0` and the wasm CI builds failed to configure. The second commit corrects it. Worth knowing for the wasm nix builds generally: their `jailbreak` did *not* strip this bound, so bounds in the `arch(wasm32)` block are load-bearing there.

## Verified

- [x] `cabal check`: "No errors or warnings could be found in the package."
- [x] `nix-build -A miso-wasm-ghc9141` — the exact derivation that failed CI on the first revision — builds with `< 9.1500`
- [x] `nix develop .#wasm -c wasm32-wasi-ghc-pkg field ghc-experimental version` → `9.1401.0` (satisfies `< 9.1500`)
- [x] `nix develop .#wasm-latest -c …` → `9.1500.0` (covered by the new `allow-newer` line)
- [ ] CI: `nix-build -A miso-ghcjs-9141` exercises the `ghcjs-base < 0.9` bound against the pinned `0.8.0.4`